### PR TITLE
fix(tearsheet-small): import scrollgradient scss

### DIFF
--- a/src/components/Tearsheet/TearsheetSmall/_index.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_index.scss
@@ -11,6 +11,7 @@
 @import '../../Button/index';
 @import '../../IconButton/index';
 @import '../../Loading/index';
+@import '../../ScrollGradient/index';
 @import '../../Tag/index';
 
 @include component($name: #{$tearsheet__name}--small) {


### PR DESCRIPTION
## Affected issues

- Resolves #10 

## Proposed changes

- import `ScrollGradient` scss into `TearsheetSmall` (which then gets imported into `Tearsheet`)


## Testing instructions

- Storybook - https://deploy-preview-tearsheet-scss-imports--ibm-security.netlify.com
