### PR TITLE
docs: remove deploy link example from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,3 @@
 ## Testing instructions
 
 - <!-- List of instructions for reviewer to test that proposed changes in this PR work properly -->
-
-- Storybook - https://deploy-preview-<!-- Deploy preview -->--ibm-security.netlify.com


### PR DESCRIPTION
## Proposed changes

- Remove the example deploy link from the PR template because Netlify will post the links in the comments + the deploy link will update if new commits are pushed. So the PR creator's posted link would likely become stale quickly. We can just rely on the Netlify bot 👍 