### PR TITLE
feat(copy-button): proxy copy button and import styles in code snippet

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.stories.js
+++ b/src/components/CodeSnippet/CodeSnippet.stories.js
@@ -7,6 +7,7 @@ import { withA11y } from '@storybook/addon-a11y';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
+import centered from '@storybook/addon-centered/react';
 
 import React from 'react';
 import { components } from '../../../.storybook';
@@ -48,6 +49,7 @@ const props = {
 
 storiesOf(components('CodeSnippet'), module)
   .addDecorator(withA11y)
+  .addDecorator(centered)
   .add(
     'inline',
     () => (

--- a/src/components/CodeSnippet/_index.scss
+++ b/src/components/CodeSnippet/_index.scss
@@ -4,4 +4,5 @@
 /// @copyright IBM Security 2019
 ////
 
+@import '../CopyButton/index';
 @import 'carbon-components/scss/components/code-snippet/code-snippet';

--- a/src/components/CopyButton/CopyButton.stories.js
+++ b/src/components/CopyButton/CopyButton.stories.js
@@ -1,0 +1,36 @@
+/**
+ * @file Checkbox stories.
+ * @copyright IBM Security 2019
+ */
+
+import React from 'react';
+import centered from '@storybook/addon-centered/react';
+import { withA11y } from '@storybook/addon-a11y';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { number, text } from '@storybook/addon-knobs';
+import CopyButton from '../CopyButton';
+
+const props = () => ({
+  feedback: text('The text shown upon clicking (feedback)', 'Copied!'),
+  feedbackTimeout: number(
+    'How long the text is shown upon clicking (feedbackTimeout)',
+    3000
+  ),
+  iconDescription: text(
+    'Feedback icon description (iconDescription)',
+    'Copy to clipboard'
+  ),
+  onClick: action('onClick'),
+});
+
+storiesOf('CopyButton', module)
+  .addDecorator(withA11y)
+  .addDecorator(centered)
+  .add('Default', () => <CopyButton {...props()} />, {
+    info: {
+      text:
+        'The copy button can be used when the user needs to copy information, such as a code snippet, to their clipboard.',
+    },
+  });

--- a/src/components/CopyButton/CopyButton.stories.js
+++ b/src/components/CopyButton/CopyButton.stories.js
@@ -1,5 +1,5 @@
 /**
- * @file Checkbox stories.
+ * @file Copy button stories.
  * @copyright IBM Security 2019
  */
 

--- a/src/components/CopyButton/_index.scss
+++ b/src/components/CopyButton/_index.scss
@@ -1,0 +1,7 @@
+////
+/// Copy button component.
+/// @group copy-button
+/// @copyright IBM Security 2019
+////
+
+@import 'carbon-components/scss/components/copy-button/copy-button';

--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -1,0 +1,6 @@
+/**
+ * @file Copy button entry point.
+ * @copyright IBM Security 2019
+ */
+
+export default from 'carbon-components-react/lib/components/CopyButton';


### PR DESCRIPTION
## Affected issues

- Resolves #37 

## Proposed changes

- proxy `CopyButton` component and create story
- import `CopyButton` styles into `CodeSnippet`
- centered `CodeSnippet` stories