### PR TITLE
fix(copy-button): export component, add category and wrapper to story

### DIFF
--- a/src/components/CopyButton/CopyButton.stories.js
+++ b/src/components/CopyButton/CopyButton.stories.js
@@ -10,7 +10,9 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { number, text } from '@storybook/addon-knobs';
-import CopyButton from '../CopyButton';
+import { CopyButton } from '../..';
+
+import { components } from '../../../.storybook';
 
 const props = () => ({
   feedback: text('The text shown upon clicking (feedback)', 'Copied!'),
@@ -25,12 +27,20 @@ const props = () => ({
   onClick: action('onClick'),
 });
 
-storiesOf('CopyButton', module)
+storiesOf(components('CopyButton'), module)
   .addDecorator(withA11y)
   .addDecorator(centered)
-  .add('Default', () => <CopyButton {...props()} />, {
-    info: {
-      text:
-        'The copy button can be used when the user needs to copy information, such as a code snippet, to their clipboard.',
-    },
-  });
+  .add(
+    'Default',
+    () => (
+      <div style={{ position: 'relative' }}>
+        <CopyButton {...props()} />
+      </div>
+    ),
+    {
+      info: {
+        text:
+          'The copy button can be used when the user needs to copy information, such as a code snippet, to their clipboard.',
+      },
+    }
+  );

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -51,6 +51,7 @@
 @import 'CodeSnippet/index';
 @import 'ComboBox/index';
 @import 'ContentSwitcher/index';
+@import 'CopyButton/index';
 @import 'DatePicker/index';
 @import 'Dropdown/index';
 @import 'FileUploader/index';

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export { Card, CardSkeleton } from './components/Card';
 export CodeSnippet, { CodeSnippetSkeleton } from './components/CodeSnippet';
 export ComboBox from './components/ComboBox';
 export ContentSwitcher from './components/ContentSwitcher';
+export CopyButton from './components/CopyButton';
 export DataDecorator, { Decorator } from './components/DataDecorator';
 
 export {


### PR DESCRIPTION
NOTE: this should have been done in #38 😅 

## Proposed changes

- export `CopyButton`
- add component category to story
- add wrapper with `position: relative` to story (required if you want the button to be centered)
