### PR TITLE
fix(shell): restructure shell styles

### DIFF
--- a/.storybook/addons/addon-theme/register.js
+++ b/.storybook/addons/addon-theme/register.js
@@ -12,6 +12,7 @@ import { action, getStoredTheme, namespace, themes, title } from '.';
 
 import { Form, Select, SelectItem } from '../../../src';
 
+// TODO: `modular-styles` - Revert.
 // import '../../../src/index.scss';
 
 const { addPanel, getChannel, register } = addons;

--- a/.storybook/components/Container/_index.scss
+++ b/.storybook/components/Container/_index.scss
@@ -4,7 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../../src/index';
+@import '../../../src/globals/layout/index';
 
 .container {
   display: flex;

--- a/.storybook/components/Container/_index.scss
+++ b/.storybook/components/Container/_index.scss
@@ -4,7 +4,9 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../../src/globals/layout/index';
+@import 'carbon-components/scss/globals/scss/spacing';
+
+@import '../../../src/index';
 
 .container {
   display: flex;

--- a/.storybook/components/Container/index.js
+++ b/.storybook/components/Container/index.js
@@ -3,6 +3,7 @@
  * @copyright IBM Security 2019
  */
 
+// TODO: `modular-styles` - Revert.
 // import '../../index.scss';
 
 const Container = ({ children }) => children;

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -71,6 +71,8 @@ addParameters({
     ),
     storySort: (a, b) =>
       ORDER.indexOf(getCategory(a)) - ORDER.indexOf(getCategory(b)),
+
+    // TODO: `modular-styles` - Revert.
     // theme,
   },
 });

--- a/.storybook/index.scss
+++ b/.storybook/index.scss
@@ -4,10 +4,9 @@
 /// @copyright IBM Security 2019
 ////
 
-// @import 'themes/index';
-// @import '../.storybook/components/Container/index';
+@import 'themes/index';
+@import '../.storybook/components/Container/index';
 
-/**
 .grid {
   display: flex;
   padding: $carbon--spacing-09;
@@ -29,4 +28,3 @@
     }
   }
 }
-**/

--- a/src/components/Accordion/_index.scss
+++ b/src/components/Accordion/_index.scss
@@ -1,10 +1,14 @@
 ////
 /// Accordion component.
 /// @group accordion
-/// @copyright IBM Security 2018
+/// @copyright IBM Security 2019
 ////
 
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/components/accordion/accordion';
+
+@import '../../globals/namespace/index';
 
 @include export-namespace($name: 'accordion') {
   .#{$prefix}--accordion {

--- a/src/components/Breadcrumb/_index.scss
+++ b/src/components/Breadcrumb/_index.scss
@@ -4,9 +4,10 @@
 /// @copyright IBM Security 2019
 ////
 
+@import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/components/breadcrumb/breadcrumb';
 
-@import '../../globals/index';
+@import '../../globals/namespace/index';
 
 /// Carbon style overrides.
 @include export-namespace($name: breadcrumb) {

--- a/src/components/Button/_mixins.scss
+++ b/src/components/Button/_mixins.scss
@@ -4,13 +4,8 @@
 /// @copyright IBM Security 2019
 ////
 
-@import 'carbon-components/scss/globals/scss/vars';
-
-@import '../../globals/color/index';
-@import '../../globals/layout/index';
-@import '../../globals/motion/index';
-@import '../../globals/rtl/index';
-@import '../../globals/theme/index';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/type/scss/styles';
 
 @mixin button {
   /// Padding.

--- a/src/components/Header/HeaderListItem/_mixins.scss
+++ b/src/components/Header/HeaderListItem/_mixins.scss
@@ -4,7 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../../globals/index';
+@import '@carbon/layout/scss/spacing';
 
 @mixin header__list__item {
   height: inherit;

--- a/src/components/Header/HeaderNotification/_mixins.scss
+++ b/src/components/Header/HeaderNotification/_mixins.scss
@@ -4,7 +4,14 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/themes/scss/mixins';
+@import '@carbon/type/scss/font-family';
+@import '@carbon/type/scss/styles';
+@import 'carbon-components/scss/globals/scss/layout';
+
+@import '../../../globals/motion/index';
 
 @import '../mixins';
 

--- a/src/components/Header/HeaderNotification/_mixins.scss
+++ b/src/components/Header/HeaderNotification/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/font-family';
 @import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/components/Header/HeaderPopoverHeader/_mixins.scss
+++ b/src/components/Header/HeaderPopoverHeader/_mixins.scss
@@ -4,7 +4,8 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../../globals/index';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/type/scss/styles';
 
 @mixin header__popover__header {
   display: flex;

--- a/src/components/Header/HeaderPopoverLinkSecondary/_mixins.scss
+++ b/src/components/Header/HeaderPopoverLinkSecondary/_mixins.scss
@@ -4,7 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../../globals/index';
+@import '@carbon/themes/scss/mixins';
 
 @mixin header__popover__link--secondary {
   &,

--- a/src/components/Header/HeaderPopoverLinkSecondary/_mixins.scss
+++ b/src/components/Header/HeaderPopoverLinkSecondary/_mixins.scss
@@ -4,7 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 
 @mixin header__popover__link--secondary {
   &,

--- a/src/components/Header/_mixins.scss
+++ b/src/components/Header/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/components/Header/_mixins.scss
+++ b/src/components/Header/_mixins.scss
@@ -4,9 +4,21 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/themes/scss/mixins';
+@import '@carbon/type/scss/styles';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+
+@import '../../globals/motion/index';
+@import '../../globals/namespace/index';
 
 @import '../../platform/body/mixins';
+
+@import '../IconButton/mixins';
+
+@import 'variables';
 
 /// Name.
 /// @type String
@@ -22,19 +34,9 @@ $header__namespace: get-component-namespace(
 /// @type Color
 $header__color__background: $body__color__background;
 
-/// Layer.
-/// @type Number
-$header__layer: z(
-  $layer: overlay,
-);
-
 /// Width.
 /// @type Length
 $header__sizing__width: 100%;
-
-/// Padding.
-/// @type Length
-$header__spacing__padding: $carbon--spacing-03;
 
 /// Transition duration.
 /// @type Length

--- a/src/components/Header/_variables.scss
+++ b/src/components/Header/_variables.scss
@@ -1,0 +1,18 @@
+////
+/// Header variables.
+/// @group header
+/// @copyright IBM Security 2019
+////
+
+@import '@carbon/layout/scss/spacing';
+@import 'carbon-components/scss/globals/scss/layout';
+
+/// Layer.
+/// @type Number
+$header__layer: z(
+  $layer: overlay,
+);
+
+/// Padding.
+/// @type Length
+$header__spacing__padding: $carbon--spacing-03;

--- a/src/components/IconButton/_mixins.scss
+++ b/src/components/IconButton/_mixins.scss
@@ -5,7 +5,7 @@
 ////
 
 @import '@carbon/layout/scss/mini-unit';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/components/IconButton/_mixins.scss
+++ b/src/components/IconButton/_mixins.scss
@@ -4,9 +4,13 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/layout/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/themes/scss/mixins';
+
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+
 @import '../../globals/motion/index';
-@import '../../globals/theme/index';
 
 @import '../Tooltip/mixins';
 

--- a/src/components/IconButton/_variables.scss
+++ b/src/components/IconButton/_variables.scss
@@ -4,6 +4,8 @@
 /// @copyright IBM Security 2019
 ////
 
+@import '../../globals/namespace/index';
+
 /// Name.
 /// @type String
 $button--icon__name: button--icon;

--- a/src/components/Nav/_mixins.scss
+++ b/src/components/Nav/_mixins.scss
@@ -4,7 +4,16 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/themes/scss/mixins';
+@import '@carbon/type/scss/styles';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+@import 'carbon-components/scss/globals/scss/motion';
+
+@import '../../globals/motion/index';
+@import '../../globals/rtl/index';
 
 @mixin nav {
   $nav__heading: '#{&}__heading';

--- a/src/components/Nav/_mixins.scss
+++ b/src/components/Nav/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/components/ProfileImage/_index.scss
+++ b/src/components/ProfileImage/_index.scss
@@ -5,6 +5,7 @@
 ////
 
 @import '../Component/mixins';
+
 @import 'mixins';
 
 @include component($name: profile-image) {

--- a/src/components/ProfileImage/_mixins.scss
+++ b/src/components/ProfileImage/_mixins.scss
@@ -4,7 +4,9 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/themes/scss/mixins';
+@import '@carbon/type/scss/styles';
 
 @mixin profile-image {
   @include carbon--type-style($name: body-short-01);

--- a/src/components/ProfileImage/_mixins.scss
+++ b/src/components/ProfileImage/_mixins.scss
@@ -5,7 +5,7 @@
 ////
 
 @import '@carbon/layout/scss/mini-unit';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/styles';
 
 @mixin profile-image {

--- a/src/components/Shell/_index.scss
+++ b/src/components/Shell/_index.scss
@@ -4,6 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
+@import '../Breadcrumb/index';
 @import '../Button/index';
 @import '../Header/index';
 @import '../Link/index';

--- a/src/components/Shell/_mixins.scss
+++ b/src/components/Shell/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/theme/scss/mixins';
+@import '@carbon/themes/scss/mixins';
 @import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/components/Shell/_mixins.scss
+++ b/src/components/Shell/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/components/Shell/_mixins.scss
+++ b/src/components/Shell/_mixins.scss
@@ -4,7 +4,14 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/theme/scss/mixins';
+@import '@carbon/type/scss/styles';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+
+@import '../../globals/motion/index';
 
 @import '../Header/mixins';
 @import '../Toolbar/mixins';

--- a/src/components/Toolbar/_index.scss
+++ b/src/components/Toolbar/_index.scss
@@ -1,7 +1,7 @@
 ////
 /// Toolbar component.
 /// @group toolbar
-/// @copyright IBM Security 2018
+/// @copyright IBM Security 2019
 ////
 
 @import '../IconButton/index';

--- a/src/components/Toolbar/_mixins.scss
+++ b/src/components/Toolbar/_mixins.scss
@@ -4,10 +4,17 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/themes/scss/mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+
+@import '../../globals/motion/index';
+@import '../../globals/namespace/index';
+@import '../../globals/rtl/index';
 
 @import '../../platform/body/mixins';
-@import '../Header/mixins';
+@import '../Header/variables';
 
 /// Name.
 /// @type String

--- a/src/components/Toolbar/_mixins.scss
+++ b/src/components/Toolbar/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import 'carbon-components/scss/globals/scss/layout';
 
 @import '../../globals/motion/index';

--- a/src/components/Tooltip/_mixins.scss
+++ b/src/components/Tooltip/_mixins.scss
@@ -4,7 +4,13 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/index';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+@import '@carbon/themes/scss/mixins';
+@import '@carbon/type/scss/styles';
+
+@import '../../globals/motion/index';
+@import '../../globals/rtl/index';
 
 @import '../Toolbar/mixins';
 

--- a/src/components/Tooltip/_mixins.scss
+++ b/src/components/Tooltip/_mixins.scss
@@ -6,7 +6,7 @@
 
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/layout/scss/spacing';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/styles';
 
 @import '../../globals/motion/index';

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -5,6 +5,7 @@
 ////
 
 // Application.
+@import 'Breadcrumb/index';
 @import 'Card/index';
 @import 'DataDecorator/index';
 @import 'DataTable/index';
@@ -16,10 +17,12 @@
 @import 'IconButtonBar/index';
 @import 'IconButton/index';
 @import 'InlineLoading/index';
+@import 'Nav/index';
 @import 'NonEntitledSection/index';
 @import 'Notification/index';
 @import 'Panel/index';
 @import 'Pill/index';
+@import 'ProfileImage/index';
 @import 'ProgressIndicator/index';
 @import 'ScrollGradient/index';
 @import 'Search/index';
@@ -39,14 +42,11 @@
 
 // Platform.
 @import 'Header/index';
-@import 'Nav/index';
-@import 'ProfileImage/index';
 @import 'Shell/index';
 
 /// Carbon proxy.
 @import 'Accordion/index';
 @import 'Button/index';
-@import 'Breadcrumb/index';
 @import 'Checkbox/index';
 @import 'CodeSnippet/index';
 @import 'ComboBox/index';

--- a/src/globals/_index.scss
+++ b/src/globals/_index.scss
@@ -4,25 +4,21 @@
 /// @copyright IBM Security 2019
 ////
 
-@import 'theme/index';
-
 @import 'variables/index';
+
+@import 'carbon-components/scss/globals/scss/helper-mixins';
 
 @import 'color/index';
 @import 'grid/index';
 @import 'layout/index';
 @import 'motion/index';
+@import 'theme/index';
 @import 'type/index';
-
-@import 'carbon-components/scss/globals/scss/css--body';
-
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/globals/scss/vars';
-
-@import '../platform/index';
 
 @import 'border/index';
 @import 'deprecate/index';
 @import 'feature-flags/index';
 @import 'namespace/index';
 @import 'rtl/index';
+
+@import '../platform/index';

--- a/src/globals/layout/_index.scss
+++ b/src/globals/layout/_index.scss
@@ -4,8 +4,6 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../variables/index';
-
 @import '@carbon/layout/scss/layout';
 
 @import 'carbon-components/scss/globals/scss/layout';

--- a/src/globals/theme/_index.scss
+++ b/src/globals/theme/_index.scss
@@ -16,14 +16,12 @@ $carbon--theme: $security--theme;
 
 @include carbon--theme;
 
-@import '../variables/index';
+@import 'carbon-components/scss/globals/scss/theme';
 
 @import '../deprecate/index';
 @import '../namespace/index';
 
 @import '../../components/IconButton/variables';
-
-@import 'carbon-components/scss/globals/scss/theme';
 
 // TODO: V3 - To be removed after the `theme` function is deprecated.
 

--- a/src/globals/type/_index.scss
+++ b/src/globals/type/_index.scss
@@ -4,10 +4,16 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../variables/index';
-
 @import '@carbon/type/scss/type';
 @import '@carbon/type/scss/classes';
+
+/// `@font-face` declarations.
+/// @type boolean
+$css--font-face: true !default;
+
+/// IBM Plex.
+/// @type boolean
+$css--plex: true;
 
 @import 'carbon-components/scss/globals/scss/css--font-face';
 

--- a/src/globals/variables/_index.scss
+++ b/src/globals/variables/_index.scss
@@ -14,14 +14,6 @@ $security--css--reset: false !default;
 
 // Carbon variables.
 
-/// `@font-face` declarations.
-/// @type boolean
-$css--font-face: true !default;
-
-/// IBM Plex.
-/// @type boolean
-$css--plex: true;
-
 /// CSS reset - https://cssreset.com/
 /// @type boolean
 $css--reset: $security--css--reset;

--- a/src/platform/body/_index.scss
+++ b/src/platform/body/_index.scss
@@ -4,6 +4,8 @@
 /// @copyright IBM Security 2019
 ////
 
+@import 'carbon-components/scss/globals/scss/css--body';
+
 @import '../../globals/feature-flags/index';
 @import '../../globals/namespace/index';
 @import '../../globals/variables/index';

--- a/src/platform/body/_mixins.scss
+++ b/src/platform/body/_mixins.scss
@@ -5,7 +5,7 @@
 ////
 
 @import '@carbon/grid/scss/mixins';
-@import '@carbon/themes/scss/mixins';
+@import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/classes';
 @import '@carbon/type/scss/reset';
 

--- a/src/platform/body/_mixins.scss
+++ b/src/platform/body/_mixins.scss
@@ -4,8 +4,10 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '../../globals/grid/index';
-@import '../../globals/type/index';
+@import '@carbon/grid/scss/mixins';
+@import '@carbon/theme/scss/mixins';
+@import '@carbon/type/scss/classes';
+@import '@carbon/type/scss/reset';
 
 /// Background color.
 /// @type Color

--- a/src/platform/body/_mixins.scss
+++ b/src/platform/body/_mixins.scss
@@ -5,7 +5,7 @@
 ////
 
 @import '@carbon/grid/scss/mixins';
-@import '@carbon/theme/scss/mixins';
+@import '@carbon/themes/scss/mixins';
 @import '@carbon/type/scss/classes';
 @import '@carbon/type/scss/reset';
 


### PR DESCRIPTION
## Affected issues

- Resolves #32 

## Proposed changes

- Update `Shell` and sub-components to use correct partials
- Move Carbon body overrides into `platform/body` to prevent override unless the platform styles are required
- Move Carbon type overrides into `globals/type` to prevent override unless the global styles are required
- Add comments for lines to revert