### PR TITLE
chore(header): convert account id in mocks to string

### DIFF
--- a/src/components/Header/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.spec.js.snap
@@ -41,15 +41,15 @@ exports[`Header Rendering renders correctly 1`] = `
   accounts={
     Array [
       Object {
-        "id": 0,
+        "id": "0",
         "name": "Company 1",
       },
       Object {
-        "id": 1,
+        "id": "1",
         "name": "Company 2",
       },
       Object {
-        "id": 2,
+        "id": "2",
         "name": "Company 3",
       },
     ]

--- a/src/components/Header/_mocks_/index.js
+++ b/src/components/Header/_mocks_/index.js
@@ -21,7 +21,7 @@ const links = {
 };
 
 const accounts = new Array(3).fill().map((name = `Company`, id) => ({
-  id,
+  id: id.toString(),
   name: `${name} ${id + 1}`,
 }));
 


### PR DESCRIPTION
## Affected issues

- Resolves #57 

## Proposed changes

- converts `id` value in mocks to a string

**NOTE:** alternatively we could change the proptype for for `accounts.id` to a `number`... but while personally I would prefer that, that change seems like a bigger deal given that this component is currently in use as-is. So with this change, we'd only be affecting our own mocks (and resulting tests)