### PR TITLE
chore(search-bar): update tests with required prop

### DIFF
--- a/src/components/SearchBar/__tests__/SearchBar.spec.js
+++ b/src/components/SearchBar/__tests__/SearchBar.spec.js
@@ -17,6 +17,7 @@ const {
   placeHolderText,
   selectedScopes,
   scopes,
+  scopesTypeLabel,
   submitLabel,
   value,
 } = props;
@@ -51,12 +52,12 @@ describe('SearchBar', () => {
     });
 
     it('renders scopes', () => {
-      searchBar.setProps({ scopes });
+      searchBar.setProps({ scopes, scopesTypeLabel });
       expect(searchBar).toMatchSnapshot();
     });
 
     it('renders selected scopes', () => {
-      searchBar.setProps({ scopes, selectedScopes });
+      searchBar.setProps({ scopes, scopesTypeLabel, selectedScopes });
 
       expect(searchBar).toMatchSnapshot();
     });
@@ -70,6 +71,7 @@ describe('SearchBar', () => {
     it('disables the submit button with no selected scopes', () => {
       searchBar.setProps({
         scopes,
+        scopesTypeLabel,
         selectedScopes: [],
       });
 
@@ -88,7 +90,7 @@ describe('SearchBar', () => {
     });
 
     it('calls the change handler when the scope changes', () => {
-      searchBar.setProps({ scopes });
+      searchBar.setProps({ scopes, scopesTypeLabel });
 
       simulate('change', { selectedItems: selectedScopes }, '__scopes');
 

--- a/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
@@ -28,6 +28,7 @@ exports[`SearchBar Rendering disables the submit button with no selected scopes 
         },
       ]
     }
+    label="Scopes"
     light={false}
     locale="en"
     name="search-scopes"
@@ -185,6 +186,7 @@ exports[`SearchBar Rendering renders scopes 1`] = `
         },
       ]
     }
+    label="Scopes"
     light={false}
     locale="en"
     name="search-scopes"
@@ -256,6 +258,7 @@ exports[`SearchBar Rendering renders selected scopes 1`] = `
         },
       ]
     }
+    label="Scopes"
     light={false}
     locale="en"
     name="search-scopes"


### PR DESCRIPTION
## Affected issues

- Resolves #58 

## Proposed changes

- `scopesTypeLabel` is required with `scopes` prop is used, so I added it where necessary to the tests to remove the prop types error identified in #58 
