### PR TITLE
docs(ica): add grid example and add box-sizing reset to storybook styles

### DIFF
--- a/.storybook/index.scss
+++ b/.storybook/index.scss
@@ -7,6 +7,10 @@
 @import 'themes/index';
 @import '../.storybook/components/Container/index';
 
+* {
+  box-sizing: border-box;
+}
+
 .grid {
   display: flex;
   padding: $carbon--spacing-09;

--- a/src/components/ICA/ICA.stories.js
+++ b/src/components/ICA/ICA.stories.js
@@ -43,6 +43,11 @@ storiesOf(components('ICA'), module)
     () => (
       <div className="bx--grid bx--grid--full-width">
         <div className="bx--row">
+          <div className="bx--col">
+            <h4>4 spaced</h4>
+          </div>
+        </div>
+        <div className="bx--row">
           {Array(4)
             .fill(0)
             .map(item => (
@@ -54,13 +59,18 @@ storiesOf(components('ICA'), module)
               </div>
             ))}
         </div>
-        <div className="bx--row" style={{ marginTop: '36px' }}>
+        <div className="bx--row">
+          <div className="bx--col">
+            <h4>8 condensed</h4>
+          </div>
+        </div>
+        <div className="bx--row">
           {Array(8)
             .fill(0)
             .map(item => (
               <div
                 key={item.id}
-                className="bx--col-sm-2 bx--col-md-1 bx--col-lg-2"
+                className="bx--col-sm-2 bx--col-md-2 bx--col-lg-2"
               >
                 <ICA {...storyProps({ total })} />
               </div>

--- a/src/components/ICA/ICA.stories.js
+++ b/src/components/ICA/ICA.stories.js
@@ -4,7 +4,6 @@
  */
 
 import { withA11y } from '@storybook/addon-a11y';
-import centered from '@storybook/addon-centered/react';
 import { boolean, select, number, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
@@ -30,11 +29,54 @@ const storyProps = ({ value = icaValue, total } = {}) => ({
 
 storiesOf(components('ICA'), module)
   .addDecorator(withA11y)
-  .addDecorator(centered)
-  .add('Default', () => <ICA {...storyProps()} />)
-  .add('Null value', () => <ICA {...storyProps({ value: null })} />)
-  .add('1000 value', () => <ICA {...storyProps({ value: icaValue * 100 })} />)
-  .add('1000000 value', () => (
+  .add('default', () => <ICA {...storyProps()} />)
+  .add('with null value', () => <ICA {...storyProps({ value: null })} />)
+  .add('with 1000 value', () => (
+    <ICA {...storyProps({ value: icaValue * 100 })} />
+  ))
+  .add('with 1000000 value', () => (
     <ICA {...storyProps({ value: icaValue * 100000 })} />
   ))
-  .add('Total', () => <ICA {...storyProps({ total })} />);
+  .add('with total', () => <ICA {...storyProps({ total })} />)
+  .add(
+    'in an ICA wall',
+    () => (
+      <div className="bx--grid bx--grid--full-width">
+        <div className="bx--row">
+          {Array(4)
+            .fill(0)
+            .map(item => (
+              <div
+                key={item.id}
+                className="bx--col-sm-4 bx--col-md-2 bx--col-lg-4"
+              >
+                <ICA {...storyProps({ total })} />
+              </div>
+            ))}
+        </div>
+        <div className="bx--row" style={{ marginTop: '36px' }}>
+          {Array(8)
+            .fill(0)
+            .map(item => (
+              <div
+                key={item.id}
+                className="bx--col-sm-2 bx--col-md-1 bx--col-lg-2"
+              >
+                <ICA {...storyProps({ total })} />
+              </div>
+            ))}
+        </div>
+      </div>
+    ),
+    {
+      info: {
+        text: `
+        Multiple \`ICA\` components (i.e., an "ICA Wall") should be presented in a grid using the correct class names.
+        
+        These two row examples show different combinations of breakpoints and spans set per column with specific class names.
+        
+        For more information the 16 column IBM grid, please review the [\`@carbon/grid\` package documentation](https://github.com/carbon-design-system/carbon/tree/master/packages/grid).
+      `,
+      },
+    }
+  );


### PR DESCRIPTION
## Affected issues

- Resolves #23 

## Proposed changes

- add "with ICA wall" example that shows how to use grid classes to display multiple ICA components
- reformat a couple of the storybook names to match convention used for other stories ("with" etc)
- add `box-sizing: border-box` reset to Storybook (⚠️ NOTE: this is necessary to use the grid, as we don't apply a reset globally)
