### PR TITLE
fix(search-bar): pass through translatewithid prop to multiselect child

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -79,6 +79,9 @@ export default class SearchBar extends React.Component {
     /** @type {string} The name text for the search scope type. */
     // eslint-disable-next-line react/require-default-props
     scopesTypeLabel: conditionalScopePropValidator,
+
+    /** @type {func} Callback function for translating MultiSelect's child ListBoxMenuIcon SVG title. */
+    translateWithId: PropTypes.func, // eslint-disable-line react/require-default-props
   };
 
   static defaultProps = {
@@ -142,6 +145,7 @@ export default class SearchBar extends React.Component {
       scopeToString,
       scopesTypeLabel,
       selectedScopes,
+      translateWithId,
     } = this.props;
 
     if (scopes.length === 0) return null;
@@ -156,6 +160,7 @@ export default class SearchBar extends React.Component {
         initialSelectedItems={selectedScopes}
         items={scopes}
         itemToString={scopeToString}
+        translateWithId={translateWithId}
       />
     );
   }

--- a/src/components/SearchBar/SearchBar.stories.js
+++ b/src/components/SearchBar/SearchBar.stories.js
@@ -74,9 +74,15 @@ const storyProps = {
     ),
     scopeToString: ({ name }) => name,
   }),
+  translationIds: {
+    'close.menu': 'Close the menu',
+    'open.menu': 'Open the menu',
+    'clear.all': 'Clear all scopes',
+    'clear.selection': 'Clear scope',
+  },
 };
 
-const { regular, scopes: scopesProps } = storyProps;
+const { regular, scopes: scopesProps, translationIds } = storyProps;
 
 storiesOf(patterns('SearchBar'), module)
   .addDecorator(withA11y)
@@ -85,12 +91,17 @@ storiesOf(patterns('SearchBar'), module)
     <SearchBarWithStateHandlers {...regular()} value={value} />
   ))
   .add('Scopes', () => (
-    <SearchBarWithStateHandlers {...regular()} {...scopesProps()} />
+    <SearchBarWithStateHandlers
+      {...regular()}
+      {...scopesProps()}
+      translateWithId={id => translationIds[id]}
+    />
   ))
   .add('Selected scopes', () => (
     <SearchBarWithStateHandlers
       {...regular()}
       {...scopesProps()}
       selectedScopes={selectedScopes}
+      translateWithId={id => translationIds[id]}
     />
   ));


### PR DESCRIPTION
## Affected issues

- Resolves #72 

## Proposed changes

- add `translateWithId` prop to `SearchBar`, then pass through to child `MultiSelect`
- show `translateWithId` prop in use in the scopes stories