### PR TITLE
docs(checkbox): add display name so prop table is correct in stories

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.js
+++ b/src/components/Checkbox/Checkbox.stories.js
@@ -19,6 +19,8 @@ import { Checkbox, CheckboxSkeleton } from '../..';
 
 const { prefix } = settings;
 
+Checkbox.displayName = 'Checkbox';
+
 const props = () => ({
   className: 'some-class',
   labelText: text('Label text (labelText)', 'Checkbox label'),


### PR DESCRIPTION
## Affected issues

- Resolves #78 

## Proposed changes

- adds a display name for the checkbox


## Testing instructions

Compare the proptable in the Netifly deploy (when it finishes) to this prop table: https://ibm-security.carbondesignsystem.com/?path=/story/components-checkbox--checked
