### PR TITLE
fix(combo-button): add ternary to handle icon not provided

### DIFF
--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -101,7 +101,7 @@ const ComboButton = ({ children, className, direction }) => {
               >
                 {children}
               </span>
-              <Icon />
+              {!Icon ? null : <Icon />}
             </Fragment>
           }
           key={item.id}


### PR DESCRIPTION
## Proposed changes

- add ternary to catch empty `renderIcon` prop