### PR TITLE
feat(component): namespace and privatise `component` mixin

### DIFF
--- a/src/components/Button/_index.scss
+++ b/src/components/Button/_index.scss
@@ -10,6 +10,6 @@
 
 @import 'mixins';
 
-@include component($name: button) {
+@include security--component($name: button) {
   @include button;
 }

--- a/src/components/Card/CardSkeleton/_index.scss
+++ b/src/components/Card/CardSkeleton/_index.scss
@@ -10,6 +10,6 @@
 
 @import 'mixins';
 
-@include component($name: #{$card__name}--skeleton) {
+@include security--component($name: #{$card__name}--skeleton) {
   @include card--skeleton;
 }

--- a/src/components/Card/_index.scss
+++ b/src/components/Card/_index.scss
@@ -10,6 +10,6 @@
 
 @import 'mixins';
 
-@include component($name: $card__name) {
+@include security--component($name: $card__name) {
   @include card;
 }

--- a/src/components/ComboButton/_index.scss
+++ b/src/components/ComboButton/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: combo-button) {
+@include security--component($name: combo-button) {
   @include combo-button;
 }

--- a/src/components/Component/_mixins.scss
+++ b/src/components/Component/_mixins.scss
@@ -1,7 +1,7 @@
 ////
 /// Mixins for base components.
 /// @group component
-/// @copyright IBM Security 2018
+/// @copyright IBM Security 2019
 ////
 
 @import '../../globals/namespace/index';
@@ -11,15 +11,16 @@
 /// @param {String} $name The name of the component which dictates what the block-level class name
 /// is going to be for the component being styled.
 /// @content The styles for the component and all of its elements.
+/// @access private
 /// @example scss
-///   @include component($name: header) {
+///   @include security--component($name: header) {
 ///     background-color: $header__color__background;
 ///   }
 /// @output css
 ///   .security--header {
 ///     background-color: #fff;
 ///   }
-@mixin component($name) {
+@mixin security--component($name) {
   @include export-namespace($name: $name) {
     @include namespace($selector: $name) {
       @content;

--- a/src/components/DataDecorator/_index.scss
+++ b/src/components/DataDecorator/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: decorator) {
+@include security--component($name: decorator) {
   @include decorator;
 }

--- a/src/components/DelimitedList/_index.scss
+++ b/src/components/DelimitedList/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: delimited-list) {
+@include security--component($name: delimited-list) {
   @include delimited-list;
 }

--- a/src/components/ErrorPage/_index.scss
+++ b/src/components/ErrorPage/_index.scss
@@ -11,6 +11,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: error-page) {
+@include security--component($name: error-page) {
   @include error-page;
 }

--- a/src/components/ExternalLink/_index.scss
+++ b/src/components/ExternalLink/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: link--external) {
+@include security--component($name: link--external) {
   @include link--external;
 }

--- a/src/components/FilterPanel/FilterCategory/_index.scss
+++ b/src/components/FilterPanel/FilterCategory/_index.scss
@@ -8,6 +8,6 @@
 
 @import 'mixins';
 
-@include component($name: filter-category) {
+@include security--component($name: filter-category) {
   @include filter-category;
 }

--- a/src/components/FilterPanel/FilterSearch/_index.scss
+++ b/src/components/FilterPanel/FilterSearch/_index.scss
@@ -8,6 +8,6 @@
 
 @import 'mixins';
 
-@include component($name: filter-search) {
+@include security--component($name: filter-search) {
   @include filter-search;
 }

--- a/src/components/FilterPanel/FilterSelector/_index.scss
+++ b/src/components/FilterPanel/FilterSelector/_index.scss
@@ -8,6 +8,6 @@
 
 @import 'mixins';
 
-@include component($name: filter-selector) {
+@include security--component($name: filter-selector) {
   @include filter-selector;
 }

--- a/src/components/FilterPanel/FilterSubcategory/_index.scss
+++ b/src/components/FilterPanel/FilterSubcategory/_index.scss
@@ -7,6 +7,6 @@
 
 @import 'mixins';
 
-@include component($name: filter-subcategory) {
+@include security--component($name: filter-subcategory) {
   @include filter-subcategory;
 }

--- a/src/components/FilterPanel/_index.scss
+++ b/src/components/FilterPanel/_index.scss
@@ -17,6 +17,6 @@
 
 @import 'mixins';
 
-@include component($name: filter-panel) {
+@include security--component($name: filter-panel) {
   @include filter-panel;
 }

--- a/src/components/Header/HeaderListItem/_index.scss
+++ b/src/components/Header/HeaderListItem/_index.scss
@@ -10,6 +10,6 @@
 
 @import 'mixins';
 
-@include component($name: #{$header__name}__list__item) {
+@include security--component($name: #{$header__name}__list__item) {
   @include header__list__item;
 }

--- a/src/components/Header/HeaderNotification/_index.scss
+++ b/src/components/Header/HeaderNotification/_index.scss
@@ -10,6 +10,6 @@
 
 @import 'mixins';
 
-@include component($name: #{$header__name}__notification) {
+@include security--component($name: #{$header__name}__notification) {
   @include header__notification;
 }

--- a/src/components/Header/HeaderPopoverHeader/_index.scss
+++ b/src/components/Header/HeaderPopoverHeader/_index.scss
@@ -10,6 +10,6 @@
 
 @import 'mixins';
 
-@include component($name: #{$header__name}__popover__header) {
+@include security--component($name: #{$header__name}__popover__header) {
   @include header__popover__header;
 }

--- a/src/components/Header/HeaderPopoverLinkSecondary/_index.scss
+++ b/src/components/Header/HeaderPopoverLinkSecondary/_index.scss
@@ -10,6 +10,8 @@
 
 @import 'mixins';
 
-@include component($name: #{$header__name}__popover__link--secondary) {
+@include security--component(
+  $name: #{$header__name}__popover__link--secondary
+) {
   @include header__popover__link--secondary;
 }

--- a/src/components/Header/_index.scss
+++ b/src/components/Header/_index.scss
@@ -19,6 +19,6 @@
 
 @import 'mixins';
 
-@include component($name: $header__name) {
+@include security--component($name: $header__name) {
   @include header;
 }

--- a/src/components/ICA/ICASkeleton/_index.scss
+++ b/src/components/ICA/ICASkeleton/_index.scss
@@ -7,6 +7,6 @@
 @import '../../Component/mixins';
 @import 'mixins';
 
-@include component($name: 'ica-skeleton') {
+@include security--component($name: 'ica-skeleton') {
   @include ica-skeleton;
 }

--- a/src/components/ICA/_index.scss
+++ b/src/components/ICA/_index.scss
@@ -8,6 +8,6 @@
 @import 'ICASkeleton/index';
 @import 'mixins';
 
-@include component($name: ica) {
+@include security--component($name: ica) {
   @include ica;
 }

--- a/src/components/IconButton/_index.scss
+++ b/src/components/IconButton/_index.scss
@@ -8,6 +8,6 @@
 @import 'variables';
 @import 'mixins';
 
-@include component($name: $button--icon__name) {
+@include security--component($name: $button--icon__name) {
   @include button--icon;
 }

--- a/src/components/IconButtonBar/_index.scss
+++ b/src/components/IconButtonBar/_index.scss
@@ -8,6 +8,6 @@
 
 @import 'mixins';
 
-@include component($name: icon-button-bar) {
+@include security--component($name: icon-button-bar) {
   @include icon-button-bar;
 }

--- a/src/components/Nav/_index.scss
+++ b/src/components/Nav/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: nav) {
+@include security--component($name: nav) {
   @include nav;
 }

--- a/src/components/NonEntitledSection/_index.scss
+++ b/src/components/NonEntitledSection/_index.scss
@@ -11,6 +11,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: ne-section) {
+@include security--component($name: ne-section) {
   @include ne-section;
 }

--- a/src/components/Panel/_index.scss
+++ b/src/components/Panel/_index.scss
@@ -11,6 +11,6 @@
 
 @import 'mixins';
 
-@include component($name: panel) {
+@include security--component($name: panel) {
   @include panel;
 }

--- a/src/components/PanelV2/_index.scss
+++ b/src/components/PanelV2/_index.scss
@@ -8,6 +8,6 @@
 
 @import 'mixins';
 
-@include component($name: panelv2) {
+@include security--component($name: panelv2) {
   @include panelv2;
 }

--- a/src/components/Pill/_index.scss
+++ b/src/components/Pill/_index.scss
@@ -9,6 +9,6 @@
 
 @import '../DataDecorator/index';
 
-@include component($name: pill) {
+@include security--component($name: pill) {
   @include pill;
 }

--- a/src/components/Portal/_index.scss
+++ b/src/components/Portal/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: portal) {
+@include security--component($name: portal) {
   @include portal;
 }

--- a/src/components/ProfileImage/_index.scss
+++ b/src/components/ProfileImage/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: profile-image) {
+@include security--component($name: profile-image) {
   @include profile-image;
 }

--- a/src/components/ScrollGradient/_index.scss
+++ b/src/components/ScrollGradient/_index.scss
@@ -6,6 +6,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: scroll-gradient) {
+@include security--component($name: scroll-gradient) {
   @include scroll-gradient;
 }

--- a/src/components/SearchBar/_index.scss
+++ b/src/components/SearchBar/_index.scss
@@ -6,6 +6,6 @@
 
 @import 'mixins';
 
-@include component($name: search-bar) {
+@include security--component($name: search-bar) {
   @include search-bar;
 }

--- a/src/components/Shell/_index.scss
+++ b/src/components/Shell/_index.scss
@@ -13,6 +13,6 @@
 
 @import 'mixins';
 
-@include component($name: shell) {
+@include security--component($name: shell) {
   @include shell;
 }

--- a/src/components/StackedNotification/_index.scss
+++ b/src/components/StackedNotification/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: stacked-notification) {
+@include security--component($name: stacked-notification) {
   @include stacked-notification;
 }

--- a/src/components/StatusIcon/_index.scss
+++ b/src/components/StatusIcon/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: status-icon) {
+@include security--component($name: status-icon) {
   @include status-icon;
 }

--- a/src/components/StatusIndicator/_index.scss
+++ b/src/components/StatusIndicator/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: status-indicator) {
+@include security--component($name: status-indicator) {
   @include status-indicator;
 }

--- a/src/components/StepIndicator/_index.scss
+++ b/src/components/StepIndicator/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: step-indicator) {
+@include security--component($name: step-indicator) {
   @include step-indicator;
 }

--- a/src/components/StringFormatter/_index.scss
+++ b/src/components/StringFormatter/_index.scss
@@ -8,7 +8,7 @@
 
 @import '../Component/mixins';
 
-@include component($name: string-formatter) {
+@include security--component($name: string-formatter) {
   display: inline-block;
 
   &--truncate {

--- a/src/components/Tag/InteractiveTag/_index.scss
+++ b/src/components/Tag/InteractiveTag/_index.scss
@@ -7,6 +7,6 @@
 @import '../../Component/mixins';
 @import 'mixins';
 
-@include component($name: $tag--interactive__name) {
+@include security--component($name: $tag--interactive__name) {
   @include tag--interactive;
 }

--- a/src/components/TagWall/_index.scss
+++ b/src/components/TagWall/_index.scss
@@ -10,6 +10,6 @@
 
 @import '../Tag/index';
 
-@include component($name: tag-wall) {
+@include security--component($name: tag-wall) {
   @include tag-wall;
 }

--- a/src/components/TagWallFilter/Filter/_index.scss
+++ b/src/components/TagWallFilter/Filter/_index.scss
@@ -9,6 +9,6 @@
 @import '../../Component/mixins';
 @import 'mixins';
 
-@include component($name: $filter__name) {
+@include security--component($name: $filter__name) {
   @include filter;
 }

--- a/src/components/TagWallFilter/_index.scss
+++ b/src/components/TagWallFilter/_index.scss
@@ -7,6 +7,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: tag-wall-filter) {
+@include security--component($name: tag-wall-filter) {
   @include tag-wall-filter;
 }

--- a/src/components/Tearsheet/TearsheetSmall/_index.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_index.scss
@@ -14,6 +14,6 @@
 @import '../../ScrollGradient/index';
 @import '../../Tag/index';
 
-@include component($name: #{$tearsheet__name}--small) {
+@include security--component($name: #{$tearsheet__name}--small) {
   @include tearsheet--small;
 }

--- a/src/components/Tearsheet/_index.scss
+++ b/src/components/Tearsheet/_index.scss
@@ -12,6 +12,6 @@
 @import '../Portal/index';
 @import 'TearsheetSmall/index';
 
-@include component($name: $tearsheet__name) {
+@include security--component($name: $tearsheet__name) {
   @include tearsheet;
 }

--- a/src/components/Toolbar/_index.scss
+++ b/src/components/Toolbar/_index.scss
@@ -11,6 +11,6 @@
 
 @import 'mixins';
 
-@include component($name: toolbar) {
+@include security--component($name: toolbar) {
   @include toolbar;
 }

--- a/src/components/Transition/_index.scss
+++ b/src/components/Transition/_index.scss
@@ -8,6 +8,6 @@
 
 @import 'mixins';
 
-@include component($name: transition) {
+@include security--component($name: transition) {
   @include transition;
 }

--- a/src/components/TypeLayout/_index.scss
+++ b/src/components/TypeLayout/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: type-layout__container) {
+@include security--component($name: type-layout__container) {
   @include type-layout__container;
 }

--- a/src/components/Wizard/_index.scss
+++ b/src/components/Wizard/_index.scss
@@ -9,6 +9,6 @@
 @import '../Component/mixins';
 @import 'mixins';
 
-@include component($name: wizard) {
+@include security--component($name: wizard) {
   @include wizard;
 }

--- a/src/globals/namespace/_index.scss
+++ b/src/globals/namespace/_index.scss
@@ -8,7 +8,8 @@
 
 /// The prefix used to namespace all selectors in the CSS.
 /// @type String
-$namespace: 'security--' !default;
+/// @access private
+$namespace: 'security--';
 
 ///
 /// Appends the namespace for a component to another namespace.


### PR DESCRIPTION
## Affected issues

- Resolves #99 

## Proposed changes

- Rename `component` mixin and mark as private in SassDoc
- Prevent `$namespace` variable from being overwritten and mark as private in SassDoc

## Testing instructions

- <!-- List of instructions for reviewer to test that proposed changes in this PR work properly -->
