### PR TITLE
fix(status-indicator): update deprecated `InlineLoading` prop

### DIFF
--- a/src/components/InlineLoading/InlineLoading.stories.js
+++ b/src/components/InlineLoading/InlineLoading.stories.js
@@ -8,14 +8,18 @@ import { storiesOf } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import { action } from '@storybook/addon-actions';
 import centered from '@storybook/addon-centered/react';
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { number, select, text } from '@storybook/addon-knobs';
 
 import { components } from '../../../.storybook';
 
 import { Button, InlineLoading } from '../../';
 
 const props = () => ({
-  success: boolean('Loading successful state (success)', false),
+  status: select(
+    'Loading status (status)',
+    ['inactive', 'active', 'finished', 'error'],
+    'active'
+  ),
   description: text(
     'Loading progress description (description)',
     'Loading data...'
@@ -92,7 +96,7 @@ storiesOf(components('InlineLoading'), module)
                 <InlineLoading
                   style={{ marginLeft: '1rem' }}
                   description="Submitting..."
-                  success={success}
+                  status={success ? 'finished' : 'active'}
                 />
               ) : (
                 <Button onClick={handleSubmit}>Submit</Button>

--- a/src/components/StatusIndicator/StatusStep/StatusStep.js
+++ b/src/components/StatusIndicator/StatusStep/StatusStep.js
@@ -39,7 +39,7 @@ const getStatusIcon = (status, description) => {
         <InlineLoading
           className={`${namespace}-wrapper`}
           description={description}
-          success
+          status="finished"
         />
       );
     case STATUS.FAILED:


### PR DESCRIPTION
## Affected issues

- Resolves partially #104

## Proposed changes

- Update deprecated `success` `InlineLoading` prop in `StatusIndicator` to `status`