### PR TITLE
docs(stacked-notification): add knobs to storybook

### DIFF
--- a/src/components/StackedNotification/StackedNotification.js
+++ b/src/components/StackedNotification/StackedNotification.js
@@ -34,6 +34,7 @@ const StackedNotification = ({
       caption={caption}
       iconDescription={iconDescription}
       onClick={onCloseButtonClick}
+      hideCloseButton={hideCloseButton}
       {...other}
     />
   );

--- a/src/components/StackedNotification/StackedNotification.stories.js
+++ b/src/components/StackedNotification/StackedNotification.stories.js
@@ -6,19 +6,24 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
+import centered from '@storybook/addon-centered/react';
+import { text, boolean } from '@storybook/addon-knobs';
 
-import { iconDescription, title, subtitle } from './_mocks_';
+import { iconDescription, title, subtitle, caption } from './_mocks_';
 
 import { components } from '../../../.storybook';
 
 import { StackedNotification } from '../..';
 
-const props = {
-  iconDescription,
-  title,
-  subtitle,
-};
+const props = () => ({
+  iconDescription: text('Icon Description (iconDescription)', iconDescription),
+  title: text('Title (title)', title),
+  subtitle: text('Subtitle (subtitle)', subtitle),
+  caption: text('Caption (caption)', caption),
+  hideCloseButton: boolean('Hide close button (hideCloseButton)', false),
+});
 
 storiesOf(components('StackedNotification'), module)
+  .addDecorator(centered)
   .addDecorator(withA11y)
-  .add('default', () => <StackedNotification {...props} />);
+  .add('Default', () => <StackedNotification {...props()} />);

--- a/src/components/StackedNotification/_mocks_/index.js
+++ b/src/components/StackedNotification/_mocks_/index.js
@@ -10,4 +10,6 @@ const title = 'You have 4 unread notifications';
 const subtitle =
   'Roius abnta mod tempor adsfiso incidfid idunt ut labnt empor uilt labnore...';
 
-export { iconDescription, title, subtitle };
+const caption = '';
+
+export { iconDescription, title, subtitle, caption };


### PR DESCRIPTION
## Affected issues

- Resolves #115

## Proposed changes

- Modified props to be in Storybook fashion with knobs available.
- Added `centered` decorator

## Testing instructions

- visit storybook

## Screenshot
![image](https://user-images.githubusercontent.com/36169811/66003664-0f5dfd00-e4a7-11e9-8d5d-92d8e32ce9bf.png)
