### PR TITLE
docs(multi-select): add and reorder props to match these from carbon-components

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.js
+++ b/src/components/MultiSelect/MultiSelect.stories.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
+import centered from '@storybook/addon-centered/react';
 import { boolean, select, text, object } from '@storybook/addon-knobs';
 
 import { components } from '../../../.storybook';
@@ -41,12 +42,14 @@ const types = {
 };
 
 const props = () => ({
+  id: text('MultiSelect ID (id)', 'carbon-multiselect-example'),
+  titleText: text('Title (titleText)', 'Multiselect title'),
+  helperText: text('Helper text (helperText)', 'This is not helper text'),
   filterable: boolean(
     'Filterable (`<MultiSelect.Filterable>` instead of `<MultiSelect>`)',
     false
   ),
   disabled: boolean('Disabled (disabled)', false),
-  id: 'multiselect',
   light: boolean('Light variant (light)', false),
   useTitleInItem: boolean('Show tooltip on hover', false),
   type: select('UI type (Only for `<MultiSelect>`) (type)', types, 'default'),
@@ -62,11 +65,14 @@ const props = () => ({
     {
       'close.menu': 'Close menu',
       'open.menu': 'Open menu',
+      'clear.all': 'Clear all',
+      'clear.selection': 'Clear selection',
     }
   ),
 });
 
 storiesOf(components('MultiSelect'), module)
+  .addDecorator(centered)
   .addDecorator(withA11y)
   .add(
     'default',


### PR DESCRIPTION
Apparently the knobs were sometimes crashing when doing some changes on them, moving filterable from the first key of props seems to fix this issue (not sure why though).

## Affected issues

- Resolves #121 

## Proposed changes

- add and reorder props to match these from carbon-components
- add `centered` decorator

## Testing instructions

As reported in the issue, **not only** changing the values in `listBoxMenuIconTranslationIds` were crashing knobs, but _any_ other change was also crashing the knobs (you can verify that by changing some knobs in the [MultiSelect](https://ibm-security.carbondesignsystem.com/?path=/story/components-multiselect--default)

- check if changing knobs will crash the knobs sidebar (crash == options to change will disappear,  and refresh is needed)