### PR TITLE
chore(tearsheet): update tearsheet snapshots to fix tests

### DIFF
--- a/src/components/Tearsheet/__tests__/__snapshots__/Tearsheet.spec.js.snap
+++ b/src/components/Tearsheet/__tests__/__snapshots__/Tearsheet.spec.js.snap
@@ -51,10 +51,9 @@ exports[`Tearsheet should override \`labels\` if button label property provided 
           className="security--tearsheet__sidebar__footer"
         >
           <Button
-            className="security--tearsheet__sidebar__button"
             disabled={false}
             iconDescription="Delete - prop"
-            kind="ghost"
+            kind="ghost-danger"
             largeText={null}
             onClick={[MockFunction]}
             renderIcon={
@@ -215,10 +214,9 @@ exports[`Tearsheet should render the Tearsheet 1`] = `
           className="security--tearsheet__sidebar__footer"
         >
           <Button
-            className="security--tearsheet__sidebar__button"
             disabled={false}
             iconDescription="Delete"
-            kind="ghost"
+            kind="ghost-danger"
             largeText={null}
             onClick={[MockFunction]}
             renderIcon={


### PR DESCRIPTION
## Proposed changes

- regenerate snapshots for `Tearsheet`, since the button has changed
