### PR TITLE
fix(filter): refactor styles and remove overrides

### DIFF
--- a/src/components/TagWallFilter/Filter/_mixins.scss
+++ b/src/components/TagWallFilter/Filter/_mixins.scss
@@ -19,46 +19,17 @@ $filter__namespace: get-component-namespace(
 @mixin filter {
   $root: &;
 
-  &.#{$prefix}--list-box {
-    padding-bottom: $carbon--spacing-03;
-    border-color: transparent;
-    outline: none;
-  }
-
-  .#{$prefix}--list-box__field {
-    height: $carbon--layout-04;
-    background: $ui-02;
-    padding: 0;
-  }
-
-  .#{$prefix}--list-box__selection {
-    right: $carbon--spacing-08;
-
-    &:before {
-      content: '';
-      height: $carbon--layout-01;
-      width: 1px;
-      position: absolute;
-      right: 0;
-      background: $ui-04;
+  .#{$prefix}--list-box {
+    &__field {
+      padding-right: 0;
+      padding-left: 0;
     }
 
-    &:focus {
-      &:before {
-        content: none;
-      }
+    &__menu-item__option {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
-  }
-
-  .#{$prefix}--list-box__menu-item__option {
-    height: carbon--mini-units(3.25);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .#{$prefix}--text-input#{$root}__input-field {
-    border-color: transparent;
   }
 
   &__search {
@@ -68,22 +39,33 @@ $filter__namespace: get-component-namespace(
     right: $carbon--spacing-05;
     height: 100%;
     top: 0;
-  }
 
-  &__search__icon {
-    fill: $icon-02;
+    &__icon {
+      fill: $icon-02;
+    }
   }
 
   &__add {
     display: flex;
-  }
 
-  &__add__icon {
-    fill: currentColor;
-    visibility: hidden;
+    &__icon {
+      fill: currentColor;
+      visibility: hidden;
+    }
   }
 
   &__list-item {
+    &:focus,
+    &:hover {
+      #{$root}__add__icon {
+        visibility: visible;
+      }
+    }
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+
     &:hover {
       background: $ui-02;
       position: relative;
@@ -99,21 +81,8 @@ $filter__namespace: get-component-namespace(
       }
     }
 
-    &:focus {
-      @include focus-outline('outline');
-    }
-
-    &:hover,
-    &:focus {
-      #{$root}__add__icon {
-        visibility: visible;
-      }
-    }
-
-    &:first-of-type {
-      .#{$prefix}--list-box__menu-item__option {
-        border-color: transparent;
-      }
+    &:first-of-type > .#{$prefix}--list-box__menu-item__option {
+      border-color: transparent;
     }
   }
 


### PR DESCRIPTION
## Affected issues

- Resolves #139 

## Proposed changes

- Remove redundant overrides to align search with `Search` and allow Carbon list item styles to display