### PR TITLE
fix(status-indicator): remove additional paddings for incomplete icon

### DIFF
--- a/src/components/StatusIndicator/_mixins.scss
+++ b/src/components/StatusIndicator/_mixins.scss
@@ -63,8 +63,6 @@
 
     &--incomplete #{$step}__icon {
       fill: $disabled-03;
-      padding-top: $carbon--spacing-03;
-      padding-bottom: $carbon--spacing-03;
     }
 
     &__icon-wrapper {


### PR DESCRIPTION
## Affected issues

- Resolves #148 

## Proposed changes

- removed `padding-top` and `padding-bottom` from `incomplete` icon as it was interfering with the icon size. 

## Testing instructions

- check if the `incomplete` icon on `StatusIndicator` component is now properly sized.

## Additional notes

If someone has an idea why these paddings were decreasing the icon size, I'd greatly appreciate any input as I'm pretty clueless about this specific thing 😄 .

Also, I've noticed that the `complete` icon is 16x16 px size and it doesn't look the best IMO for example in `StatusIndicator` - `Dynamic` story, when the icon sizes change from 20x20 to 16x16. (not sure if it's supposed to be like this, or it is a bug)
