### PR TITLE
feat(button): add loading state

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -4,10 +4,11 @@
  */
 
 import classnames from 'classnames';
-import { bool, oneOf } from 'prop-types';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import CarbonButton from 'carbon-components-react/lib/components/Button';
+import InlineLoading from '../InlineLoading';
 
 import { getComponentNamespace } from '../../globals/namespace';
 import deprecatedProp from '../../globals/prop-types';
@@ -18,20 +19,33 @@ const { defaultProps, propTypes } = CarbonButton;
 
 // TODO: V3 - Remove deprecated props `largeText`.
 
-const Button = ({ className, largeText, size, kind, ...other }) => {
+const Button = ({
+  className,
+  disabled,
+  largeText,
+  loading,
+  kind,
+  renderIcon,
+  size,
+  ...other
+}) => {
   const isSize = value => size === value;
   const isLarge = isSize('large') || largeText || isSize('lg') || isSize('xlg');
-
   const isGhostDanger = kind === 'ghost-danger';
+
+  const buttonClasses = classnames(namespace, className, {
+    [`${namespace}--ghost-danger`]: isGhostDanger,
+    [`${namespace}--large`]: isLarge,
+    [`${namespace}--loading`]: loading,
+  });
 
   return (
     <CarbonButton
-      className={classnames(namespace, className, {
-        [`${namespace}--large`]: isLarge,
-        [`${namespace}--ghost-danger`]: isGhostDanger,
-      })}
+      className={buttonClasses}
+      disabled={disabled || loading}
+      kind={isGhostDanger || loading ? 'ghost' : kind}
+      renderIcon={loading ? InlineLoading : renderIcon}
       size={!isLarge ? size : null}
-      kind={!isGhostDanger ? kind : 'ghost'}
       {...other}
     />
   );
@@ -39,15 +53,27 @@ const Button = ({ className, largeText, size, kind, ...other }) => {
 
 Button.defaultProps = {
   ...defaultProps,
+  disabled: false,
   largeText: null,
+  loading: false,
+  renderIcon: undefined,
 };
 
 Button.propTypes = {
   ...propTypes,
 
+  /** @type {boolean} Whether or not the button is disabled. */
+  disabled: PropTypes.bool,
+
+  /** @type {boolean} Whether or not the button is in a loading state. While loading, the button is disabled & icons provided via the `renderIcon` prop will not be shown. */
+  loading: PropTypes.bool,
+
+  /** @type {Function|object} Optional prop to allow overriding the icon rendering. Can be a React component class. */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+
   // It's not possible to add to Carbon's values here, so the `PropType` is recreated to include the large variant.
-  size: oneOf(['default', 'field', 'large', 'small']),
-  largeText: deprecatedProp('size="large"', bool),
+  size: PropTypes.oneOf(['default', 'field', 'large', 'small']),
+  largeText: deprecatedProp('size="large"', PropTypes.bool),
 };
 
 export default Button;

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -68,6 +68,7 @@ const props = {
   ) => {
     return {
       className: 'some-class',
+      loading: boolean('Button loading state (loading)', false),
       kind: select('Button kind (kind)', kinds, 'primary'),
       disabled: boolean('Disabled (disabled)', false),
       size: select('Button size (size)', sizes, 'default'),

--- a/src/components/Button/_mixins.scss
+++ b/src/components/Button/_mixins.scss
@@ -17,17 +17,13 @@
   /// @type Length
   $button__spacing__padding: $carbon--spacing-05;
 
-  /// Selector.
-  /// @type String
-  $carbon--button__selector: '.#{$prefix}--btn';
-
   &--ghost-danger {
     &,
     &:focus,
     &:hover {
       color: $text-01;
 
-      > #{$carbon--button__selector}__icon > path {
+      > .#{$prefix}--btn__icon > path {
         fill: currentColor;
       }
     }
@@ -47,12 +43,23 @@
     align-items: start;
     flex-direction: column;
 
-    > #{$carbon--button__selector}__icon {
+    > .#{$prefix}--btn__icon {
       position: absolute;
       bottom: $button__spacing__padding;
       width: unset;
       height: unset;
       margin-left: unset;
+    }
+  }
+
+  &--loading {
+    &.#{$prefix}--btn:disabled,
+    &.#{$prefix}--btn.#{$prefix}--btn--disabled {
+      color: $link-01;
+    }
+
+    .#{$prefix}--inline-loading {
+      width: auto;
     }
   }
 }


### PR DESCRIPTION
## Affected issues

- Resolves #96 

## Proposed changes

- adds a loading state for the `Button` that passes an `InlineLoading` component to `renderIcon` (NOTE: if `loading={true}`, then the loading spinner replaces whatever icon is passed into `renderIcon`. Also, if `loading={true}`, then the button is also disabled.)

## Testing instructions

- You can open the storybook deployment and toggle the `loading` knob.
