### PR TITLE
feat(nav-item-link): add component that accepts custom tag, include in nav

### DIFF
--- a/src/components/Nav/Nav.stories.js
+++ b/src/components/Nav/Nav.stories.js
@@ -8,7 +8,6 @@ import { storiesOf } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 
 import { components } from '../../../.storybook';
-
 import { Nav, NavItem, NavList } from '../..';
 
 storiesOf(components('Nav'), module)
@@ -18,8 +17,8 @@ storiesOf(components('Nav'), module)
     () => (
       <Nav heading="Nav example" label="Nav">
         <NavList title="Nav list 1">
-          <NavItem key="navitem_1-1" href="#navitem_1-1">
-            Nav item 1-1
+          <NavItem key="navitem_1-1" element="span" customprop="uniqueValue">
+            Nav item 1-1 (with a custom element)
           </NavItem>
           <NavItem key="navitem_1-2" href="#navitem_1-2">
             Nav item 1-2
@@ -41,9 +40,6 @@ storiesOf(components('Nav'), module)
             Nav item 3-2
           </NavItem>
         </NavList>
-        <NavItem key="navitem_0-1" href="#navitem_0-1">
-          Nav item not in a nav list
-        </NavItem>
       </Nav>
     ),
     {

--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -6,8 +6,9 @@
 import Launch16 from '@carbon/icons-react/lib/launch/16';
 
 import classnames from 'classnames';
-import { bool, func, node, number, string } from 'prop-types';
+import { bool, elementType, func, node, number, string } from 'prop-types';
 import React, { Component } from 'react';
+import NavItemLink from '../NavItemLink';
 
 import Icon from '../../Icon';
 
@@ -25,7 +26,9 @@ export default class NavItem extends Component {
     className: '',
     current: null,
     disabled: false,
+    element: 'a',
     handleItemSelect: null,
+    href: undefined,
     id: namespace,
     label: '',
     link: true,
@@ -50,8 +53,14 @@ export default class NavItem extends Component {
     /** @type {bool} Whether the item is disabled. */
     disabled: bool,
 
+    /** @type {elementType} The base element to use to build the link. Defaults to `a`, can also accept alternative tag names or custom components like `Link` from `react-router`. */
+    element: elementType,
+
     /** @type {Function} Click handler of an item. */
     handleItemSelect: func,
+
+    /** @type {string} The href of the nav item. */
+    href: string,
 
     /** @type {string} Identifier. */
     id: string,
@@ -83,6 +92,7 @@ export default class NavItem extends Component {
   render() {
     const {
       className,
+      element,
       tabIndex,
       children,
       disabled,
@@ -124,16 +134,16 @@ export default class NavItem extends Component {
         onKeyPress={event => handleDisabled(onClick(event, href))}
         role="menuitem"
         tabIndex={handleDisabled(children ? -1 : tabIndex)}
-        {...other}
       >
         {link ? (
-          <a
+          <NavItemLink
             id={id}
             className={classnames(linkClassName, {
               [`${namespace}__link--external`]: externalLink,
-              [`${namespace}__link--external`]: externalLink,
             })}
+            element={element}
             href={href}
+            {...other}
             {...externalLinkProps}
           >
             {children}
@@ -143,7 +153,7 @@ export default class NavItem extends Component {
                 renderIcon={Launch16}
               />
             )}
-          </a>
+          </NavItemLink>
         ) : (
           <div
             id={id}

--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -96,6 +96,7 @@ export default class NavItem extends Component {
       tabIndex,
       children,
       disabled,
+      label,
       onClick,
       onKeyPress,
       href,
@@ -130,6 +131,7 @@ export default class NavItem extends Component {
     return (
       <li
         className={classNames}
+        label={label}
         onClick={event => handleDisabled(onClick(event, href))}
         onKeyPress={event => handleDisabled(onClick(event, href))}
         role="menuitem"

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -9,14 +9,14 @@ exports[`NavItem Rendering renders correctly 1`] = `
   role="menuitem"
   tabIndex={-1}
 >
-  <ForwardRef(NavItemLink)
+  <NavItemLink
     className="security--nav__list__item__link"
     element="a"
     href="#"
     id="security--nav__list__item"
   >
     Label
-  </ForwardRef(NavItemLink)>
+  </NavItemLink>
 </li>
 `;
 

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -9,14 +9,14 @@ exports[`NavItem Rendering renders correctly 1`] = `
   role="menuitem"
   tabIndex={-1}
 >
-  <Link
+  <ForwardRef(NavItemLink)
     className="security--nav__list__item__link"
     element="a"
     href="#"
     id="security--nav__list__item"
   >
     Label
-  </Link>
+  </ForwardRef(NavItemLink)>
 </li>
 `;
 

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -3,26 +3,26 @@
 exports[`NavItem Rendering renders correctly 1`] = `
 <li
   className="security--nav__list__item class security--nav__list__item--active"
-  label=""
   onClick={[Function]}
   onKeyPress={[Function]}
   role="menuitem"
   tabIndex={-1}
 >
-  <a
+  <Link
     className="security--nav__list__item__link"
+    element="a"
     href="#"
     id="security--nav__list__item"
+    label=""
   >
     Label
-  </a>
+  </Link>
 </li>
 `;
 
 exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
 <li
   class="security--nav__list__item class security--nav__list__item--active"
-  label=""
   role="menuitem"
   tabindex="-1"
 >
@@ -30,6 +30,7 @@ exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
     class="security--nav__list__item__link"
     href="#"
     id="security--nav__list__item"
+    label=""
   >
     Label
   </a>

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`NavItem Rendering renders correctly 1`] = `
 <li
   className="security--nav__list__item class security--nav__list__item--active"
+  label=""
   onClick={[Function]}
   onKeyPress={[Function]}
   role="menuitem"
@@ -13,7 +14,6 @@ exports[`NavItem Rendering renders correctly 1`] = `
     element="a"
     href="#"
     id="security--nav__list__item"
-    label=""
   >
     Label
   </Link>
@@ -23,6 +23,7 @@ exports[`NavItem Rendering renders correctly 1`] = `
 exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
 <li
   class="security--nav__list__item class security--nav__list__item--active"
+  label=""
   role="menuitem"
   tabindex="-1"
 >
@@ -30,7 +31,6 @@ exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
     class="security--nav__list__item__link"
     href="#"
     id="security--nav__list__item"
-    label=""
   >
     Label
   </a>

--- a/src/components/Nav/NavItemLink/NavItemLink.js
+++ b/src/components/Nav/NavItemLink/NavItemLink.js
@@ -11,6 +11,8 @@ const NavItemLink = React.forwardRef(function NavItemLink(props, ref) {
   return React.createElement(element, { ...rest, ref });
 });
 
+NavItemLink.displayName = 'NavItemLink';
+
 NavItemLink.PropTypes = {
   /** @type {elementType} The base element to use to build the link. Defaults to `a`, can also accept alternative tag names or custom components like `Link` from `react-router`. */
   element: PropTypes.elementType,

--- a/src/components/Nav/NavItemLink/NavItemLink.js
+++ b/src/components/Nav/NavItemLink/NavItemLink.js
@@ -1,0 +1,25 @@
+/**
+ * @file Nav item link.
+ * @copyright IBM Security 2019
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const NavItemLink = React.forwardRef(function NavItemLink(props, ref) {
+  const { element, ...rest } = props;
+  return React.createElement(element, { ...rest, ref });
+});
+
+NavItemLink.displayName = 'Link';
+
+NavItemLink.PropTypes = {
+  /** @type {elementType} The base element to use to build the link. Defaults to `a`, can also accept alternative tag names or custom components like `Link` from `react-router`. */
+  element: PropTypes.elementType,
+};
+
+NavItemLink.defaultProps = {
+  element: 'a',
+};
+
+export default NavItemLink;

--- a/src/components/Nav/NavItemLink/NavItemLink.js
+++ b/src/components/Nav/NavItemLink/NavItemLink.js
@@ -11,8 +11,6 @@ const NavItemLink = React.forwardRef(function NavItemLink(props, ref) {
   return React.createElement(element, { ...rest, ref });
 });
 
-NavItemLink.displayName = 'Link';
-
 NavItemLink.PropTypes = {
   /** @type {elementType} The base element to use to build the link. Defaults to `a`, can also accept alternative tag names or custom components like `Link` from `react-router`. */
   element: PropTypes.elementType,

--- a/src/components/Nav/NavItemLink/index.js
+++ b/src/components/Nav/NavItemLink/index.js
@@ -1,0 +1,6 @@
+/**
+ * @file Navigation item link entry point.
+ * @copyright IBM Security 2019
+ */
+
+export default from './NavItemLink';

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -111,6 +111,7 @@ exports[`Nav Rendering renders correctly 1`] = `
       >
         <li
           className="security--nav__list__item security--nav__list__item--active"
+          label=""
           onClick={[Function]}
           onKeyPress={[Function]}
           role="menuitem"
@@ -121,13 +122,11 @@ exports[`Nav Rendering renders correctly 1`] = `
             element="a"
             href="#"
             id="security--nav__list__item"
-            label=""
           >
             <a
               className="security--nav__list__item__link"
               href="#"
               id="security--nav__list__item"
-              label=""
             >
               Label
             </a>
@@ -175,6 +174,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
   >
     <li
       class="security--nav__list__item security--nav__list__item--active"
+      label=""
       role="menuitem"
       tabindex="-1"
     >
@@ -182,7 +182,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
         class="security--nav__list__item__link"
         href="#"
         id="security--nav__list__item"
-        label=""
       >
         Label
       </a>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -117,7 +117,7 @@ exports[`Nav Rendering renders correctly 1`] = `
           role="menuitem"
           tabIndex={-1}
         >
-          <Link
+          <ForwardRef(NavItemLink)
             className="security--nav__list__item__link"
             element="a"
             href="#"
@@ -130,7 +130,7 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               Label
             </a>
-          </Link>
+          </ForwardRef(NavItemLink)>
         </li>
       </NavItem>
     </ul>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -117,7 +117,7 @@ exports[`Nav Rendering renders correctly 1`] = `
           role="menuitem"
           tabIndex={-1}
         >
-          <ForwardRef(NavItemLink)
+          <NavItemLink
             className="security--nav__list__item__link"
             element="a"
             href="#"
@@ -130,7 +130,7 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               Label
             </a>
-          </ForwardRef(NavItemLink)>
+          </NavItemLink>
         </li>
       </NavItem>
     </ul>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -98,6 +98,7 @@ exports[`Nav Rendering renders correctly 1`] = `
         className=""
         current={null}
         disabled={false}
+        element="a"
         handleItemSelect={null}
         href="#"
         id="security--nav__list__item"
@@ -110,19 +111,27 @@ exports[`Nav Rendering renders correctly 1`] = `
       >
         <li
           className="security--nav__list__item security--nav__list__item--active"
-          label=""
           onClick={[Function]}
           onKeyPress={[Function]}
           role="menuitem"
           tabIndex={-1}
         >
-          <a
+          <Link
             className="security--nav__list__item__link"
+            element="a"
             href="#"
             id="security--nav__list__item"
+            label=""
           >
-            Label
-          </a>
+            <a
+              className="security--nav__list__item__link"
+              href="#"
+              id="security--nav__list__item"
+              label=""
+            >
+              Label
+            </a>
+          </Link>
         </li>
       </NavItem>
     </ul>
@@ -166,7 +175,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
   >
     <li
       class="security--nav__list__item security--nav__list__item--active"
-      label=""
       role="menuitem"
       tabindex="-1"
     >
@@ -174,6 +182,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
         class="security--nav__list__item__link"
         href="#"
         id="security--nav__list__item"
+        label=""
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -117,6 +117,7 @@ exports[`Nav Rendering renders correctly 1`] = `
               className=""
               current={null}
               disabled={false}
+              element="a"
               handleItemSelect={null}
               href="#0"
               id="security--nav__list__item"
@@ -129,19 +130,27 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               <li
                 className="security--nav__list__item"
-                label=""
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="menuitem"
                 tabIndex={-1}
               >
-                <a
+                <Link
                   className="security--nav__list__item__link"
+                  element="a"
                   href="#0"
                   id="security--nav__list__item"
+                  label=""
                 >
-                  Label
-                </a>
+                  <a
+                    className="security--nav__list__item__link"
+                    href="#0"
+                    id="security--nav__list__item"
+                    label=""
+                  >
+                    Label
+                  </a>
+                </Link>
               </li>
             </NavItem>
           </ul>
@@ -245,6 +254,7 @@ exports[`Nav Rendering renders correctly 1`] = `
               className=""
               current={null}
               disabled={false}
+              element="a"
               handleItemSelect={null}
               href="#1"
               id="security--nav__list__item"
@@ -257,19 +267,27 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               <li
                 className="security--nav__list__item"
-                label=""
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="menuitem"
                 tabIndex={-1}
               >
-                <a
+                <Link
                   className="security--nav__list__item__link"
+                  element="a"
                   href="#1"
                   id="security--nav__list__item"
+                  label=""
                 >
-                  Label
-                </a>
+                  <a
+                    className="security--nav__list__item__link"
+                    href="#1"
+                    id="security--nav__list__item"
+                    label=""
+                  >
+                    Label
+                  </a>
+                </Link>
               </li>
             </NavItem>
           </ul>
@@ -280,6 +298,7 @@ exports[`Nav Rendering renders correctly 1`] = `
         className=""
         current={null}
         disabled={false}
+        element="a"
         handleItemSelect={null}
         href="#2"
         id="security--nav__list__item"
@@ -292,19 +311,27 @@ exports[`Nav Rendering renders correctly 1`] = `
       >
         <li
           className="security--nav__list__item"
-          label=""
           onClick={[Function]}
           onKeyPress={[Function]}
           role="menuitem"
           tabIndex={-1}
         >
-          <a
+          <Link
             className="security--nav__list__item__link"
+            element="a"
             href="#2"
             id="security--nav__list__item"
+            label=""
           >
-            Label
-          </a>
+            <a
+              className="security--nav__list__item__link"
+              href="#2"
+              id="security--nav__list__item"
+              label=""
+            >
+              Label
+            </a>
+          </Link>
         </li>
       </NavItem>
     </ul>
@@ -361,7 +388,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       >
         <li
           class="security--nav__list__item"
-          label=""
           role="menuitem"
           tabindex="-1"
         >
@@ -369,6 +395,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
             class="security--nav__list__item__link"
             href="#0"
             id="security--nav__list__item"
+            label=""
           >
             Label
           </a>
@@ -410,7 +437,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       >
         <li
           class="security--nav__list__item"
-          label=""
           role="menuitem"
           tabindex="-1"
         >
@@ -418,6 +444,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
             class="security--nav__list__item__link"
             href="#1"
             id="security--nav__list__item"
+            label=""
           >
             Label
           </a>
@@ -426,7 +453,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
     </li>
     <li
       class="security--nav__list__item"
-      label=""
       role="menuitem"
       tabindex="-1"
     >
@@ -434,6 +460,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
         class="security--nav__list__item__link"
         href="#2"
         id="security--nav__list__item"
+        label=""
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -130,6 +130,7 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               <li
                 className="security--nav__list__item"
+                label=""
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="menuitem"
@@ -140,13 +141,11 @@ exports[`Nav Rendering renders correctly 1`] = `
                   element="a"
                   href="#0"
                   id="security--nav__list__item"
-                  label=""
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#0"
                     id="security--nav__list__item"
-                    label=""
                   >
                     Label
                   </a>
@@ -267,6 +266,7 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               <li
                 className="security--nav__list__item"
+                label=""
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="menuitem"
@@ -277,13 +277,11 @@ exports[`Nav Rendering renders correctly 1`] = `
                   element="a"
                   href="#1"
                   id="security--nav__list__item"
-                  label=""
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#1"
                     id="security--nav__list__item"
-                    label=""
                   >
                     Label
                   </a>
@@ -311,6 +309,7 @@ exports[`Nav Rendering renders correctly 1`] = `
       >
         <li
           className="security--nav__list__item"
+          label=""
           onClick={[Function]}
           onKeyPress={[Function]}
           role="menuitem"
@@ -321,13 +320,11 @@ exports[`Nav Rendering renders correctly 1`] = `
             element="a"
             href="#2"
             id="security--nav__list__item"
-            label=""
           >
             <a
               className="security--nav__list__item__link"
               href="#2"
               id="security--nav__list__item"
-              label=""
             >
               Label
             </a>
@@ -388,6 +385,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       >
         <li
           class="security--nav__list__item"
+          label=""
           role="menuitem"
           tabindex="-1"
         >
@@ -395,7 +393,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
             class="security--nav__list__item__link"
             href="#0"
             id="security--nav__list__item"
-            label=""
           >
             Label
           </a>
@@ -437,6 +434,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       >
         <li
           class="security--nav__list__item"
+          label=""
           role="menuitem"
           tabindex="-1"
         >
@@ -444,7 +442,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
             class="security--nav__list__item__link"
             href="#1"
             id="security--nav__list__item"
-            label=""
           >
             Label
           </a>
@@ -453,6 +450,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
     </li>
     <li
       class="security--nav__list__item"
+      label=""
       role="menuitem"
       tabindex="-1"
     >
@@ -460,7 +458,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
         class="security--nav__list__item__link"
         href="#2"
         id="security--nav__list__item"
-        label=""
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -136,7 +136,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                 role="menuitem"
                 tabIndex={-1}
               >
-                <Link
+                <ForwardRef(NavItemLink)
                   className="security--nav__list__item__link"
                   element="a"
                   href="#0"
@@ -149,7 +149,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                   >
                     Label
                   </a>
-                </Link>
+                </ForwardRef(NavItemLink)>
               </li>
             </NavItem>
           </ul>
@@ -272,7 +272,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                 role="menuitem"
                 tabIndex={-1}
               >
-                <Link
+                <ForwardRef(NavItemLink)
                   className="security--nav__list__item__link"
                   element="a"
                   href="#1"
@@ -285,7 +285,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                   >
                     Label
                   </a>
-                </Link>
+                </ForwardRef(NavItemLink)>
               </li>
             </NavItem>
           </ul>
@@ -315,7 +315,7 @@ exports[`Nav Rendering renders correctly 1`] = `
           role="menuitem"
           tabIndex={-1}
         >
-          <Link
+          <ForwardRef(NavItemLink)
             className="security--nav__list__item__link"
             element="a"
             href="#2"
@@ -328,7 +328,7 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               Label
             </a>
-          </Link>
+          </ForwardRef(NavItemLink)>
         </li>
       </NavItem>
     </ul>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -136,7 +136,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                 role="menuitem"
                 tabIndex={-1}
               >
-                <ForwardRef(NavItemLink)
+                <NavItemLink
                   className="security--nav__list__item__link"
                   element="a"
                   href="#0"
@@ -149,7 +149,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                   >
                     Label
                   </a>
-                </ForwardRef(NavItemLink)>
+                </NavItemLink>
               </li>
             </NavItem>
           </ul>
@@ -272,7 +272,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                 role="menuitem"
                 tabIndex={-1}
               >
-                <ForwardRef(NavItemLink)
+                <NavItemLink
                   className="security--nav__list__item__link"
                   element="a"
                   href="#1"
@@ -285,7 +285,7 @@ exports[`Nav Rendering renders correctly 1`] = `
                   >
                     Label
                   </a>
-                </ForwardRef(NavItemLink)>
+                </NavItemLink>
               </li>
             </NavItem>
           </ul>
@@ -315,7 +315,7 @@ exports[`Nav Rendering renders correctly 1`] = `
           role="menuitem"
           tabIndex={-1}
         >
-          <ForwardRef(NavItemLink)
+          <NavItemLink
             className="security--nav__list__item__link"
             element="a"
             href="#2"
@@ -328,7 +328,7 @@ exports[`Nav Rendering renders correctly 1`] = `
             >
               Label
             </a>
-          </ForwardRef(NavItemLink)>
+          </NavItemLink>
         </li>
       </NavItem>
     </ul>


### PR DESCRIPTION
## Affected issues

- Partially addresses #31 for the `Nav` only (followup to feedback from https://github.com/carbon-design-system/ibm-security/pull/33) 

## Proposed changes

- create `NavItemLink` that accepts custom tag
- pass through extra props in `NavItem` to `NavItemLink` (so that a custom routing element with its given props can be used)
- update story and snapshots
