### PR TITLE
fix(select): apply text-rendering style to stop safari from crashing

### DIFF
--- a/src/components/Select/_index.scss
+++ b/src/components/Select/_index.scss
@@ -5,3 +5,9 @@
 ////
 
 @import 'carbon-components/scss/components/select/select';
+
+@include export-namespace($name: select) {
+  .#{$prefix}--select-input {
+    text-rendering: auto;
+  }
+}


### PR DESCRIPTION
## Affected issues

- Resolves #149 

## Proposed changes

- resets the `text-rendering` style rule because `text-render: optimizeLegibility` appears to cause `select` elements in Safari to crash. See my comment here for webkit bug info & breakdown: https://github.com/carbon-design-system/ibm-security/issues/149#issuecomment-542298389

## Testing instructions

To see Safari breaking:
- Go to https://ibm-security.carbondesignsystem.com/?path=/story/components-select--default (or `Pagination`, which also uses a `Select` component that has an underlying `select` element) 
- Try interacting with the `Select` -- Safari will quickly "beach ball" and require a force quit.
- Force quit Safari

To see it fixed:
- Open the Netlify deployment for this PR (https://deploy-preview-157--ibm-security.netlify.com/) and view the `Select` component
- Try interacting with the `Select` component
- Note that you can open the `Select` options repeatedly, and Safari doesn't "beach ball" / require a force quit.
