### PR TITLE
fix(table-toolbar-download): require rows and headers for export, set row property to empty string if not defined

### DIFF
--- a/src/components/DataTable/TableToolbarDownload.js
+++ b/src/components/DataTable/TableToolbarDownload.js
@@ -22,7 +22,7 @@ const TableToolbarDownload = ({ headers, rows, title, filename, label }) => {
   const csvRows = rows.map(row => {
     const newRow = {};
     headers.forEach(({ key }) => {
-      if (row[key]) newRow[key] = row[key];
+      newRow[key] = row[key] ? row[key] : '';
     });
     return newRow;
   });
@@ -43,7 +43,8 @@ const TableToolbarDownload = ({ headers, rows, title, filename, label }) => {
       renderIcon={Download16}
       label={label}
       onClick={() => {
-        csvExporter.generateCsv(csvRows);
+        if (rows.length > 0 && headers.length > 0)
+          csvExporter.generateCsv(csvRows);
       }}
     />
   );


### PR DESCRIPTION
## Proposed changes

- Populating row property with empty string if not defined
- Only allowing exporting when rows and headers exist

## Testing instructions
- Refer to [original PR](https://github.com/carbon-design-system/ibm-security/pull/130)