### PR TITLE
fix(select): add focus text color override

### DIFF
--- a/src/components/Select/_index.scss
+++ b/src/components/Select/_index.scss
@@ -9,5 +9,11 @@
 @include export-namespace($name: select) {
   .#{$prefix}--select-input {
     text-rendering: auto;
+
+    // TODO - remove when Carbon fix is released.
+    // https://github.com/carbon-design-system/carbon/pull/4343
+    &:focus {
+      color: $text-01;
+    }
   }
 }


### PR DESCRIPTION
## Affected issues

- Resolves #168 

## Proposed changes

- change focus text color to `$text-01` to resolve issue in Firefox

## Testing instructions

- view the netlify deployment in Firefox & interact with the `Select` component
