### PR TITLE
fix(icon-button-bar): override `OverflowMenu` styles, prevent potential variable override

### DIFF
--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -31,8 +31,10 @@ const IconButtonBar = ({
     [`${namespace}--${size}`]: size,
   });
 
-  const iconButtonBarMenuOptionsClasses = classnames({
-    [`${namespace}__overflow-menu-options--${size}`]: size,
+  const menuOptionsNamespace = `${namespace}__overflow-menu-options`;
+
+  const iconButtonBarMenuOptionsClasses = classnames(menuOptionsNamespace, {
+    [`${menuOptionsNamespace}--${size}`]: size,
   });
 
   const renderIconButton = action => (

--- a/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
+++ b/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
@@ -48,7 +48,7 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--lg"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--lg"
     renderIcon={[Function]}
   >
     <OverflowMenuItem
@@ -123,7 +123,7 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--md"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--md"
     renderIcon={[Function]}
   >
     <OverflowMenuItem
@@ -198,7 +198,7 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--sm"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--sm"
     renderIcon={[Function]}
   >
     <OverflowMenuItem
@@ -273,7 +273,7 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--xl"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--xl"
     renderIcon={[Function]}
   >
     <OverflowMenuItem
@@ -308,7 +308,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--lg"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--lg"
     renderIcon={[Function]}
   >
     <OverflowMenuItem
@@ -383,7 +383,7 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--lg"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--lg"
     renderIcon={[Function]}
   >
     <OverflowMenuItem
@@ -468,7 +468,7 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
     className="security--icon-button-bar__overflow-menu"
     direction="top"
     flipped={true}
-    menuOptionsClass="security--icon-button-bar__overflow-menu-options--lg"
+    menuOptionsClass="security--icon-button-bar__overflow-menu-options security--icon-button-bar__overflow-menu-options--lg"
     renderIcon={[Function]}
   >
     <OverflowMenuItem

--- a/src/components/IconButtonBar/_index.scss
+++ b/src/components/IconButtonBar/_index.scss
@@ -1,8 +1,10 @@
 ////
 /// Icon button bar component.
-/// @group IconButtonBar
+/// @group icon-button-bar
 /// @copyright IBM Security 2019
 ////
+
+@import '../OverflowMenu/index';
 
 @import '../Component/mixins';
 

--- a/src/components/IconButtonBar/_mixins.scss
+++ b/src/components/IconButtonBar/_mixins.scss
@@ -1,10 +1,12 @@
 ////
 /// Icon button bar component.
-/// @group IconButtonBar
+/// @group icon-button-bar
 /// @copyright IBM Security 2019
 ////
 
-$sizes: (
+/// Variation dimensions.
+/// @type Map<String, Length>
+$icon-button__sizes: (
   'sm': 4,
   'md': 5,
   'lg': 6,
@@ -13,21 +15,32 @@ $sizes: (
 
 @mixin icon-button-bar {
   $root: &;
+
   display: flex;
   overflow: none;
 
-  @each $size, $unit in $sizes {
-    &--#{$size} {
-      min-width: carbon--mini-units($unit);
+  @each $icon-button__size, $icon-button__unit in $icon-button__sizes {
+    /// Variation dimensions.
+    /// @type Length
+    $icon-button-bar__sizing__dimensions: carbon--mini-units(
+      $count: $icon-button__unit,
+    );
+
+    &--#{$icon-button__size} {
+      min-width: $icon-button-bar__sizing__dimensions;
 
       #{$root}__overflow-menu {
-        height: carbon--mini-units($unit);
-        width: carbon--mini-units($unit);
+        height: $icon-button-bar__sizing__dimensions;
+        width: $icon-button-bar__sizing__dimensions;
       }
     }
+  }
 
-    &__overflow-menu-options--#{$size}.#{$prefix}--overflow-menu-options[data-floating-menu-direction='top']::after {
-      width: carbon--mini-units($unit);
+  &__overflow-menu-options {
+    box-shadow: unset;
+
+    &.#{$prefix}--overflow-menu-options::after {
+      height: 0;
     }
   }
 }


### PR DESCRIPTION
## Affected issues

- Resolves #165

## Proposed changes

- Include `OverflowMenu` styles as dependency of `IconButtonBar`
- Override conflicting `OverflowMenu` styles
- Rename variables to prevent from being overridden
- Fix SassDoc formatting
- Update snapshot tests