### PR TITLE
fix(search-bar): remove styles overriding focus state

### DIFF
--- a/src/components/SearchBar/_mixins.scss
+++ b/src/components/SearchBar/_mixins.scss
@@ -25,15 +25,6 @@
     width: auto;
   }
 
-  &__submit {
-    border: 0;
-
-    &:disabled,
-    &:disabled:hover {
-      background-color: $disabled-02;
-    }
-  }
-
   &__scopes.#{$prefix}--list-box {
     flex: 0 0 carbon--mini-units(28);
     border: 0;


### PR DESCRIPTION
## Proposed changes

- remove `border: 0` on the search button that was overriding the `Button` component focus border (without this change, if you focus on this button, it doesn't have a visible focus border)
- remove unnecessary background color rules for the submit button