### PR TITLE
fix(tearsheet-small): add content overflow to prevent scrolling

### DIFF
--- a/src/components/Tearsheet/TearsheetSmall/_mixins.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_mixins.scss
@@ -64,6 +64,7 @@
 
   &__content {
     flex-grow: inherit;
+    overflow-x: auto;
 
     #{$filter__namespace}__search-field {
       background-color: $carbon--gray-70;


### PR DESCRIPTION
## Proposed changes

- Allow the content to horizontally scroll within the tearsheet if it's not styled to break