### PR TITLE
fix(accordion): vertically center items in heading

### DIFF
--- a/src/components/Accordion/_index.scss
+++ b/src/components/Accordion/_index.scss
@@ -29,6 +29,10 @@
       }
     }
 
+    &__heading {
+      align-items: center;
+    }
+
     &__item--active &__title {
       font-weight: 600;
     }

--- a/src/components/Accordion/_index.scss
+++ b/src/components/Accordion/_index.scss
@@ -13,6 +13,7 @@
     &.#{$namespace}accordion--start {
       .#{$prefix}--accordion__heading {
         flex-direction: row;
+        align-items: center;
       }
 
       .#{$prefix}--accordion__arrow {
@@ -27,10 +28,6 @@
       .#{$prefix}--accordion__content {
         margin-left: $carbon--spacing-06;
       }
-    }
-
-    &__heading {
-      align-items: center;
     }
 
     &__item--active &__title {


### PR DESCRIPTION
## Proposed changes

- vertically center items in the `Accordion` heading