### PR TITLE
fix(data-table): adjust overflow `z-index` to work with `Tearsheet`

### DIFF
--- a/src/components/DataTable/_index.scss
+++ b/src/components/DataTable/_index.scss
@@ -4,6 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
+@import 'carbon-components/scss/globals/scss/layout';
 @import 'carbon-components/scss/components/data-table-v2/data-table-v2';
 
 @import '../Search/index';
@@ -35,7 +36,7 @@
       border-top: 1px solid transparent;
 
       .#{$prefix}--overflow-menu {
-        z-index: z($layer: dropdown);
+        z-index: z($layer: overlay);
         margin-left: auto;
       }
     }

--- a/src/components/Tearsheet/_mixins.scss
+++ b/src/components/Tearsheet/_mixins.scss
@@ -4,6 +4,8 @@
 /// @copyright IBM Security 2019
 ////
 
+@import 'carbon-components/scss/globals/scss/layout';
+
 @import '../../globals/index';
 
 @import '../Panel/mixins';


### PR DESCRIPTION
## Affected issues

- Resolves #206

## Proposed changes

- Adjust `DataTable` overflow `z-index` to work with `Tearsheet`
- Add Carbon imports for modularity