### PR TITLE
fix(decorator): provide only necessary variations for inline, vertically align, revert viewbox

### DIFF
--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -37,10 +37,10 @@ class Decorator extends Component {
       {!noIcon && (
         <span className={`${namespace}__icon`}>
           <Icon
-            size={inline ? 12 : 16}
-            viewBox={inline ? '0 0 12 12' : '0 0 16 16'}
-            path={path}
             fillRule="evenodd"
+            path={path}
+            size={inline ? 12 : 16}
+            viewBox="0 0 16 16"
           />
         </span>
       )}

--- a/src/components/DataDecorator/_mixins.scss
+++ b/src/components/DataDecorator/_mixins.scss
@@ -11,9 +11,26 @@
 
 @import '../../globals/index';
 
+@mixin security--decorator__padding($decorator__spacing__padding) {
+  &__icon {
+    padding-left: $decorator__spacing__padding;
+  }
+
+  &__type,
+  &__value {
+    padding-right: $decorator__spacing__padding;
+    padding-left: $decorator__spacing__padding;
+  }
+}
+
 @mixin decorator {
   $root: &;
+
   @include carbon--type-style($name: body-short-01);
+  @include security--decorator__padding(
+    $decorator__spacing__padding: $carbon--spacing-03
+  );
+
   display: inline-flex;
   box-sizing: border-box;
   font-family: carbon--font-family($name: sans);
@@ -67,22 +84,15 @@
       $count: 2.5,
     );
 
-    /// Inline padding.
-    /// @type Length
-    $data-decorator--inline__spacing__padding: $carbon--spacing-02;
-
     @include carbon--type-style($name: caption-01);
 
-    display: inline-block;
     height: $data-decorator--inline__sizing__height;
+    vertical-align: middle;
 
     > #{$root} {
-      &__icon,
-      &__type,
-      &__value {
-        padding-right: $data-decorator--inline__spacing__padding;
-        padding-left: $data-decorator--inline__spacing__padding;
-      }
+      @include security--decorator__padding(
+        $decorator__spacing__padding: $carbon--spacing-02
+      );
 
       &__type,
       &__value {
@@ -140,26 +150,21 @@
   &__type,
   &__value {
     display: inherit;
+    height: inherit;
     align-items: center;
     transition-duration: 0.2s;
     transition-property: background-color;
     transition-timing-function: $timing-function;
   }
 
-  &__icon {
-    padding-left: $carbon--spacing-03;
-  }
-
   &__type {
     color: $text-02;
-    padding: 0 $carbon--spacing-03;
     border-right: 1px solid $ui-01;
     white-space: nowrap;
   }
 
   &__value {
     color: $link-01;
-    padding: 0 $carbon--spacing-03;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/src/components/DataDecorator/_mixins.scss
+++ b/src/components/DataDecorator/_mixins.scss
@@ -6,6 +6,9 @@
 
 /* stylelint-disable no-descending-specificity */
 
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
+
 @import '../../globals/index';
 
 @mixin decorator {
@@ -58,26 +61,32 @@
   }
 
   &--inline {
+    /// Inline height.
+    /// @type Length
+    $data-decorator--inline__sizing__height: carbon--mini-units(
+      $count: 2.5,
+    );
+
+    /// Inline padding.
+    /// @type Length
+    $data-decorator--inline__spacing__padding: $carbon--spacing-02;
+
     @include carbon--type-style($name: caption-01);
 
     display: inline-block;
-    height: carbon--mini-units(2.5);
-    overflow: hidden;
-    vertical-align: middle;
+    height: $data-decorator--inline__sizing__height;
 
-    #{$root}__type,
-    #{$root}__value {
-      line-height: carbon--mini-units(2.5);
-      padding: 0 $carbon--spacing-02;
-    }
+    > #{$root} {
+      &__icon,
+      &__type,
+      &__value {
+        padding-right: $data-decorator--inline__spacing__padding;
+        padding-left: $data-decorator--inline__spacing__padding;
+      }
 
-    #{$root}__icon {
-      padding: 0 $carbon--spacing-02;
-      vertical-align: top;
-
-      .#{$namespace}icon {
-        display: inline-block;
-        vertical-align: middle;
+      &__type,
+      &__value {
+        line-height: $data-decorator--inline__sizing__height;
       }
     }
   }
@@ -130,7 +139,6 @@
   &__icon,
   &__type,
   &__value {
-    height: inherit;
     display: inherit;
     align-items: center;
     transition-duration: 0.2s;


### PR DESCRIPTION
## Affected issues

- Resolves #198 

## Proposed changes

- Revert `viewBox`
- Align inline styles with default styles, add only height and padding variations