### PR TITLE
fix(combo-button): placement in scrollable parent

### DIFF
--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -124,7 +124,7 @@ const ComboButton = ({ children, className, direction }) => {
       ref={wrapper}
       data-floating-menu-container
     >
-      <div className={`this ${namespace}__group`}>
+      <div className={`${namespace}__group`}>
         {primaryActionWithProps}
 
         {overflowMenuItemWithProps !== undefined && (

--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -5,7 +5,7 @@
 
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { Fragment, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import ChevronDown16 from '@carbon/icons-react/lib/chevron--down/16';
 import ChevronUp16 from '@carbon/icons-react/lib/chevron--up/16';
 import { settings } from 'carbon-components';
@@ -98,7 +98,7 @@ const ComboButton = ({ children, className, direction }) => {
           disabled={disabled}
           href={href}
           itemText={
-            <Fragment>
+            <>
               <span
                 className={`${prefix}--text-truncate--end`}
                 title={children}
@@ -106,7 +106,7 @@ const ComboButton = ({ children, className, direction }) => {
                 {children}
               </span>
               {!Icon ? null : <Icon />}
-            </Fragment>
+            </>
           }
           key={item.id}
           onClick={onClick}
@@ -124,34 +124,36 @@ const ComboButton = ({ children, className, direction }) => {
       ref={wrapper}
       data-floating-menu-container
     >
-      {primaryActionWithProps}
+      <div className={`this ${namespace}__group`}>
+        {primaryActionWithProps}
 
-      {overflowMenuItemWithProps !== undefined && (
-        <OverflowMenu
-          className={classnames(
-            // Button-specific classes for styling:
-            buttonNamespace,
-            `${prefix}--btn`,
-            `${prefix}--btn--primary`,
+        {overflowMenuItemWithProps !== undefined && (
+          <OverflowMenu
+            className={classnames(
+              // Button-specific classes for styling:
+              buttonNamespace,
+              `${prefix}--btn`,
+              `${prefix}--btn--primary`,
 
-            // Button as a child of combo button:
-            `${namespace}__button`,
+              // Button as a child of combo button:
+              `${namespace}__button`,
 
-            // Overflow menu as a child of combo button:
-            `${namespace}__overflow-menu`
-          )}
-          direction={direction}
-          menuOffset={getMenuOffset}
-          menuOptionsClass={`${prefix}--list-box__menu`}
-          onClose={() => setIsOpen(false)}
-          onOpen={() => setIsOpen(true)}
-          renderIcon={() =>
-            isOpen ? overflowIcon(ChevronUp16) : overflowIcon(ChevronDown16)
-          }
-        >
-          {overflowMenuItemWithProps}
-        </OverflowMenu>
-      )}
+              // Overflow menu as a child of combo button:
+              `${namespace}__overflow-menu`
+            )}
+            direction={direction}
+            menuOffset={getMenuOffset}
+            menuOptionsClass={`${prefix}--list-box__menu`}
+            onClose={() => setIsOpen(false)}
+            onOpen={() => setIsOpen(true)}
+            renderIcon={() =>
+              isOpen ? overflowIcon(ChevronUp16) : overflowIcon(ChevronDown16)
+            }
+          >
+            {overflowMenuItemWithProps}
+          </OverflowMenu>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/ComboButton/ComboButton.stories.js
+++ b/src/components/ComboButton/ComboButton.stories.js
@@ -30,7 +30,7 @@ const props = () => ({
 storiesOf(patterns('ComboButton'), module).add(
   'default',
   () => (
-    <div style={{ width: '300px' }}>
+    <div style={{ width: 1000, height: 600 }}>
       <ComboButton {...props()}>
         <ComboButtonItem href="#" renderIcon={ArrowRight20}>
           Item 1 (becomes primary button and text will be truncated)
@@ -61,7 +61,7 @@ storiesOf(patterns('ComboButton'), module).add(
           The \`ComboButton\` accepts \`ComboButtonItem\` components as children.
 
           The first child of the \`ComboButton\` will be marked as the "primary" action, and will appear as a \`Button\` next to the \`OverflowMenu\` of additional actions.
-          
+
           If there is only one child of \`ComboButton\`, then an \`OverflowMenu\` will not be rendered.
         `,
     },

--- a/src/components/ComboButton/ComboButton.stories.js
+++ b/src/components/ComboButton/ComboButton.stories.js
@@ -30,7 +30,7 @@ const props = () => ({
 storiesOf(patterns('ComboButton'), module).add(
   'default',
   () => (
-    <div style={{ width: 1000, height: 1000, marginTop: 152, marginLeft: 24 }}>
+    <div style={{ width: 300 }}>
       <ComboButton {...props()}>
         <ComboButtonItem href="#" renderIcon={ArrowRight20}>
           Item 1 (becomes primary button and text will be truncated)

--- a/src/components/ComboButton/ComboButton.stories.js
+++ b/src/components/ComboButton/ComboButton.stories.js
@@ -30,7 +30,7 @@ const props = () => ({
 storiesOf(patterns('ComboButton'), module).add(
   'default',
   () => (
-    <div style={{ width: 1000, height: 600 }}>
+    <div style={{ width: 1000, height: 1000, marginTop: 152, marginLeft: 24 }}>
       <ComboButton {...props()}>
         <ComboButtonItem href="#" renderIcon={ArrowRight20}>
           Item 1 (becomes primary button and text will be truncated)

--- a/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
+++ b/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
@@ -10,7 +10,7 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
     data-floating-menu-container={true}
   >
     <div
-      className="this security--combo-button__group"
+      className="security--combo-button__group"
     >
       <Button
         className="security--combo-button--primary"
@@ -198,7 +198,7 @@ exports[`ComboButton renders a combo button without an overflow menu 1`] = `
     data-floating-menu-container={true}
   >
     <div
-      className="this security--combo-button__group"
+      className="security--combo-button__group"
     >
       <Button
         className="security--combo-button--primary"

--- a/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
+++ b/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
@@ -9,28 +9,16 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
     className="security--combo-button"
     data-floating-menu-container={true}
   >
-    <Button
-      className="security--combo-button--primary"
-      disabled={false}
-      iconDescription=""
-      kind="primary"
-      largeText={null}
-      loading={false}
-      onClick={[Function]}
-      renderIcon={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "render": [Function],
-        }
-      }
-      tabIndex={0}
-      type="button"
+    <div
+      className="this security--combo-button__group"
     >
-      <ForwardRef(Button)
-        className="security--button security--combo-button--primary"
+      <Button
+        className="security--combo-button--primary"
         disabled={false}
         iconDescription=""
         kind="primary"
+        largeText={null}
+        loading={false}
         onClick={[Function]}
         renderIcon={
           Object {
@@ -41,145 +29,161 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
         tabIndex={0}
         type="button"
       >
-        <button
-          className="security--button security--combo-button--primary bx--btn bx--btn--primary"
+        <ForwardRef(Button)
+          className="security--button security--combo-button--primary"
           disabled={false}
+          iconDescription=""
+          kind="primary"
           onClick={[Function]}
+          renderIcon={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            }
+          }
           tabIndex={0}
           type="button"
         >
-          <span
-            className="bx--text-truncate--end"
-            title="Start a task"
+          <button
+            className="security--button security--combo-button--primary bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
           >
-            Start a task
-          </span>
-          <ForwardRef(ArrowRight20)
-            aria-hidden="true"
-            aria-label=""
-            className="bx--btn__icon"
-          >
-            <Icon
+            <span
+              className="bx--text-truncate--end"
+              title="Start a task"
+            >
+              Start a task
+            </span>
+            <ForwardRef(ArrowRight20)
               aria-hidden="true"
               aria-label=""
               className="bx--btn__icon"
-              height={20}
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 20 20"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-hidden={true}
+              <Icon
+                aria-hidden="true"
                 aria-label=""
                 className="bx--btn__icon"
-                focusable="false"
                 height={20}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 20 20"
                 width={20}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <path
-                  d="M11.8 2.8l-1 1 5.4 5.5H1v1.4h15.2l-5.4 5.5 1 1L19 10z"
-                />
-              </svg>
-            </Icon>
-          </ForwardRef(ArrowRight20)>
-        </button>
-      </ForwardRef(Button)>
-    </Button>
-    <ForwardRef(OverflowMenu)
-      className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu"
-      direction="top"
-      menuOffset={[Function]}
-      menuOptionsClass="bx--list-box__menu"
-      onClose={[Function]}
-      onOpen={[Function]}
-      renderIcon={[Function]}
-    >
-      <OverflowMenu
-        ariaLabel="Menu"
-        className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu"
-        direction="top"
-        flipped={false}
-        iconDescription="open and close list of options"
-        innerRef={null}
-        menuOffset={[Function]}
-        menuOffsetFlip={[Function]}
-        menuOptionsClass="bx--list-box__menu"
-        onClick={[Function]}
-        onClose={[Function]}
-        onKeyDown={[Function]}
-        onOpen={[Function]}
-        open={false}
-        renderIcon={[Function]}
-        tabIndex={0}
-      >
-        <ClickListener
-          onClickOutside={[Function]}
-        >
-          <div
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-label="Menu"
-            className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu bx--overflow-menu"
-            onClick={[Function]}
-            onClose={[Function]}
-            onKeyDown={[Function]}
-            open={false}
-            role="button"
-            tabIndex={0}
-          >
-            <renderIcon
-              aria-label="open and close list of options"
-              className="bx--overflow-menu__icon"
-              focusable="false"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-            >
-              <ForwardRef(ChevronDown16)
-                className="security--combo-button__icon"
-              >
-                <Icon
-                  className="security--combo-button__icon"
-                  height={16}
+                <svg
+                  aria-hidden={true}
+                  aria-label=""
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={20}
                   preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 16 16"
-                  width={16}
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 20 20"
+                  width={20}
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    aria-hidden={true}
+                  <path
+                    d="M11.8 2.8l-1 1 5.4 5.5H1v1.4h15.2l-5.4 5.5 1 1L19 10z"
+                  />
+                </svg>
+              </Icon>
+            </ForwardRef(ArrowRight20)>
+          </button>
+        </ForwardRef(Button)>
+      </Button>
+      <ForwardRef(OverflowMenu)
+        className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu"
+        direction="top"
+        menuOffset={[Function]}
+        menuOptionsClass="bx--list-box__menu"
+        onClose={[Function]}
+        onOpen={[Function]}
+        renderIcon={[Function]}
+      >
+        <OverflowMenu
+          ariaLabel="Menu"
+          className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu"
+          direction="top"
+          flipped={false}
+          iconDescription="open and close list of options"
+          innerRef={null}
+          menuOffset={[Function]}
+          menuOffsetFlip={[Function]}
+          menuOptionsClass="bx--list-box__menu"
+          onClick={[Function]}
+          onClose={[Function]}
+          onKeyDown={[Function]}
+          onOpen={[Function]}
+          open={false}
+          renderIcon={[Function]}
+          tabIndex={0}
+        >
+          <ClickListener
+            onClickOutside={[Function]}
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Menu"
+              className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu bx--overflow-menu"
+              onClick={[Function]}
+              onClose={[Function]}
+              onKeyDown={[Function]}
+              open={false}
+              role="button"
+              tabIndex={0}
+            >
+              <renderIcon
+                aria-label="open and close list of options"
+                className="bx--overflow-menu__icon"
+                focusable="false"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                <ForwardRef(ChevronDown16)
+                  className="security--combo-button__icon"
+                >
+                  <Icon
                     className="security--combo-button__icon"
-                    focusable="false"
                     height={16}
                     preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
                     viewBox="0 0 16 16"
                     width={16}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                    />
-                  </svg>
-                </Icon>
-              </ForwardRef(ChevronDown16)>
-            </renderIcon>
-          </div>
-        </ClickListener>
-      </OverflowMenu>
-    </ForwardRef(OverflowMenu)>
+                    <svg
+                      aria-hidden={true}
+                      className="security--combo-button__icon"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                      />
+                    </svg>
+                  </Icon>
+                </ForwardRef(ChevronDown16)>
+              </renderIcon>
+            </div>
+          </ClickListener>
+        </OverflowMenu>
+      </ForwardRef(OverflowMenu)>
+    </div>
   </div>
 </ComboButton>
 `;
@@ -193,28 +197,16 @@ exports[`ComboButton renders a combo button without an overflow menu 1`] = `
     className="security--combo-button"
     data-floating-menu-container={true}
   >
-    <Button
-      className="security--combo-button--primary"
-      disabled={false}
-      iconDescription=""
-      kind="primary"
-      largeText={null}
-      loading={false}
-      onClick={[Function]}
-      renderIcon={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "render": [Function],
-        }
-      }
-      tabIndex={0}
-      type="button"
+    <div
+      className="this security--combo-button__group"
     >
-      <ForwardRef(Button)
-        className="security--button security--combo-button--primary"
+      <Button
+        className="security--combo-button--primary"
         disabled={false}
         iconDescription=""
         kind="primary"
+        largeText={null}
+        loading={false}
         onClick={[Function]}
         renderIcon={
           Object {
@@ -225,59 +217,75 @@ exports[`ComboButton renders a combo button without an overflow menu 1`] = `
         tabIndex={0}
         type="button"
       >
-        <button
-          className="security--button security--combo-button--primary bx--btn bx--btn--primary"
+        <ForwardRef(Button)
+          className="security--button security--combo-button--primary"
           disabled={false}
+          iconDescription=""
+          kind="primary"
           onClick={[Function]}
+          renderIcon={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            }
+          }
           tabIndex={0}
           type="button"
         >
-          <span
-            className="bx--text-truncate--end"
-            title="Start a task"
+          <button
+            className="security--button security--combo-button--primary bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
           >
-            Start a task
-          </span>
-          <ForwardRef(ArrowRight20)
-            aria-hidden="true"
-            aria-label=""
-            className="bx--btn__icon"
-          >
-            <Icon
+            <span
+              className="bx--text-truncate--end"
+              title="Start a task"
+            >
+              Start a task
+            </span>
+            <ForwardRef(ArrowRight20)
               aria-hidden="true"
               aria-label=""
               className="bx--btn__icon"
-              height={20}
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 20 20"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-hidden={true}
+              <Icon
+                aria-hidden="true"
                 aria-label=""
                 className="bx--btn__icon"
-                focusable="false"
                 height={20}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 20 20"
                 width={20}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <path
-                  d="M11.8 2.8l-1 1 5.4 5.5H1v1.4h15.2l-5.4 5.5 1 1L19 10z"
-                />
-              </svg>
-            </Icon>
-          </ForwardRef(ArrowRight20)>
-        </button>
-      </ForwardRef(Button)>
-    </Button>
+                <svg
+                  aria-hidden={true}
+                  aria-label=""
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={20}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 20 20"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11.8 2.8l-1 1 5.4 5.5H1v1.4h15.2l-5.4 5.5 1 1L19 10z"
+                  />
+                </svg>
+              </Icon>
+            </ForwardRef(ArrowRight20)>
+          </button>
+        </ForwardRef(Button)>
+      </Button>
+    </div>
   </div>
 </ComboButton>
 `;

--- a/src/components/ComboButton/_mixins.scss
+++ b/src/components/ComboButton/_mixins.scss
@@ -9,15 +9,19 @@
 @mixin combo-button {
   $root: &;
 
+  display: inline-flex;
   position: relative;
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
 
   & &--primary {
     @include text-overflow();
     display: flex;
     flex: 1;
+  }
+
+  &__group {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
   }
 
   &__icon {


### PR DESCRIPTION
## Affected issues

- Resolves partially https://github.com/carbon-design-system/ibm-security/issues/178

## Proposed changes

- Tweaks placement, creating a nested group to create the layout that the menu item's width is derived from

## Testing instructions

- Add a `ComboButton` inside a div without a fixed width
- Menu should no longer occupy 100% of wrapper div.
