### PR TITLE
fix(filter-subcategory): expand and collapse

### DIFF
--- a/src/components/FilterPanel/FilterSubcategory/FilterSubcategory.js
+++ b/src/components/FilterPanel/FilterSubcategory/FilterSubcategory.js
@@ -7,7 +7,7 @@ import Add16 from '@carbon/icons-react/lib/add/16';
 import Subtract16 from '@carbon/icons-react/lib/subtract/16';
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import * as defaultLabels from '../../../globals/nls';
 import { getComponentNamespace } from '../../../globals/namespace';
@@ -24,134 +24,112 @@ import ScrollGradient from '../../ScrollGradient';
 
 export const namespace = getComponentNamespace('filter-subcategory');
 
-class FilterSubcategory extends Component {
-  state = { isExpanded: false };
+const FilterSubcategory = ({
+  filterData,
+  subcategory,
+  onChange,
+  labels,
+  filtersExpandLabel,
+  filtersCollapseLabel,
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [listContainer, setListContainer] = React.useState(null);
+  const visibleChildren = React.useRef(null);
 
-  componentDidUpdate = () => this.updateListContainerHeight();
+  const filters = subcategory.filters
+    .map(filterId => filterData.filters[filterId])
+    .filter(filter => filter.count > 0);
 
-  /**
-   * Saves reference to scrolling element.
-   * @param {HTMLElement} element Element to save reference to.
-   */
-  setReference = element => {
-    this.listContainer = element;
+  const shouldTruncate = filters.length > 10;
+
+  let displayCount = shouldTruncate ? 5 : filters.length;
+  if (shouldTruncate && isExpanded) {
+    displayCount = 10;
+  }
+
+  // After the component's expanded state has changed update the height of the list container to be
+  // the same as its visible children set.
+  React.useEffect(() => {
+    if (shouldTruncate && listContainer && visibleChildren.current) {
+      listContainer.style.height = `${visibleChildren.current.clientHeight}px`;
+    }
+  }, [isExpanded]);
+
+  const handleExpand = () => {
+    // Pre-set the height of the list container to its own current height so we can smoothly
+    // transition into its new height in the React Effect hook.
+    if (listContainer && visibleChildren.current) {
+      listContainer.style.height = `${listContainer.clientHeight}px`;
+    }
+    setIsExpanded(!isExpanded);
   };
 
-  static visibleFiltersContainerClassName = `${namespace}__filters--visible`;
-
-  /**
-   * @type {HTMLElement} Reference to list container.
-   */
-  listContainer = null;
-
-  /**
-   * Toggles the expanded state of this component.
-   */
-  toggleExpand = () => this.setState({ isExpanded: !this.state.isExpanded });
-
-  /**
-   * Updates height of filter list container so that only a certain number of filters are displayed
-   * at once.
-   */
-  updateListContainerHeight = () => {
-    const { listContainer } = this;
-
-    if (listContainer) {
-      listContainer.style.height = `${
-        listContainer.querySelector(
-          `.${FilterSubcategory.visibleFiltersContainerClassName}`
-        ).clientHeight
-      }px`;
-    }
+  const componentLabels = {
+    ...defaultLabels.labels,
+    ...defaultLabels.filterFalsey({
+      FILTER_PANEL_CATEGORY_EXPAND_LABEL: filtersExpandLabel,
+      FILTER_PANEL_CATEGORY_COLLAPSE_LABEL: filtersCollapseLabel,
+    }),
+    ...labels,
   };
 
-  render() {
-    const {
-      filterData,
-      subcategory,
-      onChange,
-      labels,
-      filtersExpandLabel,
-      filtersCollapseLabel,
-    } = this.props;
-    const { isExpanded } = this.state;
-    const filters = subcategory.filters
-      .map(filterId => filterData.filters[filterId])
-      .filter(filter => filter.count > 0);
+  const buttonLabel = isExpanded
+    ? componentLabels.FILTER_PANEL_CATEGORY_COLLAPSE_LABEL
+    : componentLabels.FILTER_PANEL_CATEGORY_EXPAND_LABEL;
 
-    const componentLabels = {
-      ...defaultLabels.labels,
-      ...defaultLabels.filterFalsey({
-        FILTER_PANEL_CATEGORY_EXPAND_LABEL: filtersExpandLabel,
-        FILTER_PANEL_CATEGORY_COLLAPSE_LABEL: filtersCollapseLabel,
-      }),
-      ...labels,
-    };
-
-    const shouldTruncate = filters.length > 10;
-
-    let displayCount = shouldTruncate ? 5 : filters.length;
-    if (shouldTruncate && isExpanded) {
-      displayCount = 10;
-    }
-
-    const buttonLabel = isExpanded
-      ? componentLabels.FILTER_PANEL_CATEGORY_COLLAPSE_LABEL
-      : componentLabels.FILTER_PANEL_CATEGORY_EXPAND_LABEL;
-
-    return (
-      <AccordionItem
-        title={subcategory.name}
-        className={namespace}
-        open={subcategory.open}
-      >
-        <ul className={`${namespace}__filter-list`}>
-          <ScrollGradient
-            scrollElementClassName={`${namespace}__scroller`}
-            color={theme.uiBackground}
-            getScrollElementRef={this.setReference}
+  return (
+    <AccordionItem
+      title={subcategory.name}
+      className={namespace}
+      open={subcategory.open}
+    >
+      <ul className={`${namespace}__filter-list`}>
+        <ScrollGradient
+          scrollElementClassName={`${namespace}__scroller`}
+          color={theme.uiBackground}
+          getScrollElementRef={setListContainer}
+        >
+          <div
+            role="presentation"
+            className={`${namespace}__filters ${namespace}__filters--visible`}
+            ref={visibleChildren}
           >
+            {filters.slice(0, displayCount).map(filter => (
+              <li className={`${namespace}__filter`} key={filter.id}>
+                <FilterSelector filter={filter} onChange={onChange} />
+              </li>
+            ))}
+          </div>
+          {shouldTruncate && isExpanded && (
             <div
               role="presentation"
-              className={`${namespace}__filters ${FilterSubcategory.visibleFiltersContainerClassName}`}
+              className={`${namespace}__filters ${namespace}__filters--hidden`}
             >
-              {filters.slice(0, displayCount).map(filter => (
+              {filters.slice(displayCount).map(filter => (
                 <li className={`${namespace}__filter`} key={filter.id}>
                   <FilterSelector filter={filter} onChange={onChange} />
                 </li>
               ))}
             </div>
-            {shouldTruncate && isExpanded && (
-              <div
-                role="presentation"
-                className={`${namespace}__filters ${namespace}__filters--hidden`}
-              >
-                {filters.slice(displayCount).map(filter => (
-                  <li className={`${namespace}__filter`} key={filter.id}>
-                    <FilterSelector filter={filter} onChange={onChange} />
-                  </li>
-                ))}
-              </div>
-            )}
-          </ScrollGradient>
-        </ul>
-        {shouldTruncate && (
-          <Button
-            className={`${namespace}__button--toggle`}
-            iconDescription={buttonLabel}
-            kind="ghost"
-            onClick={this.toggleExpand}
-            renderIcon={isExpanded ? Subtract16 : Add16}
-          >
-            {isExpanded
-              ? buttonLabel
-              : `${buttonLabel} (${filters.length - displayCount})`}
-          </Button>
-        )}
-      </AccordionItem>
-    );
-  }
-}
+          )}
+        </ScrollGradient>
+      </ul>
+      {shouldTruncate && (
+        <Button
+          className={`${namespace}__button--toggle`}
+          iconDescription={buttonLabel}
+          kind="ghost"
+          onClick={handleExpand}
+          renderIcon={isExpanded ? Subtract16 : Add16}
+        >
+          {isExpanded
+            ? buttonLabel
+            : `${buttonLabel} (${filters.length - displayCount})`}
+        </Button>
+      )}
+    </AccordionItem>
+  );
+};
 
 FilterSubcategory.propTypes = {
   /** @type {string} Label for truncated filters list to expand */

--- a/src/components/FilterPanel/FilterSubcategory/__tests__/FilterSubcategory.spec.js
+++ b/src/components/FilterPanel/FilterSubcategory/__tests__/FilterSubcategory.spec.js
@@ -91,10 +91,8 @@ describe('FilterSubcategory', () => {
       filterSubcategory.setProps({
         subcategory: { ...MockFilterData.subcategories.TRUNCATED, open: true },
       });
-      filterSubcategory
-        .find(`.${namespace}__button--toggle`)
-        .simulate('click')
-        .simulate('click');
+      filterSubcategory.find(`.${namespace}__button--toggle`).simulate('click');
+      filterSubcategory.find(`.${namespace}__button--toggle`).simulate('click');
       expect(filterSubcategory).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
## Affected issues

- Resolves #235 
## Proposed changes

- Refactor the `FilterSubcategory` component to use hooks
- Fix expand and collapse issues on the `FilterSubcategory` when selecting filters

## Testing instructions

- Go to the FilterPanel story in Storybook
- Check one of the visible filters
- Expand any of the collapsed subcategory accordions 