### PR TITLE
fix(header): add hyphenated word break for popover title

### DIFF
--- a/src/components/Header/_mixins.scss
+++ b/src/components/Header/_mixins.scss
@@ -306,16 +306,18 @@ $header__transition__timing-function: $timing-function;
         &__title,
         &__email {
           display: block;
-          word-break: break-all;
           word-wrap: anywhere;
         }
 
         &__title {
           @include carbon--type-style($name: productive-heading-03);
+          hyphens: auto;
+          word-break: break-word;
         }
 
         &__email {
           @include carbon--type-style($name: caption-01);
+          word-break: break-all;
         }
       }
 


### PR DESCRIPTION
## Affected issues

- Resolves #247 

## Proposed changes

- Add hyphenated word break for header popover title

## Testing instructions

1. Navigate to https://deploy-preview-250--ibm-security.netlify.com/?path=/story/patterns-header--with-active-user
2. In the `profile` knob, update `first_name` value to 'ReallyLongSampleFirstName'