### PR TITLE
feat(summary-card): allow truncated title with tooltip, allow pass through props

### DIFF
--- a/src/components/StringFormatter/_index.scss
+++ b/src/components/StringFormatter/_index.scss
@@ -24,6 +24,7 @@
   }
 
   &__tooltip > .#{$prefix}--tooltip__trigger {
+    color: currentColor;
     font-size: inherit;
     font-weight: inherit;
     line-height: inherit;

--- a/src/components/SummaryCard/SummaryCard.js
+++ b/src/components/SummaryCard/SummaryCard.js
@@ -11,8 +11,10 @@ import { getComponentNamespace } from '../../globals/namespace';
 
 export const namespace = getComponentNamespace('summary-card');
 
-const SummaryCard = ({ children, className }) => (
-  <section className={classnames(namespace, className)}>{children}</section>
+const SummaryCard = ({ children, className, ...other }) => (
+  <section className={classnames(namespace, className)} {...other}>
+    {children}
+  </section>
 );
 
 SummaryCard.defaultProps = {

--- a/src/components/SummaryCard/SummaryCard.stories.js
+++ b/src/components/SummaryCard/SummaryCard.stories.js
@@ -45,12 +45,13 @@ storiesOf(patterns('SummaryCard'), module)
       <div className={`${prefix}--col-md-4 ${prefix}--col-lg-4`}>
         <SummaryCard>
           <SummaryCardHeader
-            title="Summary card that is super long and will wrap the next time and needs to be truncated"
+            title="Summary card that is super long and will wrap the next line. Therefore it needs to be truncated with a tooltip for accessibility."
             status={
               <Tooltip showIcon iconDescription="Status">
                 Tooltip content
               </Tooltip>
             }
+            truncate
           />
           <SummaryCardBody>{lorem}</SummaryCardBody>
           <SummaryCardFooter>

--- a/src/components/SummaryCard/SummaryCard.stories.js
+++ b/src/components/SummaryCard/SummaryCard.stories.js
@@ -45,7 +45,7 @@ storiesOf(patterns('SummaryCard'), module)
       <div className={`${prefix}--col-md-4 ${prefix}--col-lg-4`}>
         <SummaryCard>
           <SummaryCardHeader
-            title="Summary card"
+            title="Summary card that is super long and will wrap the next time and needs to be truncated"
             status={
               <Tooltip showIcon iconDescription="Status">
                 Tooltip content

--- a/src/components/SummaryCard/SummaryCardAction/SummaryCardAction.js
+++ b/src/components/SummaryCard/SummaryCardAction/SummaryCardAction.js
@@ -131,7 +131,7 @@ SummaryCardAction.propTypes = {
 
 SummaryCardAction.defaultProps = {
   children: null,
-  className: '',
+  className: null,
   closeButtonIconDescription: 'close',
   expandedContent: undefined,
   hasIconOnly: false,

--- a/src/components/SummaryCard/SummaryCardBatchActions/SummaryCardBatchActions.js
+++ b/src/components/SummaryCard/SummaryCardBatchActions/SummaryCardBatchActions.js
@@ -23,7 +23,7 @@ const translationKeys = [
   'security.summary-card.batch.item.selected',
 ];
 
-const SummaryCardBatchActions = ({ translateWithId: t, ...props }) => (
+const SummaryCardBatchActions = ({ translateWithId: t, ...other }) => (
   <TableBatchActions
     className={appendComponentNamespace(summaryCardNamespace, 'batch-actions')}
     translateWithId={(id, state) =>
@@ -31,7 +31,7 @@ const SummaryCardBatchActions = ({ translateWithId: t, ...props }) => (
         ? t(translationKeys[carbonTranslationKeys.indexOf(id)], state)
         : translateWithId(id, state)
     }
-    {...props}
+    {...other}
   />
 );
 

--- a/src/components/SummaryCard/SummaryCardBody/SummaryCardBody.js
+++ b/src/components/SummaryCard/SummaryCardBody/SummaryCardBody.js
@@ -14,8 +14,8 @@ import theme from '../../../globals/theme';
 
 const namespace = getComponentNamespace('summary-card__body');
 
-const SummaryCardBody = ({ children, className }) => (
-  <div className={classnames(namespace, className)}>
+const SummaryCardBody = ({ children, className, ...other }) => (
+  <div className={classnames(namespace, className)} {...other}>
     <ScrollGradient color={theme.uiBackground}>{children}</ScrollGradient>
   </div>
 );
@@ -29,7 +29,7 @@ SummaryCardBody.propTypes = {
 };
 
 SummaryCardBody.defaultProps = {
-  className: '',
+  className: null,
 };
 
 export default SummaryCardBody;

--- a/src/components/SummaryCard/SummaryCardContainer/SummaryCardContainer.js
+++ b/src/components/SummaryCard/SummaryCardContainer/SummaryCardContainer.js
@@ -16,7 +16,7 @@ const getSummaryCard = (summaryCards, selectedId) =>
 
 const resetSelectedSummaryCards = state => state([]);
 
-function SummaryCardContainer({ render, summaryCards }) {
+function SummaryCardContainer({ render, summaryCards, ...other }) {
   const [
     selectedSummaryCards,
     setSelectedSummaryCards,
@@ -64,6 +64,7 @@ function SummaryCardContainer({ render, summaryCards }) {
   return (
     <div
       className={appendComponentNamespace(summaryCardNamespace, 'container')}
+      {...other}
     >
       {render(renderProps)}
     </div>

--- a/src/components/SummaryCard/SummaryCardFooter/SummaryCardFooter.js
+++ b/src/components/SummaryCard/SummaryCardFooter/SummaryCardFooter.js
@@ -11,8 +11,10 @@ import { getComponentNamespace } from '../../../globals/namespace/index';
 
 const namespace = getComponentNamespace('summary-card__footer');
 
-const SummaryCardFooter = ({ className, children }) => (
-  <div className={classnames(namespace, className)}>{children}</div>
+const SummaryCardFooter = ({ className, children, ...other }) => (
+  <div className={classnames(namespace, className)} {...other}>
+    {children}
+  </div>
 );
 
 SummaryCardFooter.propTypes = {
@@ -24,7 +26,7 @@ SummaryCardFooter.propTypes = {
 };
 
 SummaryCardFooter.defaultProps = {
-  className: '',
+  className: null,
 };
 
 export default SummaryCardFooter;

--- a/src/components/SummaryCard/SummaryCardHeader/SummaryCardHeader.js
+++ b/src/components/SummaryCard/SummaryCardHeader/SummaryCardHeader.js
@@ -7,31 +7,54 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import StringFormatter from '../../StringFormatter';
+
 import { getComponentNamespace } from '../../../globals/namespace/index';
 
 const namespace = getComponentNamespace('summary-card__header');
 
-const SummaryCardHeader = ({ className, title, status, ...other }) => (
+const SummaryCardHeader = ({
+  className,
+  status,
+  title,
+  titleTooltipDirection,
+  truncate,
+  ...other
+}) => (
   <div className={classnames(namespace, className)} {...other}>
-    <h2 className={`${namespace}__title`}>{title}</h2>
+    <h2 className={`${namespace}__title`}>
+      <StringFormatter
+        truncate={truncate}
+        value={title}
+        tooltipDirection={titleTooltipDirection}
+      />
+    </h2>
     {status}
   </div>
 );
 
 SummaryCardHeader.propTypes = {
-  /** @type {string} Extra class names to add. */
+  /** Extra class names to add. */
   className: PropTypes.string,
 
-  /** @type {node} The status of the Card. */
+  /** The status of the Card. */
   status: PropTypes.node,
 
-  /** @type {string} The title of the summary card. */
+  /** The title of the summary card. */
   title: PropTypes.string.isRequired,
+
+  /** Specify the direction of the title's tooltip. Can be either top or bottom. */
+  titleTooltipDirection: PropTypes.oneOf(['top', 'bottom']),
+
+  /** Whether or not the value should be truncated. */
+  truncate: PropTypes.bool,
 };
 
 SummaryCardHeader.defaultProps = {
   className: null,
   status: undefined,
+  titleTooltipDirection: 'bottom',
+  truncate: false,
 };
 
 export default SummaryCardHeader;

--- a/src/components/SummaryCard/SummaryCardHeader/SummaryCardHeader.js
+++ b/src/components/SummaryCard/SummaryCardHeader/SummaryCardHeader.js
@@ -11,8 +11,8 @@ import { getComponentNamespace } from '../../../globals/namespace/index';
 
 const namespace = getComponentNamespace('summary-card__header');
 
-const SummaryCardHeader = ({ className, title, status }) => (
-  <div className={classnames(namespace, className)}>
+const SummaryCardHeader = ({ className, title, status, ...other }) => (
+  <div className={classnames(namespace, className)} {...other}>
     <h2 className={`${namespace}__title`}>{title}</h2>
     {status}
   </div>
@@ -30,7 +30,7 @@ SummaryCardHeader.propTypes = {
 };
 
 SummaryCardHeader.defaultProps = {
-  className: '',
+  className: null,
   status: undefined,
 };
 

--- a/src/components/SummaryCard/SummaryCardSelect/SummaryCardSelect.js
+++ b/src/components/SummaryCard/SummaryCardSelect/SummaryCardSelect.js
@@ -18,11 +18,11 @@ export const namespace = appendComponentNamespace(
   'select'
 );
 
-const SummaryCardSelect = ({ className, ...props }) => (
+const SummaryCardSelect = ({ className, ...other }) => (
   <div className={namespace}>
     <Checkbox
       className={classnames(`${namespace}__checkbox`, className)}
-      {...props}
+      {...other}
     />
   </div>
 );
@@ -30,6 +30,10 @@ const SummaryCardSelect = ({ className, ...props }) => (
 SummaryCardSelect.propTypes = {
   /** Provide an optional class to be applied to the containing node */
   className: string,
+};
+
+SummaryCardSelect.defaultProps = {
+  className: null,
 };
 
 export default SummaryCardSelect;

--- a/src/components/SummaryCard/_mixins.scss
+++ b/src/components/SummaryCard/_mixins.scss
@@ -85,7 +85,6 @@
 
     &__title {
       @include carbon--type-style($name: caption-01);
-      @include text-overflow;
       color: $text-02;
       flex-grow: 1;
       margin: 0;

--- a/src/components/SummaryCard/_mixins.scss
+++ b/src/components/SummaryCard/_mixins.scss
@@ -85,6 +85,7 @@
 
     &__title {
       @include carbon--type-style($name: caption-01);
+      @include text-overflow;
       color: $text-02;
       flex-grow: 1;
       margin: 0;


### PR DESCRIPTION
## Affected issues

- Resolves #261

## Proposed changes

- add `StringFormatter` to `SummaryCardHeader` so that the title can be truncated with a proper, accessible Carbon tooltip
- add `...other` to each `SummaryCard` subcomponent to allow additional props passed through if necessary
- use `currentColor` for `Tooltip` trigger styles inside `StringFormatter` so as not to override `SummaryCardHeader` text color
- in components modified, change default value of `className` to `null`
- update `SummaryCard` story to include example of a truncated title