### PR TITLE
fix(panel-v2): reorder header to ensure that close button has initial focus

### DIFF
--- a/src/components/PanelV2/PanelV2.js
+++ b/src/components/PanelV2/PanelV2.js
@@ -100,6 +100,14 @@ export default class PanelV2 extends Component {
           >
             <section className={classnames(namespace, className)}>
               <header ref={this.header} className={`${namespace}__header`}>
+                <IconButton
+                  id={closeButton.id}
+                  className={`${namespace}__button--close`}
+                  label={PANEL_CONTAINER_CLOSE_BUTTON}
+                  onClick={closeButton.onClick}
+                  renderIcon={closeButton.icon || Close20}
+                  tooltip={false}
+                />
                 {title && (
                   <div className={`${namespace}__header__container--title`}>
                     {typeof title === 'string' ? (
@@ -116,14 +124,6 @@ export default class PanelV2 extends Component {
                     )}
                   </div>
                 )}
-                <IconButton
-                  id={closeButton.id}
-                  className={`${namespace}__button--close`}
-                  label={PANEL_CONTAINER_CLOSE_BUTTON}
-                  onClick={closeButton.onClick}
-                  renderIcon={closeButton.icon || Close20}
-                  tooltip={false}
-                />
               </header>
               <section
                 className={classnames(`${namespace}__body`, {

--- a/src/components/PanelV2/__tests__/__snapshots__/PanelV2.spec.js.snap
+++ b/src/components/PanelV2/__tests__/__snapshots__/PanelV2.spec.js.snap
@@ -99,20 +99,6 @@ exports[`PanelV2 renders 1`] = `
                     <header
                       class="security--panelv2__header"
                     >
-                      <div
-                        class="security--panelv2__header__container--title"
-                      >
-                        <h2
-                          class="security--panelv2__header--title"
-                        >
-                          Label
-                        </h2>
-                        <div
-                          class="security--panelv2__header--subtitle"
-                        >
-                          Label
-                        </div>
-                      </div>
                       <button
                         aria-label="Close"
                         class="security--button--icon security--panelv2__button--close"
@@ -133,6 +119,20 @@ exports[`PanelV2 renders 1`] = `
                           />
                         </svg>
                       </button>
+                      <div
+                        class="security--panelv2__header__container--title"
+                      >
+                        <h2
+                          class="security--panelv2__header--title"
+                        >
+                          Label
+                        </h2>
+                        <div
+                          class="security--panelv2__header--subtitle"
+                        >
+                          Label
+                        </div>
+                      </div>
                     </header>
                     <section
                       class="security--panelv2__body security--panelv2__body--footer"
@@ -186,20 +186,6 @@ exports[`PanelV2 renders 1`] = `
                       <header
                         class="security--panelv2__header"
                       >
-                        <div
-                          class="security--panelv2__header__container--title"
-                        >
-                          <h2
-                            class="security--panelv2__header--title"
-                          >
-                            Label
-                          </h2>
-                          <div
-                            class="security--panelv2__header--subtitle"
-                          >
-                            Label
-                          </div>
-                        </div>
                         <button
                           aria-label="Close"
                           class="security--button--icon security--panelv2__button--close"
@@ -220,6 +206,20 @@ exports[`PanelV2 renders 1`] = `
                             />
                           </svg>
                         </button>
+                        <div
+                          class="security--panelv2__header__container--title"
+                        >
+                          <h2
+                            class="security--panelv2__header--title"
+                          >
+                            Label
+                          </h2>
+                          <div
+                            class="security--panelv2__header--subtitle"
+                          >
+                            Label
+                          </div>
+                        </div>
                       </header>
                       <section
                         class="security--panelv2__body security--panelv2__body--footer"
@@ -277,20 +277,6 @@ exports[`PanelV2 renders 1`] = `
                     <header
                       className="security--panelv2__header"
                     >
-                      <div
-                        className="security--panelv2__header__container--title"
-                      >
-                        <h2
-                          className="security--panelv2__header--title"
-                        >
-                          Label
-                        </h2>
-                        <div
-                          className="security--panelv2__header--subtitle"
-                        >
-                          Label
-                        </div>
-                      </div>
                       <IconButton
                         className="security--panelv2__button--close"
                         iconClassName=""
@@ -378,6 +364,20 @@ exports[`PanelV2 renders 1`] = `
                           </Icon>
                         </button>
                       </IconButton>
+                      <div
+                        className="security--panelv2__header__container--title"
+                      >
+                        <h2
+                          className="security--panelv2__header--title"
+                        >
+                          Label
+                        </h2>
+                        <div
+                          className="security--panelv2__header--subtitle"
+                        >
+                          Label
+                        </div>
+                      </div>
                     </header>
                     <section
                       className="security--panelv2__body security--panelv2__body--footer"

--- a/src/components/PanelV2/_mixins.scss
+++ b/src/components/PanelV2/_mixins.scss
@@ -85,6 +85,7 @@
     margin-right: $panel__spacing__padding;
     margin-left: $panel__spacing__padding;
     box-sizing: border-box;
+    flex-direction: row-reverse;
     justify-content: space-between;
     border-bottom: $panel__content__sizing__border solid
       $panel__content__color__border;


### PR DESCRIPTION
## Affected issues

- Resolves #276 

## Proposed changes

- reorder header so that close button comes first in DOM
- add `flex-direction: row-reverse` to header so that title/subtitle *appear* first
