### PR TITLE
chore(nav-item-link): update propTypes declaration

### DIFF
--- a/src/components/Nav/NavItemLink/NavItemLink.js
+++ b/src/components/Nav/NavItemLink/NavItemLink.js
@@ -13,7 +13,7 @@ const NavItemLink = React.forwardRef(function NavItemLink(props, ref) {
 
 NavItemLink.displayName = 'NavItemLink';
 
-NavItemLink.PropTypes = {
+NavItemLink.propTypes = {
   /** @type {elementType} The base element to use to build the link. Defaults to `a`, can also accept alternative tag names or custom components like `Link` from `react-router`. */
   element: PropTypes.elementType,
 };


### PR DESCRIPTION
Warning in test output:

```
Warning: Component NavItemLink declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?
```

## Proposed changes

- change `NavItemLink.PropTypes` to `NavItemLink.propTypes`
