### PR TITLE
refactor: remove deprecated SCSS

### DIFF
--- a/docs/migration/2.x-color.md
+++ b/docs/migration/2.x-color.md
@@ -16,3 +16,4 @@ Also refer to [migration in Carbon](https://github.com/carbon-design-system/carb
 | `1.x`                                      | `2.x`                           |
 | ------------------------------------------ | ------------------------------- |
 | `$ibm-colors__white` / `$ibm-color__white` | `$carbon--white-0` / `$white-0` |
+| `$security-color__gray-90--hover`          | `$hover-ui`                     |

--- a/docs/migration/2.x-themes.md
+++ b/docs/migration/2.x-themes.md
@@ -1,0 +1,13 @@
+# Themes
+
+### Functions
+
+| `1.x`   | `2.x`                         |
+| ------- | ----------------------------- |
+| `theme` | [Themes](../themes/README.md) |
+
+### Variables
+
+| `1.x`              | `2.x`                         |
+| ------------------ | ----------------------------- |
+| `$security--theme` | [Themes](../themes/README.md) |

--- a/docs/migration/migrate-to-2.x.md
+++ b/docs/migration/migrate-to-2.x.md
@@ -18,6 +18,7 @@ Remove any `@ibmduo`-scoped packages if they're listed as a dependency
 | Color  | [Migrate](2.x-color.md)  |
 | Grid   | [Migrate](2.x-grid.md)   |
 | Layout | [Migrate](2.x-layout.md) |
+| Themes | [Migrate](2.x-themes.md) |
 | Type   | [Migrate](2.x-type.md)   |
 
 ## Components

--- a/src/globals/color/_index.scss
+++ b/src/globals/color/_index.scss
@@ -5,12 +5,6 @@
 ////
 
 @import '@carbon/colors/scss/colors';
-@import '@carbon/themes/scss/tokens';
-
-/// TODO: `2.x` - Deprecate in favor of `$hover-ui`.
-/// @type Color
-/// @deprecated
-$security-color__gray-90--hover: $hover-ui;
 
 /// 'Cool gray 10' hover.
 /// @type Color

--- a/src/globals/layout/_index.scss
+++ b/src/globals/layout/_index.scss
@@ -10,18 +10,3 @@
 
 @import 'carbon-components/scss/globals/scss/layout';
 @import 'carbon-components/scss/globals/scss/spacing';
-
-@import '../deprecate/index';
-
-// TODO: `2.x` - To be removed.
-
-///
-/// Deprecation warning method for `get-fixed-size`.
-/// @param {Length} $unitQuantity The deprecated unit quantity parameter.
-/// @return {Length} The correct `mini-unit` size.
-///
-@function get-fixed-size($unitQuantity) {
-  @warn deprecate($actual: 'get-fixed-size($unitQuantity: #{$unitQuantity})', $expected: 'carbon--mini-units($count: #{$unitQuantity})');
-
-  @return carbon--mini-units($count: $unitQuantity);
-}

--- a/src/globals/theme/_functions.scss
+++ b/src/globals/theme/_functions.scss
@@ -10,7 +10,6 @@
 /// @param {Map<String, Color>} $theme The theme to remove the type tokens from.
 /// @returns {Map<String, Color>} The transformed theme.
 /// @access private
-/// @deprecated
 @function security--type-tokens-remove($theme) {
   @each $token in map-keys($map: $tokens) {
     $theme: map-remove($theme, $token);

--- a/src/globals/theme/_index.scss
+++ b/src/globals/theme/_index.scss
@@ -8,7 +8,7 @@
 
 @import 'functions';
 
-// TODO: `2.x` - To be removed.
+// TODO: `3.x` - To be removed.
 
 /// Security theme.
 /// @type Map<String, Color>
@@ -46,26 +46,6 @@ $carbon--theme: $-theme;
 
 @import 'mixins';
 @import 'variables';
-
-// TODO: `2.x` - To be removed after the `theme` function is deprecated.
-
-/// Dark theme.
-/// @type String
-/// @access private
-/// @deprecated
-$theme: dark;
-
-/// Handles theme switching between light and dark.
-/// @param {Color} $light The light color to use.
-/// @param {Color} $dark The dark color to use.
-/// @returns {Color} The determined theme color to use.
-/// @access private
-/// @deprecated
-@function theme($light, $dark) {
-  @warn deprecate($actual: 'theme', $expected: '@carbon/themes');
-
-  @return if($theme == dark, $dark, $light);
-}
 
 // Outputs the relevant classes for each supported theme.
 @each $theme, $tokens in $security--themes {

--- a/src/globals/type/_index.scss
+++ b/src/globals/type/_index.scss
@@ -17,24 +17,6 @@
 
 // TODO: `2.x` - To be removed.
 
-/// Monospaced font family.
-/// @type string
-$font-family-mono: carbon--font-family(
-  $name: mono,
-);
-
-/// Sans serif font family.
-/// @type string
-$font-family-sans-serif: carbon--font-family(
-  $name: sans,
-);
-
-/// Serif font family.
-/// @type string
-$font-family-serif: carbon--font-family(
-  $name: serif,
-);
-
 /// Font family deprecation mappings.
 /// @type Map<string, string>
 $font-family-deprecation-map: (


### PR DESCRIPTION
BREAKING CHANGE: The following SCSS has been removed:

- Color - `$security-color__gray-90--hover`
- Layout - `get-fixed-size`
- Themes - `theme` function and `$theme` variable

## Affected issues

- Resolves #257 

## Proposed changes

- Remove deprecated color, layout, and themes methods