### PR TITLE
build: move reset after expressive heading overrides to fix build

### DIFF
--- a/src/globals/type/_index.scss
+++ b/src/globals/type/_index.scss
@@ -8,7 +8,6 @@
 @import '@carbon/type/scss/classes';
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
-@import '@carbon/type/scss/reset';
 
 // TODO: Remove when fix is released in `@carbon/type` - https://github.com/carbon-design-system/carbon/pull/4927
 
@@ -31,3 +30,5 @@ $expressive-heading-02: map-merge(
       ),
   ),
 );
+
+@import '@carbon/type/scss/reset';


### PR DESCRIPTION
## Affected issues

- Resolves #299

Expressive headings overrides are required for now because Carbon's vendor files for `10.9.0` of `carbon-components` has broken scss (i.e., unitless values are passed into a function & the result is an invalid string not a valid rem value).

So we need to include the css-reset after the expressive heading overrides so that our overrides get applied.

## Proposed changes

- move css-reset to after expressive headings overrides
