### PR TITLE
fix(trending-card): use Link component in test

### DIFF
--- a/src/components/TrendingCard/__tests__/TrendingCard.spec.js
+++ b/src/components/TrendingCard/__tests__/TrendingCard.spec.js
@@ -7,6 +7,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { Default as TrendingCard } from '../TrendingCard.stories';
+import Link from '../../Link';
 
 describe('TrendingCard', () => {
   it('renders', () => {
@@ -15,7 +16,7 @@ describe('TrendingCard', () => {
 
   it('renders a custom link', () => {
     expect(
-      render(<TrendingCard element="a" />).container.firstChild
+      render(<TrendingCard element={Link} />).container.firstChild
     ).toMatchSnapshot();
   });
 });

--- a/src/components/TrendingCard/__tests__/TrendingCard.spec.js
+++ b/src/components/TrendingCard/__tests__/TrendingCard.spec.js
@@ -15,7 +15,7 @@ describe('TrendingCard', () => {
 
   it('renders a custom link', () => {
     expect(
-      render(<TrendingCard element="Link" />).container.firstChild
+      render(<TrendingCard element="a" />).container.firstChild
     ).toMatchSnapshot();
   });
 });

--- a/src/components/TrendingCard/__tests__/__snapshots__/TrendingCard.spec.js.snap
+++ b/src/components/TrendingCard/__tests__/__snapshots__/TrendingCard.spec.js.snap
@@ -20,7 +20,7 @@ exports[`TrendingCard renders 1`] = `
 `;
 
 exports[`TrendingCard renders a custom link 1`] = `
-<link
+<a
   class="security--trending-card"
   href="#"
   style="width: 20rem;"
@@ -35,5 +35,5 @@ exports[`TrendingCard renders a custom link 1`] = `
   >
     Subtitle
   </span>
-</link>
+</a>
 `;

--- a/src/components/TrendingCard/__tests__/__snapshots__/TrendingCard.spec.js.snap
+++ b/src/components/TrendingCard/__tests__/__snapshots__/TrendingCard.spec.js.snap
@@ -21,7 +21,7 @@ exports[`TrendingCard renders 1`] = `
 
 exports[`TrendingCard renders a custom link 1`] = `
 <a
-  class="security--trending-card"
+  class="bx--link security--trending-card"
   href="#"
   style="width: 20rem;"
 >


### PR DESCRIPTION
Tests generated the following error for `TrendingCard` --

```
    console.error node_modules/react-dom/cjs/react-dom.development.js:530
      Warning: <Link /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
          in Link (created by TrendingCard)
          in TrendingCard (created by Default)
          in Default
```

## Proposed changes

- ~use HTML element `a` instead of `Link` for snapshot test~ make sure to import the `Link` component to use as a custom component in test
