### PR TITLE
fix(panel): only apply aria-labelledby if title or subtitle provided

### DIFF
--- a/src/components/Panel/PanelContainer.js
+++ b/src/components/Panel/PanelContainer.js
@@ -162,7 +162,7 @@ export default class PanelContainer extends Component {
     const getAriaLabelledBy =
       title || subtitle
         ? {
-            'aria-labelledBy': title ? this.panelTitleId : this.panelSubtitleId,
+            'aria-labelledby': title ? this.panelTitleId : this.panelSubtitleId,
           }
         : {};
 
@@ -171,7 +171,6 @@ export default class PanelContainer extends Component {
           tabIndex: 0,
           role: 'region',
           'aria-label': ariaLabel,
-          'aria-labelledby': getAriaLabelledBy,
         }
       : {};
 

--- a/src/components/Panel/PanelContainer.js
+++ b/src/components/Panel/PanelContainer.js
@@ -159,7 +159,12 @@ export default class PanelContainer extends Component {
 
     const ariaLabel = this.props['aria-label'] || title || subtitle;
 
-    const getAriaLabelledBy = title ? this.panelTitleId : this.panelSubtitleId;
+    const getAriaLabelledBy =
+      title || subtitle
+        ? {
+            'aria-labelledBy': title ? this.panelTitleId : this.panelSubtitleId,
+          }
+        : {};
 
     const hasScrollingContentProps = hasScrollingContent
       ? {
@@ -209,7 +214,7 @@ export default class PanelContainer extends Component {
             marginBottom: `${this.state.bodyMargin.bottom}px`,
           }}
           {...hasScrollingContentProps}
-          aria-labelledby={getAriaLabelledBy}
+          {...getAriaLabelledBy}
         >
           {children}
         </section>

--- a/src/components/PanelV2/PanelV2.js
+++ b/src/components/PanelV2/PanelV2.js
@@ -105,7 +105,7 @@ export default class PanelV2 extends Component {
     const getAriaLabelledBy =
       title || subtitle
         ? {
-            'aria-labelledBy': title ? this.panelTitleId : this.panelSubtitleId,
+            'aria-labelledby': title ? this.panelTitleId : this.panelSubtitleId,
           }
         : {};
 

--- a/src/components/PanelV2/PanelV2.js
+++ b/src/components/PanelV2/PanelV2.js
@@ -102,14 +102,18 @@ export default class PanelV2 extends Component {
 
     const ariaLabel = this.props['aria-label'] || title || subtitle;
 
-    const getAriaLabelledBy = title ? this.panelTitleId : this.panelSubtitleId;
+    const getAriaLabelledBy =
+      title || subtitle
+        ? {
+            'aria-labelledBy': title ? this.panelTitleId : this.panelSubtitleId,
+          }
+        : {};
 
     const hasScrollingContentProps = hasScrollingContent
       ? {
           tabIndex: 0,
           role: 'region',
           'aria-label': ariaLabel,
-          'aria-labelledby': getAriaLabelledBy,
         }
       : {};
 
@@ -173,7 +177,7 @@ export default class PanelV2 extends Component {
                   marginBottom: `${this.state.bodyMargin.bottom}px`,
                 }}
                 {...hasScrollingContentProps}
-                aria-labelledby={getAriaLabelledBy}
+                {...getAriaLabelledBy}
               >
                 {children}
               </section>


### PR DESCRIPTION
## Affected issues

- Resolves #332 

## Proposed changes

- remove duplicate `aria-labelledby` in `hasScrollingContentProps`
- add logic to only apply `aria-labelledby` if there is a valid `title` or `subtitle`

## Testing instructions

Pull down the branch and experiment with the storybook by commenting out `title` and `subtitle` & checking rendered story to see there is no `aria-labelledby` attribute.

👉 Note that because we do not enforce/require many of this props, you can still generate a DAP error *if* you set `hasScrollingContent={true}` and remove `title`, `subtitle`, and `aria-label`. This error happens because `hasScrollingContent` adds `role="region"` to the panel content wrapper, which then *requires* some kind of label (but since there is no `aria-label`, or not `title` / `subtitle` to apply an `aria-labelledby`, the region is unlabeled and in violation). I think unless we start requiring certain props, this is unavoidable. BUT worth noting: there is a proptypes error asking the dev to add an `aria-label` if `hasScrollingContent={true}`, which would be helpful & remove the violation.