### PR TITLE
docs(panelv2): add knobs for title, subtitle, and aria-label

### DIFF
--- a/src/components/PanelV2/PanelV2.stories.js
+++ b/src/components/PanelV2/PanelV2.stories.js
@@ -37,12 +37,12 @@ const { interactive01, text04 } = theme;
 
 const closeButtonLabel = 'Close';
 
-const props = {
-  title: 'Example title',
-  subtitle: 'Example subtitle',
-  ['aria-label']: 'Example aria-label', // eslint-disable-line no-useless-computed-key
+const props = () => ({
+  title: text('title', 'Example title'),
+  subtitle: text('subtitle', 'Example subtitle'),
+  ['aria-label']: text('aria-label', 'Example aria-label'), // eslint-disable-line no-useless-computed-key
   labels,
-};
+});
 
 const comboButtonProps = () => ({
   direction: radios(
@@ -130,7 +130,7 @@ disableCentered(storiesOf(patterns('PanelV2'), module))
               <PanelV2
                 key="p1"
                 isOpen={this.state.firstOpen}
-                {...props}
+                {...props()}
                 closeButton={{
                   onClick: this.closeFirst,
                   label: text('closeButton.label', closeButtonLabel),
@@ -168,7 +168,7 @@ disableCentered(storiesOf(patterns('PanelV2'), module))
               <PanelV2
                 key="p2"
                 isOpen={this.state.secondOpen}
-                {...props}
+                {...props()}
                 closeButton={{
                   onClick: this.closeSecond,
                   label: text('closeButton.label', closeButtonLabel),
@@ -221,7 +221,7 @@ disableCentered(storiesOf(patterns('PanelV2'), module))
               <PanelV2
                 key="p3"
                 isOpen={this.state.thirdOpen}
-                {...props}
+                {...props()}
                 closeButton={{
                   onClick: this.closethird,
                   label: closeButtonLabel,


### PR DESCRIPTION
## Proposed changes

- per https://github.com/carbon-design-system/ibm-security/pull/308#discussion_r371760928, add knobs so that `title`, `subtitle`, and `aria-label` can be customized in storybook
