### PR TITLE
docs: set escapeHTML to false for decorator and datadecorator storybook knobs

### DIFF
--- a/src/components/DataDecorator/DataDecorator.stories.js
+++ b/src/components/DataDecorator/DataDecorator.stories.js
@@ -35,6 +35,12 @@ const storyProps = () => ({
   renderFooter: () => <Button size="large">Custom footer</Button>,
 });
 
-storiesOf(patterns('DataDecorator'), module).add('Default', () => (
-  <DataDecorator {...storyProps()} />
-));
+storiesOf(patterns('DataDecorator'), module).add(
+  'Default',
+  () => <DataDecorator {...storyProps()} />,
+  {
+    knobs: {
+      escapeHTML: false,
+    },
+  }
+);

--- a/src/components/DataDecorator/Decorator/Decorator.stories.js
+++ b/src/components/DataDecorator/Decorator/Decorator.stories.js
@@ -35,10 +35,22 @@ const storyProps = () => ({
 });
 
 storiesOf(components('Decorator'), module)
-  .add('Default', () => <Decorator {...storyProps()} />)
-  .add('Inline', () => (
-    <p className="bx--type-body-long-01">
-      This is an inline decorator <Decorator {...storyProps()} inline /> that
-      appears alongside some text.
-    </p>
-  ));
+  .add('Default', () => <Decorator {...storyProps()} />, {
+    knobs: {
+      escapeHTML: false,
+    },
+  })
+  .add(
+    'Inline',
+    () => (
+      <p className="bx--type-body-long-01">
+        This is an inline decorator <Decorator {...storyProps()} inline /> that
+        appears alongside some text.
+      </p>
+    ),
+    {
+      knobs: {
+        escapeHTML: false,
+      },
+    }
+  );


### PR DESCRIPTION
## Affected issues

- Resolves #356 

## Proposed changes

- turn off `escapeHTML` option for `Decorator` and `DataDecorator` storybook knobs
