### PR TITLE
fix(accordion): add alignment test, fix custom class addition

### DIFF
--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -10,7 +10,7 @@ import CarbonAccordion from 'carbon-components-react/lib/components/Accordion';
 
 const { defaultProps, propTypes } = CarbonAccordion;
 
-const Accordion = ({ className, align, ...other }) => (
+const Accordion = ({ align, ...other }) => (
   <CarbonAccordion {...other} align={align} />
 );
 

--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -1,0 +1,40 @@
+/**
+ * @file Accordion tests.
+ * @copyright IBM Security 2020
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { carbonPrefix } from '../../../globals/namespace';
+
+import { Accordion, AccordionItem } from '../../..';
+
+describe('Accordion', () => {
+  test('should have icon aligned at start by default', () => {
+    const { getByLabelText, getByText } = render(
+      <Accordion>
+        <AccordionItem title="test title" iconDescription="test icon label">
+          test content
+        </AccordionItem>
+      </Accordion>
+    );
+    // Expect accordion to have correct alignment class:
+    expect(getByText(/test title/i).closest('ul')).toHaveClass(
+      `${carbonPrefix}accordion--start`
+    );
+    // Expect the icon to be first inside the accordion item heading button:
+    expect(getByText(/test title/i).closest('button').firstChild).toBe(
+      getByLabelText(/test icon label/i)
+    );
+  });
+
+  test('should pass custom class through spread attribute', () => {
+    const { getByText } = render(
+      <Accordion className="custom-class">
+        <AccordionItem title="test title">test content</AccordionItem>
+      </Accordion>
+    );
+    expect(getByText(/test title/i).closest('ul')).toHaveClass('custom-class');
+  });
+});

--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -19,10 +19,6 @@ describe('Accordion', () => {
         </AccordionItem>
       </Accordion>
     );
-    // Expect accordion to have correct alignment class:
-    expect(getByText(/test title/i).closest('ul')).toHaveClass(
-      `${carbonPrefix}accordion--start`
-    );
     // Expect the icon to be first inside the accordion item heading button:
     expect(getByText(/test title/i).closest('button').firstChild).toBe(
       getByLabelText(/test icon label/i)


### PR DESCRIPTION
## Proposed changes

- add test to check for "start" alignment by default (opposite of Carbn's default)
- add test to check for custom class name passed through spread attribute

Also:
- fix custom class addition in `Accordion` 😳
