### PR TITLE
fix(decorator): add `vertical-align` property

### DIFF
--- a/src/components/DataDecorator/_mixins.scss
+++ b/src/components/DataDecorator/_mixins.scss
@@ -43,6 +43,7 @@
   max-width: 100%;
   padding: unset;
   border: unset;
+  vertical-align: middle;
 
   &:focus {
     @include focus-outline('outline');


### PR DESCRIPTION
## Affected issues

Resolves #363

## Proposed changes

Add `vertical-align` property to ensure `Decorator` aligns itself correctly for each variation