### PR TITLE
fix(filter-panel-group): remove header if no title is provided

### DIFF
--- a/src/components/FilterPanel/FilterPanelGroup/FilterPanelGroup.js
+++ b/src/components/FilterPanel/FilterPanelGroup/FilterPanelGroup.js
@@ -22,11 +22,13 @@ const FilterPanelGroup = ({
   ...other
 }) => (
   <div className={classnames(namespace, className)} {...other}>
-    <h2 className={classnames(`${namespace}__title`, titleClassName)}>
-      <FilterPanelLabel count={count} countLabel={countLabel}>
-        {title}
-      </FilterPanelLabel>
-    </h2>
+    {title && (
+      <h2 className={classnames(`${namespace}__title`, titleClassName)}>
+        <FilterPanelLabel count={count} countLabel={countLabel}>
+          {title}
+        </FilterPanelLabel>
+      </h2>
+    )}
     <div className={`${namespace}__content`}>{children}</div>
   </div>
 );

--- a/src/components/FilterPanel/FilterPanelGroup/__tests__/FilterPanelGroup.spec.js
+++ b/src/components/FilterPanel/FilterPanelGroup/__tests__/FilterPanelGroup.spec.js
@@ -30,6 +30,18 @@ describe('FilterPanelGroup', () => {
     expect(getByTestId('content')).toBeVisible();
   });
 
+  it('does not render the count if the title is not provided', () => {
+    const { queryByText } = render(<FilterPanelGroup count={200} />);
+    expect(queryByText(/200/)).not.toBeInTheDocument();
+  });
+
+  it('renders the count if the title is also provided', () => {
+    const { queryByText } = render(
+      <FilterPanelGroup title="title" count={200} />
+    );
+    expect(queryByText(/200/)).toBeVisible();
+  });
+
   it('adds custom class name', () => {
     const { container } = render(<FilterPanelGroup className="custom-class" />);
     expect(container.querySelector('.custom-class')).toBeInTheDocument();


### PR DESCRIPTION
## Proposed changes

- Makes titles optional for filter panel groups

## Testing instructions

- Render a `FilterPanelGroup` without a title
