### PR TITLE
fix(filter-panel-accordion-item): reorder elems so li are children of ul elems

### DIFF
--- a/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordiontItem.js
+++ b/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordiontItem.js
@@ -85,37 +85,39 @@ const FilterPanelAccordionItem = ({
       open={open}
       {...other}
     >
-      <ul className={`${namespace}__list`}>
-        <ScrollGradient
-          scrollElementClassName={`${namespace}__scroller`}
-          getScrollElementRef={setListContainer}
-          color={scrollGradientColor}
+      <ScrollGradient
+        scrollElementClassName={`${namespace}__scroller`}
+        getScrollElementRef={setListContainer}
+        color={scrollGradientColor}
+      >
+        <div
+          role="presentation"
+          ref={visibleChildren}
+          className={`${namespace}__list-items ${namespace}__list-items--visible`}
         >
-          <div
-            role="presentation"
-            ref={visibleChildren}
-            className={`${namespace}__list-items ${namespace}__list-items--visible`}
-          >
+          <ul className={`${namespace}__list`}>
             {childrenArray.slice(0, displayCount).map(child => (
               <li className={`${namespace}__list-item`} key={child.key}>
                 {child}
               </li>
             ))}
-          </div>
-          {shouldTruncate && isExpanded && (
-            <div
-              role="presentation"
-              className={`${namespace}__list-items ${namespace}__list-items--hidden`}
-            >
+          </ul>
+        </div>
+        {shouldTruncate && isExpanded && (
+          <div
+            role="presentation"
+            className={`${namespace}__list-items ${namespace}__list-items--hidden`}
+          >
+            <ul className={`${namespace}__list`}>
               {childrenArray.slice(displayCount).map(child => (
                 <li className={`${namespace}__filter`} key={child.key}>
                   {child}
                 </li>
               ))}
-            </div>
-          )}
-        </ScrollGradient>
-      </ul>
+            </ul>
+          </div>
+        )}
+      </ScrollGradient>
       {shouldTruncate && (
         <Button
           className={`${namespace}__button--toggle`}


### PR DESCRIPTION
## Affected issues

- Resolves #376 

## Proposed changes

- reorder elements so that `ul`s are only direct parents of `li` elements (nothing else was reordered)
