### PR TITLE
fix(filter-panel): accordion item themed gradient color

### DIFF
--- a/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordiontItem.js
+++ b/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordiontItem.js
@@ -8,13 +8,13 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Add16 from '@carbon/icons-react/lib/add/16';
 import Subtract16 from '@carbon/icons-react/lib/subtract/16';
-import { g100 as theme } from '@carbon/themes';
 
 import ScrollGradient from '../../ScrollGradient';
 import { AccordionItem } from '../../Accordion';
 import Button from '../../Button';
 import { getComponentNamespace } from '../../../globals/namespace';
 import FilterPanelLabel from '../FilterPanelLabel';
+import theme from '../../../globals/theme';
 
 export const namespace = getComponentNamespace('filter-panel-accordion-item');
 


### PR DESCRIPTION
## Affected issues

- Resolves #393 

## Proposed changes

- Use the same theme color mechanism as the scroll gradient for the filter panel accordion item

## Testing instructions

- Go to the filter panel story
- Change the theme to g10
- Expand a scrollable filter panel accordion item
- Notice the gradient color
