### PR TITLE
feat(unstable-pagination): add page input child component, split out tests

### DIFF
--- a/src/components/UNSTABLE__Pagination/PageInput.js
+++ b/src/components/UNSTABLE__Pagination/PageInput.js
@@ -18,6 +18,8 @@ function PageSelector({
   id,
   invalidText,
   label,
+  max,
+  min,
   totalPages,
   ...other
 }) {
@@ -29,8 +31,8 @@ function PageSelector({
       invalidText={invalidText}
       label={label}
       value={currentPage}
-      min={1}
-      max={totalPages}
+      max={max || totalPages}
+      min={min}
       {...other}
     />
   );
@@ -52,6 +54,12 @@ PageSelector.propTypes = {
   /** Translatable string to label the page input element. */
   label: PropTypes.string,
 
+  /** The maximum value accepted. */
+  max: PropTypes.number,
+
+  /** The minimum value accepted. */
+  min: PropTypes.number,
+
   /**
    * Total number of pages.
    * This value is calculated using a valid `totalItems` prop passed to the parent `UNSTABLE__Pagination`.
@@ -64,6 +72,8 @@ PageSelector.defaultProps = {
   className: null,
   id: 1,
   label: 'Current page number',
+  max: undefined,
+  min: 1,
   invalidText: 'Not a valid page number.',
 };
 

--- a/src/components/UNSTABLE__Pagination/PageInput.js
+++ b/src/components/UNSTABLE__Pagination/PageInput.js
@@ -1,50 +1,36 @@
 /**
- * @file Page selector.
- * @copyright IBM Security 2019
+ * @file Page input.
+ * @copyright IBM Security 2020
  */
 
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Select, SelectItem } from '../Select';
+import NumberInput from '../NumberInput';
 import { appendComponentNamespace } from '../../globals/namespace/index';
 import { namespace as paginationNamespace } from './Pagination';
 
-const namespace = appendComponentNamespace(
-  paginationNamespace,
-  'page-selector'
-);
+const namespace = appendComponentNamespace(paginationNamespace, 'page-input');
 
 function PageSelector({
   className,
   currentPage,
   id,
-  labelText,
+  label,
   totalPages,
   ...other
 }) {
-  const renderPages = total => {
-    const pages = [];
-    for (let counter = 1; counter <= total; counter += 1) {
-      pages.push(
-        <SelectItem key={counter} value={counter} text={String(counter)} />
-      );
-    }
-    return pages;
-  };
-
   return (
-    <Select
+    <NumberInput
       className={classnames(namespace, className)}
       hideLabel
       id={`${namespace}__input-${id}`}
-      inline
-      labelText={labelText}
+      label={label}
       value={currentPage}
+      min={1}
+      max={totalPages}
       {...other}
-    >
-      {renderPages(totalPages)}
-    </Select>
+    />
   );
 }
 
@@ -52,20 +38,19 @@ PageSelector.propTypes = {
   /** Extra class names to add. */
   className: PropTypes.string,
 
-  /**
-   * The current page.
-   */
+  /** The current page. */
   currentPage: PropTypes.number.isRequired,
 
   /** The unique ID of this component instance. */
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
-  /** Translatable string to label the page selector element. */
-  labelText: PropTypes.string,
+  /** Translatable string to label the page input element. */
+  label: PropTypes.string,
 
   /**
    * Total number of pages.
    * This value is calculated using a valid `totalItems` prop passed to the parent `UNSTABLE__Pagination`.
+   * Here, `totalItems` is used to set the `max` on the page input.
    */
   totalPages: PropTypes.number.isRequired,
 };
@@ -73,7 +58,7 @@ PageSelector.propTypes = {
 PageSelector.defaultProps = {
   className: null,
   id: 1,
-  labelText: 'Current page number',
+  label: 'Current page number',
 };
 
 export default PageSelector;

--- a/src/components/UNSTABLE__Pagination/PageInput.js
+++ b/src/components/UNSTABLE__Pagination/PageInput.js
@@ -16,6 +16,7 @@ function PageSelector({
   className,
   currentPage,
   id,
+  invalidText,
   label,
   totalPages,
   ...other
@@ -25,6 +26,7 @@ function PageSelector({
       className={classnames(namespace, className)}
       hideLabel
       id={`${namespace}__input-${id}`}
+      invalidText={invalidText}
       label={label}
       value={currentPage}
       min={1}
@@ -44,6 +46,9 @@ PageSelector.propTypes = {
   /** The unique ID of this component instance. */
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
+  /** Translatable string for the message shown when an invalid page is entered. */
+  invalidText: PropTypes.string,
+
   /** Translatable string to label the page input element. */
   label: PropTypes.string,
 
@@ -59,6 +64,7 @@ PageSelector.defaultProps = {
   className: null,
   id: 1,
   label: 'Current page number',
+  invalidText: 'Not a valid page number.',
 };
 
 export default PageSelector;

--- a/src/components/UNSTABLE__Pagination/PageInput.js
+++ b/src/components/UNSTABLE__Pagination/PageInput.js
@@ -6,13 +6,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
 import NumberInput from '../NumberInput';
 import { appendComponentNamespace } from '../../globals/namespace/index';
 import { namespace as paginationNamespace } from './Pagination';
 
 const namespace = appendComponentNamespace(paginationNamespace, 'page-input');
+const getInstanceId = setupGetInstanceId();
 
-function PageSelector({
+function PageInput({
   className,
   currentPage,
   id,
@@ -23,11 +25,13 @@ function PageSelector({
   totalPages,
   ...other
 }) {
+  const instanceId = `${namespace}__input-${getInstanceId()}`;
+
   return (
     <NumberInput
       className={classnames(namespace, className)}
       hideLabel
-      id={`${namespace}__input-${id}`}
+      id={instanceId || id}
       invalidText={invalidText}
       label={label}
       value={currentPage}
@@ -38,7 +42,7 @@ function PageSelector({
   );
 }
 
-PageSelector.propTypes = {
+PageInput.propTypes = {
   /** Extra class names to add. */
   className: PropTypes.string,
 
@@ -54,7 +58,7 @@ PageSelector.propTypes = {
   /** Translatable string to label the page input element. */
   label: PropTypes.string,
 
-  /** The maximum value accepted. */
+  /** The maximum value accepted. By default, this value will be the `totalPages` passed from the parent. */
   max: PropTypes.number,
 
   /** The minimum value accepted. */
@@ -68,7 +72,7 @@ PageSelector.propTypes = {
   totalPages: PropTypes.number.isRequired,
 };
 
-PageSelector.defaultProps = {
+PageInput.defaultProps = {
   className: null,
   id: 1,
   label: 'Current page number',
@@ -77,4 +81,4 @@ PageSelector.defaultProps = {
   invalidText: 'Not a valid page number.',
 };
 
-export default PageSelector;
+export default PageInput;

--- a/src/components/UNSTABLE__Pagination/PageSelector.js
+++ b/src/components/UNSTABLE__Pagination/PageSelector.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
 import { Select, SelectItem } from '../Select';
 import { appendComponentNamespace } from '../../globals/namespace/index';
 import { namespace as paginationNamespace } from './Pagination';
@@ -14,6 +15,7 @@ const namespace = appendComponentNamespace(
   paginationNamespace,
   'page-selector'
 );
+const getInstanceId = setupGetInstanceId();
 
 function PageSelector({
   className,
@@ -23,6 +25,8 @@ function PageSelector({
   totalPages,
   ...other
 }) {
+  const instanceId = `${namespace}__select-${getInstanceId()}`;
+
   const renderPages = total => {
     const pages = [];
     for (let counter = 1; counter <= total; counter += 1) {
@@ -37,7 +41,7 @@ function PageSelector({
     <Select
       className={classnames(namespace, className)}
       hideLabel
-      id={`${namespace}__input-${id}`}
+      id={instanceId || id}
       inline
       labelText={labelText}
       value={currentPage}

--- a/src/components/UNSTABLE__Pagination/Pagination.js
+++ b/src/components/UNSTABLE__Pagination/Pagination.js
@@ -104,6 +104,7 @@ function UNSTABLE__Pagination({
             totalItems &&
             children({
               currentPage,
+              currentPageSize,
               onSetPage,
               totalPages,
             })}

--- a/src/components/UNSTABLE__Pagination/Pagination.stories.js
+++ b/src/components/UNSTABLE__Pagination/Pagination.stories.js
@@ -141,10 +141,10 @@ storiesOf(components('UNSTABLE Pagination'), module)
                   totalPages={totalPages}
                   id="number-input-1"
 
-                  {/**
+                  /**
                    * NOTE: we are using \`event.imaginaryTarget.value\` because this is a controlled input:
-                   */}
-                   onChange={event => onSetPage(event.imaginaryTarget.value)}
+                   */
+                  onChange={event => onSetPage(event.imaginaryTarget.value)}
                 />
               )}
             </UNSTABLE__Pagination>

--- a/src/components/UNSTABLE__Pagination/Pagination.stories.js
+++ b/src/components/UNSTABLE__Pagination/Pagination.stories.js
@@ -111,7 +111,7 @@ storiesOf(components('UNSTABLE Pagination'), module)
     ),
     {
       info: {
-        propTables: [UNSTABLE__Pagination, PageSelector],
+        propTables: [UNSTABLE__Pagination, PageInput],
         text: `
             🚨 This component is *experimental* and may change. 🚨
 
@@ -123,7 +123,7 @@ storiesOf(components('UNSTABLE Pagination'), module)
             {/** 
               * Provide \`totalItems\` to \`UNSTABLE__Pagination\` when using the \`PageSelector\` child.
               * \`UNSTABLE__Pagination\` uses \`totalItems\` to calculate \`totalPages\`.
-              * And then, \`PageSelector\` uses the calculated \`totalPages\` to accurately display page options.
+              * And then, \`PageInput\` uses the calculated \`totalPages\` to set the \`max\` for the input.
               */}
             <UNSTABLE__Pagination
               totalItems={350}

--- a/src/components/UNSTABLE__Pagination/Pagination.stories.js
+++ b/src/components/UNSTABLE__Pagination/Pagination.stories.js
@@ -8,7 +8,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { array, boolean, number, text } from '@storybook/addon-knobs';
 
-import { UNSTABLE__Pagination, PageSelector } from '../..';
+import { UNSTABLE__Pagination, PageInput, PageSelector } from '../..';
 
 import { components } from '../../../.storybook';
 
@@ -34,7 +34,7 @@ const props = () => ({
 storiesOf(components('UNSTABLE Pagination'), module)
   .addDecorator(story => <div style={{ width: '800px' }}>{story()}</div>)
   .add(
-    'default',
+    'with a page selector',
     () => (
       <UNSTABLE__Pagination
         {...props()}
@@ -59,7 +59,7 @@ storiesOf(components('UNSTABLE Pagination'), module)
 
             \`UNSTABLE__Pagination\` accepts a render prop \`children\`.
 
-            In this case, you can wrap the \`children\` (\`PageSelector\`) in a function, allowing it to pass information back to the parent component.
+            This example wraps the \`children\` (\`PageSelector\`) in a function, allowing it to pass information back to the parent component.
 
             \`\`\`jsx
             {/** 
@@ -92,7 +92,69 @@ storiesOf(components('UNSTABLE Pagination'), module)
     }
   )
   .add(
-    'with no page selector or sizer',
+    'with a page input',
+    () => (
+      <UNSTABLE__Pagination
+        {...props()}
+        totalItems={350}
+        pageSizes={array('Choices of `pageSize` (pageSizes)', [10, 20, 30])}
+      >
+        {({ currentPage, onSetPage, totalPages }) => (
+          <PageInput
+            currentPage={currentPage}
+            totalPages={totalPages}
+            id="number-input-1"
+            onChange={event => onSetPage(event.imaginaryTarget.value)}
+          />
+        )}
+      </UNSTABLE__Pagination>
+    ),
+    {
+      info: {
+        propTables: [UNSTABLE__Pagination, PageSelector],
+        text: `
+            🚨 This component is *experimental* and may change. 🚨
+
+            \`UNSTABLE__Pagination\` accepts a render prop \`children\`.
+
+            This example wraps the \`children\` (\`PageInput\`) in a function, allowing it to pass information back to the parent component.
+
+            \`\`\`jsx
+            {/** 
+              * Provide \`totalItems\` to \`UNSTABLE__Pagination\` when using the \`PageSelector\` child.
+              * \`UNSTABLE__Pagination\` uses \`totalItems\` to calculate \`totalPages\`.
+              * And then, \`PageSelector\` uses the calculated \`totalPages\` to accurately display page options.
+              */}
+            <UNSTABLE__Pagination
+              totalItems={350}
+              pageSizes={[10, 15, 20, 25]}
+            >
+              {/** 
+                * Below, \`children\` is a render prop, wrapped in a function.
+                * - \`currentPage\` is used to display the current page.
+                * - \`onSetPage\` is used to update the current page state in the parent component.
+                * - \`totalPages\` is calculated using the \`totalItems\` value provided to the parent component. In the child \`PageInput\` component shown below, \`totalPages\` is used to set the \`max\` for the input.
+                */}
+              {({ currentPage, onSetPage, totalPages }) => (
+                <PageInput
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  id="number-input-1"
+
+                  {/**
+                   * NOTE: we are using \`event.imaginaryTarget.value\` because this is a controlled input:
+                   */}
+                   onChange={event => onSetPage(event.imaginaryTarget.value)}
+                />
+              )}
+            </UNSTABLE__Pagination>
+            \`\`\`
+          `,
+      },
+    }
+  )
+  .add(
+    'with no sizer, child input, or child selector',
     () => <UNSTABLE__Pagination {...props()} totalItems={350} />,
     {
       info: {

--- a/src/components/UNSTABLE__Pagination/__tests__/PageInput.spec.js
+++ b/src/components/UNSTABLE__Pagination/__tests__/PageInput.spec.js
@@ -1,0 +1,40 @@
+/**
+ * @file Page input tests.
+ * @copyright IBM Security 2020
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { PageInput } from '../../..';
+
+describe('PageInput', () => {
+  test('should add a custom class', () => {
+    const { getByText } = render(
+      <PageInput
+        currentPage={1}
+        id="test-input-1"
+        totalPages={1}
+        onChange={() => {}}
+        label="test page input"
+        className="custom-class"
+      />
+    );
+    expect(getByText(/test page input/i).parentNode).toHaveClass(
+      'custom-class'
+    );
+  });
+
+  test('should pass through extra props via spread attribute', () => {
+    const { queryByTestId } = render(
+      <PageInput
+        currentPage={1}
+        id="test-input-1"
+        totalPages={1}
+        onChange={() => {}}
+        data-testid="test-id"
+      />
+    );
+    expect(queryByTestId('test-id')).toBeVisible();
+  });
+});

--- a/src/components/UNSTABLE__Pagination/__tests__/PageSelector.spec.js
+++ b/src/components/UNSTABLE__Pagination/__tests__/PageSelector.spec.js
@@ -1,0 +1,38 @@
+/**
+ * @file Page selector tests.
+ * @copyright IBM Security 2020
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { PageSelector } from '../../..';
+
+describe('PageSelector', () => {
+  test('should add a custom class', () => {
+    const { getByText } = render(
+      <PageSelector
+        currentPage={1}
+        totalPages={1}
+        onChange={() => {}}
+        labelText="test page selector"
+        className="custom-class"
+      />
+    );
+    expect(getByText(/test page selector/i).parentNode).toHaveClass(
+      'custom-class'
+    );
+  });
+
+  test('should pass through extra props via spread attribute', () => {
+    const { queryByTestId } = render(
+      <PageSelector
+        currentPage={1}
+        totalPages={1}
+        onChange={() => {}}
+        data-testid="test-id"
+      />
+    );
+    expect(queryByTestId('test-id')).toBeVisible();
+  });
+});

--- a/src/components/UNSTABLE__Pagination/__tests__/Pagination.spec.js
+++ b/src/components/UNSTABLE__Pagination/__tests__/Pagination.spec.js
@@ -7,12 +7,24 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { UNSTABLE__Pagination, PageSelector } from '../../..';
+import { UNSTABLE__Pagination, PageInput, PageSelector } from '../../..';
 
 import { namespace } from '../Pagination';
 
 describe('UNSTABLE__Pagination', () => {
-  test('should have no Axe or DAP violations', async () => {
+  test('should have no Axe or DAP violations with no children', async () => {
+    const main = document.createElement('main');
+    render(<UNSTABLE__Pagination totalItems={40} pageSizes={[10, 20]} />, {
+      // DAP requires a landmark '<main>' in the DOM:
+      container: document.body.appendChild(main),
+    });
+    await expect(document.body).toHaveNoAxeViolations();
+    await expect(document.body).toHaveNoDAPViolations(
+      'UNSTABLE__Pagination with no children'
+    );
+  });
+
+  test('should have no Axe or DAP violations with a child page selector', async () => {
     const main = document.createElement('main');
     render(
       <UNSTABLE__Pagination totalItems={40} pageSizes={[10, 20]}>
@@ -30,7 +42,34 @@ describe('UNSTABLE__Pagination', () => {
       }
     );
     await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('UNSTABLE_Pagination');
+    await expect(document.body).toHaveNoDAPViolations(
+      'UNSTABLE__Pagination with child page selector'
+    );
+  });
+
+  test('should have no Axe or DAP violations with a child page input', async () => {
+    const main = document.createElement('main');
+    render(
+      <UNSTABLE__Pagination totalItems={40} pageSizes={[10, 20]}>
+        {({ currentPage, onSetPage, totalPages }) => (
+          <PageInput
+            currentPage={currentPage}
+            id="test-input-1"
+            label="test input"
+            onChange={event => onSetPage(event.target.value)}
+            totalPages={totalPages}
+          />
+        )}
+      </UNSTABLE__Pagination>,
+      {
+        // DAP requires a landmark '<main>' in the DOM:
+        container: document.body.appendChild(main),
+      }
+    );
+    await expect(document.body).toHaveNoAxeViolations();
+    await expect(document.body).toHaveNoDAPViolations(
+      'UNSTABLE__Pagination with child page input'
+    );
   });
 
   test('should cycle pagination elements in tab order', () => {
@@ -412,43 +451,16 @@ describe('UNSTABLE__Pagination', () => {
     expect(getByText(/1–5 items/i)).toBeInTheDocument();
   });
 
-  test('should add a custom class to parent pagination component', () => {
+  test('should add a custom class', () => {
     const { container } = render(
       <UNSTABLE__Pagination totalItems={10} className="custom-class" />
     );
     expect(container.firstElementChild).toHaveClass('custom-class');
   });
 
-  test('should pass through extra props to parent pagination component via spread attribute', () => {
+  test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
       <UNSTABLE__Pagination totalItems={10} data-testid="test-id" />
-    );
-    expect(queryByTestId('test-id')).toBeVisible();
-  });
-
-  test('should add a custom class to child page selector component', () => {
-    const { getByText } = render(
-      <PageSelector
-        currentPage={1}
-        totalPages={1}
-        onChange={() => {}}
-        labelText="test page selector"
-        className="custom-class"
-      />
-    );
-    expect(getByText(/test page selector/i).parentNode).toHaveClass(
-      'custom-class'
-    );
-  });
-
-  test('should pass through extra props to child page selector component via spread attribute', () => {
-    const { queryByTestId } = render(
-      <PageSelector
-        currentPage={1}
-        totalPages={1}
-        onChange={() => {}}
-        data-testid="test-id"
-      />
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/UNSTABLE__Pagination/_index.scss
+++ b/src/components/UNSTABLE__Pagination/_index.scss
@@ -161,5 +161,10 @@
       border: none;
       background-color: $ui-03;
     }
+
+    // Visually hide error text for now:
+    .#{$prefix}--form-requirement {
+      @include hidden;
+    }
   }
 }

--- a/src/components/UNSTABLE__Pagination/_index.scss
+++ b/src/components/UNSTABLE__Pagination/_index.scss
@@ -151,4 +151,15 @@
   &__page-sizer {
     border-right: 1px solid $ui-02;
   }
+
+  &__page-input {
+    height: 100%;
+    justify-content: center;
+    margin-right: $carbon--spacing-03;
+
+    &.#{$prefix}--number input[type='number'] {
+      border: none;
+      background-color: $ui-03;
+    }
+  }
 }

--- a/src/components/UNSTABLE__Pagination/index.js
+++ b/src/components/UNSTABLE__Pagination/index.js
@@ -4,6 +4,7 @@
  */
 
 import UNSTABLE__Pagination from './Pagination';
+import PageInput from './PageInput';
 import PageSelector from './PageSelector';
 
-export { UNSTABLE__Pagination as default, PageSelector };
+export { UNSTABLE__Pagination as default, PageInput, PageSelector };

--- a/src/index.js
+++ b/src/index.js
@@ -225,5 +225,6 @@ export UnorderedList from 'carbon-components-react/lib/components/UnorderedList'
 
 // Unstable experimental components
 export UNSTABLE__Pagination, {
+  PageInput,
   PageSelector,
 } from './components/UNSTABLE__Pagination';


### PR DESCRIPTION
## Affected issues

- Resolves #295 

NOTE: tied to https://github.com/carbon-design-system/carbon/pull/5485

## Proposed changes

- add `PageInput` component with tests & a story with docs
- split out `PageSelector` tests into separate file
- add a11y test to `UNSTABLE__Pagination` test file that checks for the new `PageInput` child
- add a couple styles but these are largely based on assumptions 😅  Definitely willing to change this with some design direction 👍 
- temporarily set invalid text to "visually hidden" -- again, need some design guidance on what should happen when that text. 🤔 

## Testing instructions

- check out the storybook demo 👀 
