### PR TITLE
fix(summary-card-action): remove overflow hidden so tooltip can be shown

### DIFF
--- a/src/components/SummaryCard/_mixins.scss
+++ b/src/components/SummaryCard/_mixins.scss
@@ -53,7 +53,6 @@
   height: $header--height + $body--height + $footer--height;
   min-width: carbon--mini-units($count: 36);
   flex-direction: column;
-  overflow: hidden;
 
   &__container {
     padding-top: $summary-card__container__sizing__height;


### PR DESCRIPTION
## Affected issues

- Resolves #419 

## Proposed changes

- remove `overflow: hidden` from `SummaryCard`

## Testing instructions

- Please verify that the component still looks correct. I'm not 100% sure why this overflow rule was necessary to begin with, but it doesn't seem so now. 🤔 And even if something is off, style-wise, we need to ensure these tooltips stay visible as they are higher priority. 
