### PR TITLE
docs(checkbox-skeleton): add required props to story demo

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.js
+++ b/src/components/Checkbox/Checkbox.stories.js
@@ -79,7 +79,11 @@ storiesOf(components('Checkbox'), module)
     'skeleton',
     () => (
       <div>
-        <CheckboxSkeleton />
+        <CheckboxSkeleton
+          id="skeleton-checkbox"
+          labelText="Checkbox label"
+          hideLabel
+        />
       </div>
     ),
     {


### PR DESCRIPTION
The `CheckboxSkeleton` has two required props (`id` and `labelText` that are no included in the storybook demo). In development, this component generates console errors due to the missing required props & creates noise:

![Screen Shot 2020-03-04 at 3 26 16 PM](https://user-images.githubusercontent.com/9057921/75924567-cd0d6300-5e2c-11ea-8daa-475bb5a49e28.png)


## Proposed changes

- add required `CheckboxSkeleton` props to storybook demo
