### PR TITLE
fix: revert `DatePicker`, update `Tile` story, revert theme order

### DIFF
--- a/src/components/DatePicker/_index.scss
+++ b/src/components/DatePicker/_index.scss
@@ -1,7 +1,87 @@
 ////
 /// Date picker component.
 /// @group date-picker
-/// @copyright IBM Security 2019
+/// @copyright IBM Security 2018 - 2020
 ////
 
 @import 'carbon-components/scss/components/date-picker/date-picker';
+
+@include export-namespace($name: datepicker) {
+  // TODO - V2: Colors need to be resolved on Carbon's end - they need to add grey-100 support for this component
+
+  .#{$prefix}--date-picker__day.inRange,
+  .flatpickr-day.inRange {
+    background: $selected-ui;
+  }
+
+  .#{$prefix}--date-picker__day.inRange:hover,
+  .flatpickr-day.inRange:hover {
+    background: $hover-selected-ui;
+  }
+
+  .#{$prefix}--date-picker__day.selected,
+  .flatpickr-day.selected {
+    background: $link-01;
+    color: $inverse-01;
+  }
+
+  .#{$prefix}--date-picker__day.selected,
+  .flatpickr-day.endRange.inRange.selected {
+    background: $link-01;
+    color: $inverse-01;
+  }
+
+  .flatpickr-current-month input.cur-year:disabled {
+    color: $carbon--gray-60;
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper .numInput:focus,
+  .flatpickr-month .numInputWrapper .numInput:focus,
+  .#{$prefix}--date-picker__day:focus,
+  .flatpickr-day:focus {
+    outline: 1px solid $interactive-04;
+  }
+
+  .#{$prefix}--date-picker__day.today,
+  .flatpickr-day.today {
+    color: $text-01;
+    &:after {
+      background-color: $support-04;
+    }
+  }
+
+  .#{$prefix}--date-picker__day.today.selected,
+  .flatpickr-day.today.selected {
+    color: $inverse-01;
+    border: none;
+    &:after {
+      background-color: $inverse-01;
+    }
+  }
+
+  .flatpickr-prev-month svg,
+  .flatpickr-next-month svg {
+    fill: $carbon--white-0;
+    &:hover,
+    &:focus,
+    &:active {
+      fill: $carbon--blue-50;
+    }
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowUp::after,
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowDown::after,
+  .flatpickr-month .numInputWrapper span.arrowUp::after,
+  .flatpickr-month .numInputWrapper span.arrowDown::after {
+    border-bottom-color: $carbon--white-0;
+    border-top-color: $carbon--white-0;
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowUp:hover::after,
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowDown:hover::after,
+  .flatpickr-month .numInputWrapper span.arrowUp:hover::after,
+  .flatpickr-month .numInputWrapper span.arrowDown:hover::after {
+    border-bottom-color: $carbon--blue-50;
+    border-top-color: $carbon--blue-50;
+  }
+}

--- a/src/components/Tile/Tile.stories.js
+++ b/src/components/Tile/Tile.stories.js
@@ -1,11 +1,10 @@
 /**
  * @file Tile stories.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import { action } from '@storybook/addon-actions';
-
-import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import React from 'react';
@@ -14,40 +13,18 @@ import {
   Tile,
   ClickableTile,
   ExpandableTile,
-  RadioTile,
   SelectableTile,
   TileAboveTheFoldContent,
   TileBelowTheFoldContent,
-  TileGroup,
-} from '../../';
+} from '../..';
 
 import { components } from '../../../.storybook';
-
-const radioValues = {
-  None: '',
-  standard: 'standard',
-  'default-selected': 'default-selected',
-  selected: 'selected',
-};
 
 const props = {
   selectable: () => ({
     selected: boolean('Selected (selected)', false),
     handleClick: action('handleClick'),
     handleKeyDown: action('handleKeyDown'),
-  }),
-  group: () => ({
-    name: text('Form item (name in <TileGroup>)', 'tile-group'),
-    valueSelected: select(
-      'Value of the selected item (valueSelected in <TileGroup>)',
-      radioValues,
-      ''
-    ),
-    onChange: action('onChange'),
-  }),
-  radio: () => ({
-    name: text('Form item name (name in <RadioTile>)', 'tiles'),
-    onChange: action('onChange'),
   }),
   expandable: () => ({
     tabIndex: number('Tab index (tabIndex)', 0),
@@ -93,7 +70,7 @@ storiesOf(components('Tile'), module)
     () => {
       const selectableProps = props.selectable();
       return (
-        <div>
+        <div aria-label="selectable tiles" role="group">
           <SelectableTile id="tile-1" name="tiles" {...selectableProps}>
             Multi-select Tile
           </SelectableTile>
@@ -111,57 +88,6 @@ storiesOf(components('Tile'), module)
         text: `
             Selectable tile
             Use this to select multiple tiles.
-          `,
-      },
-    }
-  )
-  .add(
-    'Selectable',
-    () => {
-      const radioProps = props.radio();
-      return (
-        <TileGroup
-          defaultSelected="default-selected"
-          legend="Selectable Tile Group"
-          {...props.group()}
-        >
-          <RadioTile
-            value="standard"
-            id="tile-1"
-            labelText="Selectable Tile"
-            {...radioProps}
-          >
-            Selectable Tile
-          </RadioTile>
-          <RadioTile
-            value="default-selected"
-            labelText="Default selected tile"
-            id="tile-2"
-            {...radioProps}
-          >
-            Selectable Tile
-          </RadioTile>
-          <RadioTile
-            value="selected"
-            labelText="Selectable Tile"
-            id="tile-3"
-            {...radioProps}
-          >
-            Selectable Tile
-          </RadioTile>
-        </TileGroup>
-      );
-    },
-    {
-      info: {
-        text: `
-             The example below shows a Tile Group component with a default selected Tile.
-             Although you can set the checked prop on the Tile, when using the RadioTile component
-             as a child of the Tile Group, either set the defaultSelected or valueSelected which will
-             automatically set the selected prop on the corresponding RadioTile component.
-             Use defaultSelected when you want a tile to be selected initially, but don't need to set it
-             at a later time. If you do need to set it dynamically at a later time, then use the valueSelected property instead.
-             Use this to select one tile at a time.
           `,
       },
     }

--- a/src/globals/_index.scss
+++ b/src/globals/_index.scss
@@ -1,8 +1,10 @@
 ////
 /// Globals entry point.
 /// @group entry
-/// @copyright IBM Security 2019
+/// @copyright IBM Security 2019 - 2020
 ////
+
+@import 'theme/index';
 
 @import 'variables/index';
 
@@ -12,7 +14,6 @@
 @import 'grid/index';
 @import 'layout/index';
 @import 'motion/index';
-@import 'theme/index';
 @import 'type/index';
 
 @import 'border/index';


### PR DESCRIPTION
Resolves https://github.com/carbon-design-system/ibm-security/pull/241#pullrequestreview-367401980

## Proposed changes

- Revert required `DatePicker` overrides
- Revert global theme ordering to ensure theme tokens are configured
- Update `Tile` story to reflect Carbon