### PR TITLE
refactor(tile): update story, refactor styles

### DIFF
--- a/src/components/Tile/Tile.stories.js
+++ b/src/components/Tile/Tile.stories.js
@@ -4,7 +4,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import React from 'react';
@@ -12,13 +12,22 @@ import React from 'react';
 import { components } from '../../../.storybook';
 
 import {
-  Tile,
   ClickableTile,
   ExpandableTile,
+  RadioTile,
   SelectableTile,
+  Tile,
   TileAboveTheFoldContent,
   TileBelowTheFoldContent,
+  TileGroup,
 } from '../..';
+
+const radioValues = {
+  None: '',
+  standard: 'standard',
+  'default-selected': 'default-selected',
+  selected: 'selected',
+};
 
 const props = {
   selectable: () => ({
@@ -26,6 +35,23 @@ const props = {
     handleClick: action('handleClick'),
     handleKeyDown: action('handleKeyDown'),
   }),
+
+  group: () => ({
+    name: text('Form item (name in <TileGroup>)', 'tile-group'),
+    valueSelected: select(
+      'Value of the selected item (valueSelected in <TileGroup>)',
+      radioValues,
+      ''
+    ),
+    onChange: action('onChange'),
+  }),
+
+  radio: () => ({
+    name: text('Form item name (name in <RadioTile>)', 'tiles'),
+    onChange: action('onChange'),
+    light: boolean('Light variant (light)', false),
+  }),
+
   expandable: () => ({
     tabIndex: number('Tab index (tabIndex)', 0),
     expanded: boolean('Expanded (expanded)', false),
@@ -88,6 +114,42 @@ storiesOf(components('Tile'), module)
         text: `
             Selectable tile
             Use this to select multiple tiles.
+          `,
+      },
+    }
+  )
+  .add(
+    'Radio',
+    () => {
+      const radioProps = props.radio();
+      return (
+        <TileGroup
+          defaultSelected="default-selected"
+          legend="Radio Tile Group"
+          {...props.group()}
+        >
+          <RadioTile value="standard" {...radioProps}>
+            Radio Tile
+          </RadioTile>
+          <RadioTile value="default-selected" id="tile-2" {...radioProps}>
+            Radio Tile
+          </RadioTile>
+          <RadioTile value="selected" id="tile-3" {...radioProps}>
+            Radio Tile
+          </RadioTile>
+        </TileGroup>
+      );
+    },
+    {
+      info: {
+        text: `
+             The example below shows a Tile Group component with a default selected Tile.
+             Although you can set the checked prop on the Tile, when using the RadioTile component
+             as a child of the Tile Group, either set the defaultSelected or valueSelected which will
+             automatically set the selected prop on the corresponding RadioTile component.
+             Use defaultSelected when you want a tile to be selected initially, but don't need to set it
+             at a later time. If you do need to set it dynamically at a later time, then use the valueSelected property instead.
+             Use this to select one tile at a time.
           `,
       },
     }

--- a/src/components/Tile/Tile.stories.js
+++ b/src/components/Tile/Tile.stories.js
@@ -1,53 +1,30 @@
 /**
  * @file Tile stories.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import { action } from '@storybook/addon-actions';
-
-import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import React from 'react';
+
+import { components } from '../../../.storybook';
 
 import {
   Tile,
   ClickableTile,
   ExpandableTile,
-  RadioTile,
   SelectableTile,
   TileAboveTheFoldContent,
   TileBelowTheFoldContent,
-  TileGroup,
-} from '../../';
-
-import { components } from '../../../.storybook';
-
-const radioValues = {
-  None: '',
-  standard: 'standard',
-  'default-selected': 'default-selected',
-  selected: 'selected',
-};
+} from '../..';
 
 const props = {
   selectable: () => ({
     selected: boolean('Selected (selected)', false),
     handleClick: action('handleClick'),
     handleKeyDown: action('handleKeyDown'),
-  }),
-  group: () => ({
-    name: text('Form item (name in <TileGroup>)', 'tile-group'),
-    valueSelected: select(
-      'Value of the selected item (valueSelected in <TileGroup>)',
-      radioValues,
-      ''
-    ),
-    onChange: action('onChange'),
-  }),
-  radio: () => ({
-    name: text('Form item name (name in <RadioTile>)', 'tiles'),
-    onChange: action('onChange'),
   }),
   expandable: () => ({
     tabIndex: number('Tab index (tabIndex)', 0),
@@ -93,7 +70,7 @@ storiesOf(components('Tile'), module)
     () => {
       const selectableProps = props.selectable();
       return (
-        <div>
+        <div aria-label="Selectable tiles" role="group">
           <SelectableTile id="tile-1" name="tiles" {...selectableProps}>
             Multi-select Tile
           </SelectableTile>
@@ -111,57 +88,6 @@ storiesOf(components('Tile'), module)
         text: `
             Selectable tile
             Use this to select multiple tiles.
-          `,
-      },
-    }
-  )
-  .add(
-    'Selectable',
-    () => {
-      const radioProps = props.radio();
-      return (
-        <TileGroup
-          defaultSelected="default-selected"
-          legend="Selectable Tile Group"
-          {...props.group()}
-        >
-          <RadioTile
-            value="standard"
-            id="tile-1"
-            labelText="Selectable Tile"
-            {...radioProps}
-          >
-            Selectable Tile
-          </RadioTile>
-          <RadioTile
-            value="default-selected"
-            labelText="Default selected tile"
-            id="tile-2"
-            {...radioProps}
-          >
-            Selectable Tile
-          </RadioTile>
-          <RadioTile
-            value="selected"
-            labelText="Selectable Tile"
-            id="tile-3"
-            {...radioProps}
-          >
-            Selectable Tile
-          </RadioTile>
-        </TileGroup>
-      );
-    },
-    {
-      info: {
-        text: `
-             The example below shows a Tile Group component with a default selected Tile.
-             Although you can set the checked prop on the Tile, when using the RadioTile component
-             as a child of the Tile Group, either set the defaultSelected or valueSelected which will
-             automatically set the selected prop on the corresponding RadioTile component.
-             Use defaultSelected when you want a tile to be selected initially, but don't need to set it
-             at a later time. If you do need to set it dynamically at a later time, then use the valueSelected property instead.
-             Use this to select one tile at a time.
           `,
       },
     }

--- a/src/components/Tile/_index.scss
+++ b/src/components/Tile/_index.scss
@@ -1,40 +1,16 @@
 ////
 /// Tile component.
 /// @group tile
-/// @copyright IBM Security 2018
+/// @copyright IBM Security 2018 - 2020
 ////
 
 @import 'carbon-components/scss/components/tile/tile';
 
+@import 'carbon-components/scss/globals/scss/css--reset';
+@import '../../globals/namespace/index';
+
 @include export-namespace($name: tile) {
   .#{$prefix}--tile-group {
-    border: 0;
-  }
-
-  // TODO - V2: remove when this issue is resolved in Carbon - https://github.com/carbon-design-system/carbon/issues/3270
-  .#{$prefix}--tile--clickable {
-    color: $link-01;
-    text-decoration: none;
-    outline: none;
-    transition: $duration--fast-01 motion(standard, productive);
-
-    &:hover {
-      color: $link-01;
-      text-decoration: underline;
-    }
-
-    &:active,
-    &:active:visited {
-      color: $text-01;
-      text-decoration: underline;
-    }
-
-    &:focus {
-      @include focus-outline('outline');
-    }
-
-    &:visited {
-      color: $link-01;
-    }
+    @include reset;
   }
 }


### PR DESCRIPTION
## Affected issues

Resolves https://github.com/carbon-design-system/ibm-security/pull/241#pullrequestreview-367401980

## Proposed changes

- Update 'Selectable' story to 'Radio' as per Carbon's updates
- Refactor fixed style overrides and apply CSS reset to `TileGroup` - Carbon applies this globally