### PR TITLE
test(public-api): sort components to ignore order

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docs": "node scripts/themes && git add docs/themes/themes.md",
     "format": "yarn format:precommit '**/*.{js,md,scss}'",
     "format:precommit": "prettier --ignore-path .gitignore --write",
+    "jest": "jest",
     "lint:js": "yarn lint:js:precommit .",
     "lint:js:precommit": "eslint --ignore-path .gitignore --fix",
     "lint:scss": "yarn lint:scss:precommit '**/*.scss'",
@@ -37,8 +38,8 @@
     "lint-staged": "lint-staged",
     "semantic-release": "semantic-release",
     "start": "run-s build:pre:grid && start-storybook -p 3000 -s public",
-    "test": "jest spec -ci",
-    "test:precommit": "jest -b --passWithNoTests --testMatch src/**/*.spec.js --findRelatedTests",
+    "test": "yarn jest spec -ci",
+    "test:precommit": "yarn jest -b --passWithNoTests --testMatch src/**/*.spec.js --findRelatedTests",
     "test:imports": "scripts/checkImports.sh",
     "test:ssr": "node scripts/ssr"
   },

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -2,150 +2,189 @@
 
 exports[`PublicAPI should only change with a semver change 1`] = `
 Map {
-  "theme" => Object {
-    "active01": "var(--active-01, #525252)",
-    "activeDanger": "var(--active-danger, #750e13)",
-    "activePrimary": "var(--active-primary, #002d9c)",
-    "activeSecondary": "var(--active-secondary, #393939)",
-    "activeTertiary": "var(--active-tertiary, #c6c6c6)",
-    "activeUI": "var(--active-ui, #525252)",
-    "bodyLong01": "var(--body-long-01, [object Object])",
-    "bodyLong02": "var(--body-long-02, [object Object])",
-    "bodyShort01": "var(--body-short-01, [object Object])",
-    "bodyShort02": "var(--body-short-02, [object Object])",
-    "brand01": "var(--brand-01, #0f62fe)",
-    "brand02": "var(--brand-02, #6f6f6f)",
-    "brand03": "var(--brand-03, #ffffff)",
-    "caption01": "var(--caption-01, [object Object])",
-    "code01": "var(--code-01, [object Object])",
-    "code02": "var(--code-02, [object Object])",
-    "container01": "var(--container-01, 1.5rem)",
-    "container02": "var(--container-02, 2rem)",
-    "container03": "var(--container-03, 2.5rem)",
-    "container04": "var(--container-04, 3rem)",
-    "container05": "var(--container-05, 4rem)",
-    "danger": "var(--danger, #da1e28)",
-    "disabled01": "var(--disabled-01, #262626)",
-    "disabled02": "var(--disabled-02, #525252)",
-    "disabled03": "var(--disabled-03, #6f6f6f)",
-    "display01": "var(--display-01, [object Object])",
-    "display02": "var(--display-02, [object Object])",
-    "display03": "var(--display-03, [object Object])",
-    "display04": "var(--display-04, [object Object])",
-    "expressiveHeading01": "var(--expressive-heading-01, [object Object])",
-    "expressiveHeading02": "var(--expressive-heading-02, [object Object])",
-    "expressiveHeading03": "var(--expressive-heading-03, [object Object])",
-    "expressiveHeading04": "var(--expressive-heading-04, [object Object])",
-    "expressiveHeading05": "var(--expressive-heading-05, [object Object])",
-    "expressiveHeading06": "var(--expressive-heading-06, [object Object])",
-    "expressiveParagraph01": "var(--expressive-paragraph-01, [object Object])",
-    "field01": "var(--field-01, #262626)",
-    "field02": "var(--field-02, #393939)",
-    "fluidSpacing01": "var(--fluid-spacing-01, 0)",
-    "fluidSpacing02": "var(--fluid-spacing-02, 2vw)",
-    "fluidSpacing03": "var(--fluid-spacing-03, 5vw)",
-    "fluidSpacing04": "var(--fluid-spacing-04, 10vw)",
-    "focus": "var(--focus, #ffffff)",
-    "heading01": "var(--heading-01, [object Object])",
-    "heading02": "var(--heading-02, [object Object])",
-    "helperText01": "var(--helper-text-01, [object Object])",
-    "highlight": "var(--highlight, #002d9c)",
-    "hoverDanger": "var(--hover-danger, #b81921)",
-    "hoverField": "var(--hover-field, #353535)",
-    "hoverPrimary": "var(--hover-primary, #0353e9)",
-    "hoverPrimaryText": "var(--hover-primary-text, #a6c8ff)",
-    "hoverRow": "var(--hover-row, #353535)",
-    "hoverSecondary": "var(--hover-secondary, #606060)",
-    "hoverSelectedUI": "var(--hover-selected-ui, #4c4c4c)",
-    "hoverTertiary": "var(--hover-tertiary, #f4f4f4)",
-    "hoverUI": "var(--hover-ui, #353535)",
-    "icon01": "var(--icon-01, #f4f4f4)",
-    "icon02": "var(--icon-02, #c6c6c6)",
-    "icon03": "var(--icon-03, #ffffff)",
-    "iconSize01": "var(--icon-size-01, 1rem)",
-    "iconSize02": "var(--icon-size-02, 1.25rem)",
-    "interactive01": "var(--interactive-01, #0f62fe)",
-    "interactive02": "var(--interactive-02, #6f6f6f)",
-    "interactive03": "var(--interactive-03, #ffffff)",
-    "interactive04": "var(--interactive-04, #4589ff)",
-    "inverse01": "var(--inverse-01, #161616)",
-    "inverse02": "var(--inverse-02, #f4f4f4)",
-    "inverseFocusUi": "var(--inverse-focus-ui, #0f62fe)",
-    "inverseHoverUI": "var(--inverse-hover-ui, #e5e5e5)",
-    "inverseLink": "var(--inverse-link, #0f62fe)",
-    "inverseSupport01": "var(--inverse-support-01, #da1e28)",
-    "inverseSupport02": "var(--inverse-support-02, #24a148)",
-    "inverseSupport03": "var(--inverse-support-03, #f1c21b)",
-    "inverseSupport04": "var(--inverse-support-04, #0f62fe)",
-    "label01": "var(--label-01, [object Object])",
-    "layout01": "var(--layout-01, 1rem)",
-    "layout02": "var(--layout-02, 1.5rem)",
-    "layout03": "var(--layout-03, 2rem)",
-    "layout04": "var(--layout-04, 3rem)",
-    "layout05": "var(--layout-05, 4rem)",
-    "layout06": "var(--layout-06, 6rem)",
-    "layout07": "var(--layout-07, 10rem)",
-    "link01": "var(--link-01, #78a9ff)",
-    "overlay01": "var(--overlay-01, rgba(22, 22, 22, 0.7))",
-    "productiveHeading01": "var(--productive-heading-01, [object Object])",
-    "productiveHeading02": "var(--productive-heading-02, [object Object])",
-    "productiveHeading03": "var(--productive-heading-03, [object Object])",
-    "productiveHeading04": "var(--productive-heading-04, [object Object])",
-    "productiveHeading05": "var(--productive-heading-05, [object Object])",
-    "productiveHeading06": "var(--productive-heading-06, [object Object])",
-    "productiveHeading07": "var(--productive-heading-07, [object Object])",
-    "quotation01": "var(--quotation-01, [object Object])",
-    "quotation02": "var(--quotation-02, [object Object])",
-    "selectedUI": "var(--selected-ui, #393939)",
-    "skeleton01": "var(--skeleton-01, #353535)",
-    "skeleton02": "var(--skeleton-02, #393939)",
-    "spacing01": "var(--spacing-01, 0.125rem)",
-    "spacing02": "var(--spacing-02, 0.25rem)",
-    "spacing03": "var(--spacing-03, 0.5rem)",
-    "spacing04": "var(--spacing-04, 0.75rem)",
-    "spacing05": "var(--spacing-05, 1rem)",
-    "spacing06": "var(--spacing-06, 1.5rem)",
-    "spacing07": "var(--spacing-07, 2rem)",
-    "spacing08": "var(--spacing-08, 2.5rem)",
-    "spacing09": "var(--spacing-09, 3rem)",
-    "spacing10": "var(--spacing-10, 4rem)",
-    "spacing11": "var(--spacing-11, 5rem)",
-    "spacing12": "var(--spacing-12, 6rem)",
-    "support01": "var(--support-01, #fa4d56)",
-    "support02": "var(--support-02, #42be65)",
-    "support03": "var(--support-03, #f1c21b)",
-    "support04": "var(--support-04, #4589ff)",
-    "text01": "var(--text-01, #f4f4f4)",
-    "text02": "var(--text-02, #c6c6c6)",
-    "text03": "var(--text-03, #6f6f6f)",
-    "text04": "var(--text-04, #ffffff)",
-    "text05": "var(--text-05, #8d8d8d)",
-    "textError": "var(--text-error, #ff8389)",
-    "ui01": "var(--ui-01, #262626)",
-    "ui02": "var(--ui-02, #393939)",
-    "ui03": "var(--ui-03, #393939)",
-    "ui04": "var(--ui-04, #6f6f6f)",
-    "ui05": "var(--ui-05, #f4f4f4)",
-    "uiBackground": "var(--ui-background, #161616)",
-    "visitedLink": "var(--visited-link, #be95ff)",
-  },
-  "ErrorPage" => Object {
+  "Accordion" => Object {
     "defaultProps": Object {
-      "backgroundImage": "",
-      "className": "",
-      "errorMessage": "",
-      "errorName": "",
-      "labels": Object {},
-      "links": Array [],
-      "statusCode": null,
-      "title": "",
+      "align": "start",
     },
     "propTypes": Object {
-      "backgroundImage": Object {
+      "align": Object {
+        "args": Array [
+          Array [
+            "start",
+            "end",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "AccordionItem" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "onHeadingClick": Object {
+        "type": "func",
+      },
+      "open": Object {
+        "type": "bool",
+      },
+      "renderExpando": Object {
+        "type": "func",
+      },
+      "title": Object {
+        "type": "node",
+      },
+    },
+  },
+  "AccordionSkeleton" => Object {
+    "defaultProps": Object {
+      "align": "end",
+      "count": 4,
+      "open": true,
+    },
+    "propTypes": Object {
+      "align": Object {
+        "args": Array [
+          Array [
+            "start",
+            "end",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "count": Object {
+        "type": "number",
+      },
+      "open": Object {
+        "type": "bool",
+      },
+      "uid": [Function],
+    },
+  },
+  "Breadcrumb" => Object {
+    "propTypes": Object {
+      "aria-label": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "noTrailingSlash": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "BreadcrumbItem" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "isCurrentPage": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "BreadcrumbSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "Button" => Object {
+    "defaultProps": Object {
+      "disabled": false,
+      "kind": "primary",
+      "largeText": null,
+      "loading": false,
+      "renderIcon": undefined,
+      "tabIndex": 0,
+      "type": "button",
+    },
+    "propTypes": Object {
+      "as": Object {
         "args": Array [
           Array [
             Object {
+              "type": "func",
+            },
+            Object {
               "type": "string",
+            },
+            Object {
+              "type": "elementType",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "hasIconOnly": Object {
+        "type": "bool",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "iconDescription": [Function],
+      "kind": Object {
+        "args": Array [
+          Array [
+            "primary",
+            "secondary",
+            "danger",
+            "ghost",
+            "danger--primary",
+            "tertiary",
+            "ghost-danger",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "largeText": [Function],
+      "loading": Object {
+        "type": "bool",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
             },
             Object {
               "type": "object",
@@ -154,67 +193,78 @@ Map {
         ],
         "type": "oneOfType",
       },
+      "role": Object {
+        "type": "string",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "default",
+            "field",
+            "large",
+            "small",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "small": [Function],
+      "tabIndex": Object {
+        "type": "number",
+      },
+      "tooltipAlignment": Object {
+        "args": Array [
+          Array [
+            "start",
+            "center",
+            "end",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "tooltipPosition": Object {
+        "args": Array [
+          Array [
+            "top",
+            "right",
+            "bottom",
+            "left",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "type": Object {
+        "args": Array [
+          Array [
+            "button",
+            "reset",
+            "submit",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
+  "ButtonSkeleton" => Object {
+    "defaultProps": Object {
+      "small": false,
+    },
+    "propTypes": Object {
       "className": Object {
         "type": "string",
       },
-      "errorMessage": Object {
+      "href": Object {
         "type": "string",
       },
-      "errorName": Object {
-        "type": "string",
+      "small": Object {
+        "type": "bool",
       },
-      "labels": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Array [
-                Object {
-                  "type": "string",
-                },
-                Object {
-                  "type": "func",
-                },
-                Object {
-                  "type": "object",
-                },
-              ],
-            ],
-            "type": "oneOfType",
-          },
-        ],
-        "type": "objectOf",
-      },
-      "links": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "href": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "icon": Object {
-                  "type": "string",
-                },
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "text": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "statusCode": Object {
-        "type": "number",
-      },
-      "title": Object {
+    },
+  },
+  "CarbonHeader" => Object {
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "className": Object {
         "type": "string",
       },
     },
@@ -333,6 +383,84 @@ Map {
     },
     "propTypes": Object {
       "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "Checkbox" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "defaultProps": Object {
+      "indeterminate": false,
+      "onChange": [Function],
+    },
+    "displayName": "Checkbox",
+    "propTypes": Object {
+      "checked": Object {
+        "type": "bool",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "defaultChecked": Object {
+        "type": "bool",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "indeterminate": Object {
+        "type": "bool",
+      },
+      "labelText": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "title": Object {
+        "type": "string",
+      },
+      "wrapperClassName": Object {
+        "type": "string",
+      },
+    },
+    "render": [Function],
+  },
+  "CheckboxSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "ClickableTile" => Object {
+    "defaultProps": Object {
+      "clicked": false,
+      "handleClick": [Function],
+      "handleKeyDown": [Function],
+      "light": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "rel": Object {
         "type": "string",
       },
     },
@@ -693,6 +821,22 @@ Map {
       },
     },
   },
+  "Content" => Object {
+    "defaultProps": Object {
+      "tagName": "main",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "tagName": Object {
+        "type": "string",
+      },
+    },
+  },
   "ContentSwitcher" => Object {
     "defaultProps": Object {
       "selectedIndex": 0,
@@ -913,67 +1057,6 @@ Map {
       "subtitle": Object {
         "type": "node",
       },
-      "title": Object {
-        "type": "string",
-      },
-      "type": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "value": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-    },
-  },
-  "Decorator" => Object {
-    "defaultProps": Object {
-      "active": false,
-      "className": "",
-      "href": undefined,
-      "inert": false,
-      "inline": false,
-      "noIcon": false,
-      "onClick": [Function],
-      "score": undefined,
-      "scoreDescription": [Function],
-      "scoreThresholds": Array [
-        0,
-        4,
-        7,
-        10,
-      ],
-      "title": "",
-    },
-    "propTypes": Object {
-      "active": Object {
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "inert": Object {
-        "type": "bool",
-      },
-      "inline": Object {
-        "type": "bool",
-      },
-      "noIcon": Object {
-        "type": "bool",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "score": Object {
-        "type": "number",
-      },
-      "scoreDescription": Object {
-        "type": "func",
-      },
-      "scoreThresholds": [Function],
       "title": Object {
         "type": "string",
       },
@@ -1815,535 +1898,257 @@ Map {
       },
     },
   },
-  "Table" => Object {
+  "DatePicker" => Object {
     "defaultProps": Object {
-      "isSortable": false,
+      "dateFormat": "m/d/Y",
+      "light": false,
+      "locale": "en",
+      "short": false,
     },
     "propTypes": Object {
+      "appendTo": Object {
+        "type": "object",
+      },
+      "children": Object {
+        "type": "node",
+      },
       "className": Object {
         "type": "string",
       },
-      "isSortable": Object {
-        "type": "bool",
+      "dateFormat": Object {
+        "type": "string",
       },
-      "shouldShowBorder": Object {
-        "type": "bool",
-      },
-      "size": Object {
+      "datePickerType": Object {
         "args": Array [
           Array [
-            "compact",
-            "short",
-            "normal",
-            "tall",
+            "simple",
+            "single",
+            "range",
           ],
         ],
         "type": "oneOf",
       },
-      "stickyHeader": Object {
+      "light": Object {
         "type": "bool",
       },
-      "useStaticWidth": Object {
-        "type": "bool",
-      },
-      "useZebraStyles": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "TableBatchAction" => Object {
-    "defaultProps": Object {
-      "renderIcon": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "render": [Function],
-      },
-    },
-    "propTypes": Object {
-      "hasIconOnly": Object {
-        "type": "bool",
-      },
-      "iconDescription": [Function],
-      "renderIcon": Object {
+      "locale": Object {
         "args": Array [
           Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-    },
-  },
-  "TableBatchActions" => Object {
-    "defaultProps": Object {
-      "translateWithId": [Function],
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "onCancel": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-      "shouldShowBatchActions": Object {
-        "type": "bool",
-      },
-      "totalSelected": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-      "translateWithId": Object {
-        "type": "func",
-      },
-    },
-    "translationKeys": Array [
-      "carbon.table.batch.cancel",
-      "carbon.table.batch.items.selected",
-      "carbon.table.batch.item.selected",
-    ],
-  },
-  "TableBody" => Object {
-    "defaultProps": Object {
-      "aria-live": "polite",
-    },
-    "propTypes": Object {
-      "aria-live": Object {
-        "args": Array [
-          Array [
-            "polite",
-            "assertive",
-            "off",
+            "ar",
+            "at",
+            "be",
+            "bg",
+            "bn",
+            "cat",
+            "cs",
+            "cy",
+            "da",
+            "de",
+            "en",
+            "en",
+            "eo",
+            "es",
+            "et",
+            "fa",
+            "fi",
+            "fr",
+            "gr",
+            "he",
+            "hi",
+            "hr",
+            "hu",
+            "id",
+            "it",
+            "ja",
+            "ko",
+            "lt",
+            "lv",
+            "mk",
+            "mn",
+            "ms",
+            "my",
+            "nl",
+            "no",
+            "pa",
+            "pl",
+            "pt",
+            "ro",
+            "ru",
+            "si",
+            "sk",
+            "sl",
+            "sq",
+            "sr",
+            "sv",
+            "th",
+            "tr",
+            "uk",
+            "vn",
+            "zh",
           ],
         ],
         "type": "oneOf",
       },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
+      "maxDate": Object {
         "type": "string",
       },
-    },
-  },
-  "TableCell" => Object {
-    "displayName": "TableCell",
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TableContainer" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "description": Object {
-        "type": "node",
-      },
-      "title": Object {
-        "type": "node",
-      },
-    },
-  },
-  "TableExpandHeader" => Object {
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "expandIconDescription": Object {
-        "type": "string",
-      },
-      "isExpanded": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "onExpand": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-    },
-  },
-  "TableExpandRow" => Object {
-    "defaultProps": Object {
-      "expandHeader": "expand",
-    },
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "expandHeader": Object {
-        "type": "string",
-      },
-      "expandIconDescription": Object {
-        "type": "string",
-      },
-      "isExpanded": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "onExpand": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-    },
-  },
-  "TableExpandedRow" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "colSpan": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-    },
-  },
-  "TableHead" => Object {
-    "displayName": "TableHead",
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TableHeader" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {
-      "isSortable": false,
-      "scope": "col",
-      "translateWithId": [Function],
-    },
-    "displayName": "TableHeader",
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "colSpan": Object {
-        "type": "number",
-      },
-      "isSortHeader": Object {
-        "type": "bool",
-      },
-      "isSortable": Object {
-        "type": "bool",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "scope": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "sortDirection": Object {
-        "args": Array [
-          Array [
-            "NONE",
-            "DESC",
-            "ASC",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "translateWithId": Object {
-        "type": "func",
-      },
-    },
-    "render": [Function],
-    "translationKeys": Array [
-      "carbon.table.header.icon.description",
-    ],
-  },
-  "TableOverflowCell" => Object {
-    "defaultProps": undefined,
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TableRow" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TableSelectAll" => Object {
-    "defaultProps": Object {
-      "ariaLabel": "Select all rows in the table",
-    },
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "checked": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "indeterminate": Object {
-        "type": "bool",
-      },
-      "name": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "onSelect": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-    },
-  },
-  "TableSelectRow" => Object {
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "checked": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "name": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "onSelect": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-      "radio": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "TableToolbar" => Object {
-    "defaultProps": Object {
-      "aria-label": "data table toolbar",
-    },
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "children": Object {
-        "type": "node",
-      },
-    },
-  },
-  "TableToolbarAction" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "displayName": "TableToolbarAction",
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "onClick": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-    },
-    "render": [Function],
-  },
-  "TableToolbarContent" => Object {
-    "displayName": "TableToolbarContent",
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TableToolbarSearch" => Object {
-    "defaultProps": Object {
-      "persistent": false,
-      "tabIndex": "0",
-      "translateWithId": [Function],
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultValue": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "labelText": Object {
+      "minDate": Object {
         "type": "string",
       },
       "onChange": Object {
         "type": "func",
       },
-      "persistant": [Function],
-      "persistent": Object {
+      "onClose": Object {
+        "type": "func",
+      },
+      "short": Object {
         "type": "bool",
       },
-      "placeHolderText": Object {
-        "type": "string",
-      },
-      "searchContainerClasses": Object {
-        "type": "string",
-      },
-      "tabIndex": Object {
+      "value": Object {
         "args": Array [
           Array [
-            Object {
-              "type": "number",
-            },
             Object {
               "type": "string",
             },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "translateWithId": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-    },
-  },
-  "TableToolbarMenu" => Object {
-    "defaultProps": Object {
-      "iconDescription": "Settings",
-      "renderIcon": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "render": [Function],
-      },
-    },
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "iconDescription": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "renderIcon": Object {
-        "args": Array [
-          Array [
             Object {
-              "type": "func",
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Array [
+                      Object {
+                        "type": "string",
+                      },
+                      Object {
+                        "type": "number",
+                      },
+                      Object {
+                        "type": "object",
+                      },
+                    ],
+                  ],
+                  "type": "oneOfType",
+                },
+              ],
+              "type": "arrayOf",
             },
             Object {
               "type": "object",
             },
+            Object {
+              "type": "number",
+            },
           ],
         ],
         "type": "oneOfType",
       },
     },
   },
-  "TableToolbarDownload" => Object {
+  "DatePickerInput" => Object {
     "defaultProps": Object {
-      "filename": "DataTable",
-      "label": "Download",
+      "disabled": false,
+      "invalid": false,
+      "onChange": [Function],
+      "onClick": [Function],
+      "pattern": "\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}",
+      "type": "text",
+    },
+    "propTypes": Object {
+      "disabled": Object {
+        "type": "bool",
+      },
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "invalid": Object {
+        "type": "bool",
+      },
+      "labelText": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "pattern": [Function],
+      "type": Object {
+        "type": "string",
+      },
+    },
+  },
+  "DatePickerSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "range": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "Decorator" => Object {
+    "defaultProps": Object {
+      "active": false,
+      "className": "",
+      "href": undefined,
+      "inert": false,
+      "inline": false,
+      "noIcon": false,
+      "onClick": [Function],
+      "score": undefined,
+      "scoreDescription": [Function],
+      "scoreThresholds": Array [
+        0,
+        4,
+        7,
+        10,
+      ],
       "title": "",
     },
     "propTypes": Object {
-      "filename": Object {
+      "active": Object {
+        "type": "bool",
+      },
+      "className": Object {
         "type": "string",
       },
-      "headers": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "header": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "key": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
-        "isRequired": true,
-        "type": "arrayOf",
-      },
-      "label": Object {
+      "href": Object {
         "type": "string",
       },
-      "rows": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
-        "isRequired": true,
-        "type": "arrayOf",
+      "inert": Object {
+        "type": "bool",
       },
+      "inline": Object {
+        "type": "bool",
+      },
+      "noIcon": Object {
+        "type": "bool",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "score": Object {
+        "type": "number",
+      },
+      "scoreDescription": Object {
+        "type": "func",
+      },
+      "scoreThresholds": [Function],
       "title": Object {
+        "type": "string",
+      },
+      "type": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "value": Object {
+        "isRequired": true,
         "type": "string",
       },
     },
@@ -2375,6 +2180,389 @@ Map {
       },
     },
   },
+  "Dropdown" => Object {
+    "defaultProps": Object {
+      "disabled": false,
+      "helperText": "",
+      "itemToElement": null,
+      "itemToString": [Function],
+      "light": false,
+      "titleText": "",
+      "type": "default",
+    },
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "downshiftProps": Object {
+        "args": Array [
+          Object {
+            "breakingChanges": Object {
+              "args": Array [
+                Object {
+                  "resetInputOnSelection": Object {
+                    "type": "bool",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            "children": Object {
+              "type": "func",
+            },
+            "defaultHighlightedIndex": Object {
+              "type": "number",
+            },
+            "defaultInputValue": Object {
+              "type": "string",
+            },
+            "defaultIsOpen": Object {
+              "type": "bool",
+            },
+            "defaultSelectedItem": Object {
+              "type": "any",
+            },
+            "environment": Object {
+              "args": Array [
+                Object {
+                  "addEventListener": Object {
+                    "type": "func",
+                  },
+                  "document": Object {
+                    "args": Array [
+                      Object {
+                        "activeElement": Object {
+                          "type": "any",
+                        },
+                        "body": Object {
+                          "type": "any",
+                        },
+                        "getElementById": Object {
+                          "type": "func",
+                        },
+                      },
+                    ],
+                    "type": "shape",
+                  },
+                  "removeEventListener": Object {
+                    "type": "func",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            "getA11yStatusMessage": Object {
+              "type": "func",
+            },
+            "highlightedIndex": Object {
+              "type": "number",
+            },
+            "id": Object {
+              "type": "string",
+            },
+            "inputValue": Object {
+              "type": "string",
+            },
+            "isOpen": Object {
+              "type": "bool",
+            },
+            "itemCount": Object {
+              "type": "number",
+            },
+            "itemToString": Object {
+              "type": "func",
+            },
+            "onChange": Object {
+              "type": "func",
+            },
+            "onInputValueChange": Object {
+              "type": "func",
+            },
+            "onOuterClick": Object {
+              "type": "func",
+            },
+            "onSelect": Object {
+              "type": "func",
+            },
+            "onStateChange": Object {
+              "type": "func",
+            },
+            "onUserAction": Object {
+              "type": "func",
+            },
+            "render": Object {
+              "type": "func",
+            },
+            "selectedItem": Object {
+              "type": "any",
+            },
+            "selectedItemChanged": Object {
+              "type": "func",
+            },
+            "stateReducer": Object {
+              "type": "func",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "helperText": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "node",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "initialSelectedItem": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "object",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "inline": Object {
+        "type": "bool",
+      },
+      "invalid": Object {
+        "type": "bool",
+      },
+      "invalidText": Object {
+        "type": "string",
+      },
+      "itemToElement": Object {
+        "type": "func",
+      },
+      "itemToString": Object {
+        "type": "func",
+      },
+      "items": Object {
+        "isRequired": true,
+        "type": "array",
+      },
+      "label": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "selectedItem": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "object",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "sm",
+            "lg",
+            "xl",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "titleText": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "node",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "translateWithId": Object {
+        "type": "func",
+      },
+      "type": Object {
+        "args": Array [
+          Array [
+            "default",
+            "inline",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
+  "DropdownSkeleton" => Object {
+    "defaultProps": Object {
+      "inline": false,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "inline": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "ErrorPage" => Object {
+    "defaultProps": Object {
+      "backgroundImage": "",
+      "className": "",
+      "errorMessage": "",
+      "errorName": "",
+      "labels": Object {},
+      "links": Array [],
+      "statusCode": null,
+      "title": "",
+    },
+    "propTypes": Object {
+      "backgroundImage": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "errorMessage": Object {
+        "type": "string",
+      },
+      "errorName": Object {
+        "type": "string",
+      },
+      "labels": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Array [
+                Object {
+                  "type": "string",
+                },
+                Object {
+                  "type": "func",
+                },
+                Object {
+                  "type": "object",
+                },
+              ],
+            ],
+            "type": "oneOfType",
+          },
+        ],
+        "type": "objectOf",
+      },
+      "links": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "href": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "icon": Object {
+                  "type": "string",
+                },
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "text": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "statusCode": Object {
+        "type": "number",
+      },
+      "title": Object {
+        "type": "string",
+      },
+    },
+  },
+  "ExpandableTile" => Object {
+    "defaultProps": Object {
+      "expanded": false,
+      "handleClick": [Function],
+      "light": false,
+      "onBeforeClick": [Function],
+      "tabIndex": 0,
+      "tileCollapsedIconText": "Interact to expand Tile",
+      "tileExpandedIconText": "Interact to collapse Tile",
+      "tileMaxHeight": 0,
+      "tilePadding": 0,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "expanded": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "onBeforeClick": Object {
+        "type": "func",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+      "tileCollapsedIconText": Object {
+        "type": "string",
+      },
+      "tileExpandedIconText": Object {
+        "type": "string",
+      },
+    },
+  },
   "ExternalLink" => Object {
     "defaultProps": Object {
       "className": "",
@@ -2389,6 +2577,185 @@ Map {
       },
       "href": Object {
         "isRequired": true,
+        "type": "string",
+      },
+    },
+  },
+  "FileUploader" => Object {
+    "defaultProps": Object {
+      "accept": Array [],
+      "buttonKind": "primary",
+      "buttonLabel": "",
+      "filenameStatus": "uploading",
+      "iconDescription": "Provide icon description",
+      "multiple": false,
+      "onClick": [Function],
+    },
+    "propTypes": Object {
+      "accept": Object {
+        "args": Array [
+          Object {
+            "type": "string",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "buttonKind": Object {
+        "args": Array [
+          Array [
+            "primary",
+            "secondary",
+            "danger",
+            "ghost",
+            "danger--primary",
+            "tertiary",
+            "ghost-danger",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "buttonLabel": Object {
+        "type": "string",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "filenameStatus": Object {
+        "args": Array [
+          Array [
+            "edit",
+            "complete",
+            "uploading",
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOf",
+      },
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "labelDescription": Object {
+        "type": "string",
+      },
+      "labelTitle": Object {
+        "type": "string",
+      },
+      "multiple": Object {
+        "type": "bool",
+      },
+      "name": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+    },
+  },
+  "FileUploaderButton" => Object {
+    "defaultProps": Object {
+      "accept": Array [],
+      "buttonKind": "primary",
+      "disableLabelChanges": false,
+      "disabled": false,
+      "labelText": "Add file",
+      "multiple": false,
+      "onChange": [Function],
+      "onClick": [Function],
+      "role": "button",
+      "tabIndex": 0,
+    },
+    "propTypes": Object {
+      "accept": Object {
+        "args": Array [
+          Object {
+            "type": "string",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "buttonKind": Object {
+        "args": Array [
+          Array [
+            "primary",
+            "secondary",
+            "danger",
+            "ghost",
+            "danger--primary",
+            "tertiary",
+            "ghost-danger",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disableLabelChanges": Object {
+        "type": "bool",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "node",
+      },
+      "listFiles": Object {
+        "type": "bool",
+      },
+      "multiple": Object {
+        "type": "bool",
+      },
+      "name": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "role": Object {
+        "type": "string",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+    },
+  },
+  "FileUploaderSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "Filename" => Object {
+    "defaultProps": Object {
+      "iconDescription": "Uploading file",
+      "status": "uploading",
+      "tabIndex": "0",
+    },
+    "propTypes": Object {
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "status": Object {
+        "args": Array [
+          Array [
+            "edit",
+            "complete",
+            "uploading",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "tabIndex": Object {
         "type": "string",
       },
     },
@@ -2602,6 +2969,487 @@ Map {
       },
     },
   },
+  "Form" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "FormGroup" => Object {
+    "defaultProps": Object {
+      "invalid": false,
+      "message": false,
+      "messageText": "",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "invalid": Object {
+        "type": "bool",
+      },
+      "legendText": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "message": Object {
+        "type": "bool",
+      },
+      "messageText": Object {
+        "type": "string",
+      },
+    },
+  },
+  "FormItem" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "FormLabel" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+    },
+  },
+  "Header" => Object {
+    "defaultProps": Object {
+      "className": null,
+      "notifications": Array [],
+      "onNotificationClear": [Function],
+      "profile": null,
+      "renderLoginAndSignup": [Function],
+      "showEditProfile": true,
+      "showNotifications": true,
+      "totalNotifications": 0,
+    },
+    "propTypes": Object {
+      "accounts": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "name": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "labels": Object {
+        "args": Array [
+          Object {
+            "brand": Object {
+              "args": Array [
+                Object {
+                  "company": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "domain": Object {
+                    "type": "string",
+                  },
+                  "product": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+            "notifications": Object {
+              "args": Array [
+                Object {
+                  "button": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "clear": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "clear_all": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "link": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "preferences": Object {
+                    "type": "string",
+                  },
+                  "success": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "title": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "today": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "via": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+            "profile": Object {
+              "args": Array [
+                Object {
+                  "account": Object {
+                    "type": "string",
+                  },
+                  "edit_profile": Object {
+                    "type": "string",
+                  },
+                  "link": Object {
+                    "type": "string",
+                  },
+                  "registration": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "sign_in": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "sign_out": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+          },
+        ],
+        "isRequired": true,
+        "type": "shape",
+      },
+      "links": Object {
+        "args": Array [
+          Object {
+            "edit_profile": Object {
+              "type": "string",
+            },
+            "notifications_preferences": Object {
+              "type": "string",
+            },
+            "notifications_view_all": Object {
+              "type": "string",
+            },
+            "product": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+            "profile": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+            "registration": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+            "sign_in": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+            "sign_out": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+          },
+        ],
+        "isRequired": true,
+        "type": "shape",
+      },
+      "notifications": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "datetime": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "description": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "href": Object {
+                  "type": "string",
+                },
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "label": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "product": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+              },
+            ],
+            "isRequired": true,
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "onAccountClick": Object {
+        "type": "func",
+      },
+      "onNotificationClear": Object {
+        "type": "func",
+      },
+      "profile": Object {
+        "args": Array [
+          Object {
+            "account": Object {
+              "args": Array [
+                Object {
+                  "id": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "name": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            "email": Object {
+              "type": "string",
+            },
+            "image_url": Object {
+              "type": "string",
+            },
+            "name": Object {
+              "args": Array [
+                Object {
+                  "first_name": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "surname": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "renderLoginAndSignup": Object {
+        "type": "func",
+      },
+      "showEditProfile": Object {
+        "type": "bool",
+      },
+      "showNotifications": Object {
+        "type": "bool",
+      },
+      "totalNotifications": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+    },
+  },
+  "HeaderContainer" => Object {
+    "defaultProps": Object {
+      "isSideNavExpanded": false,
+    },
+    "propTypes": Object {
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "HeaderGlobalAction" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "HeaderGlobalAction",
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "isActive": Object {
+        "type": "bool",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+    },
+    "render": [Function],
+  },
+  "HeaderGlobalBar" => Object {
+    "displayName": "HeaderGlobalBar",
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "HeaderMenu" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "HeaderMenu",
+    "render": [Function],
+  },
+  "HeaderMenuButton" => Object {
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "className": Object {
+        "type": "string",
+      },
+      "isActive": Object {
+        "type": "bool",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+    },
+  },
+  "HeaderMenuItem" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "element": Object {
+        "type": "elementType",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+      "role": Object {
+        "type": "string",
+      },
+    },
+    "render": [Function],
+  },
+  "HeaderName" => Object {
+    "defaultProps": Object {
+      "prefix": "IBM",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "element": Object {
+        "type": "elementType",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+      "prefix": Object {
+        "type": "string",
+      },
+    },
+  },
+  "HeaderNavigation" => Object {
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "HeaderPanel" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "HeaderPanel",
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "className": Object {
+        "type": "string",
+      },
+      "expanded": Object {
+        "type": "bool",
+      },
+    },
+    "render": [Function],
+  },
+  "HeaderSideNavItems" => Object {
+    "defaultProps": Object {
+      "hasDivider": false,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "hasDivider": Object {
+        "type": "bool",
+      },
+    },
+  },
   "ICA" => Object {
     "defaultProps": Object {
       "className": "",
@@ -2728,6 +3576,100 @@ Map {
         "type": "string",
       },
       "width": [Function],
+    },
+  },
+  "IconButton" => Object {
+    "TooltipDirection": Object {
+      "BOTTOM": "bottom",
+      "LEFT": "left",
+      "RIGHT": "right",
+      "TOP": "top",
+    },
+    "defaultProps": Object {
+      "className": null,
+      "iconClassName": "",
+      "iconSize": 20,
+      "label": null,
+      "onClick": null,
+      "path": null,
+      "renderIcon": null,
+      "size": null,
+      "state": false,
+      "tooltip": true,
+      "tooltipDirection": "bottom",
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "iconClassName": Object {
+        "type": "string",
+      },
+      "iconSize": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "label": Object {
+        "type": "string",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "path": Object {
+        "type": "string",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "state": Object {
+        "type": "bool",
+      },
+      "tooltip": Object {
+        "type": "bool",
+      },
+      "tooltipDirection": Object {
+        "args": Array [
+          Array [
+            "top",
+            "right",
+            "bottom",
+            "left",
+          ],
+        ],
+        "type": "oneOf",
+      },
     },
   },
   "IconButtonBar" => Object {
@@ -2862,100 +3804,6 @@ Map {
       },
     },
   },
-  "IconButton" => Object {
-    "TooltipDirection": Object {
-      "BOTTOM": "bottom",
-      "LEFT": "left",
-      "RIGHT": "right",
-      "TOP": "top",
-    },
-    "defaultProps": Object {
-      "className": null,
-      "iconClassName": "",
-      "iconSize": 20,
-      "label": null,
-      "onClick": null,
-      "path": null,
-      "renderIcon": null,
-      "size": null,
-      "state": false,
-      "tooltip": true,
-      "tooltipDirection": "bottom",
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "iconClassName": Object {
-        "type": "string",
-      },
-      "iconSize": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "number",
-            },
-            Object {
-              "type": "string",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "label": Object {
-        "type": "string",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "path": Object {
-        "type": "string",
-      },
-      "renderIcon": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "size": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "number",
-            },
-            Object {
-              "type": "string",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "state": Object {
-        "type": "bool",
-      },
-      "tooltip": Object {
-        "type": "bool",
-      },
-      "tooltipDirection": Object {
-        "args": Array [
-          Array [
-            "top",
-            "right",
-            "bottom",
-            "left",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
   "InlineLoading" => Object {
     "defaultProps": Object {
       "successDelay": 1500,
@@ -2987,6 +3835,401 @@ Map {
       "success": [Function],
       "successDelay": Object {
         "type": "number",
+      },
+    },
+  },
+  "InlineNotification" => Object {
+    "defaultProps": Object {
+      "hideCloseButton": false,
+      "iconDescription": "closes notification",
+      "notificationType": "inline",
+      "onCloseButtonClick": [Function],
+      "role": "alert",
+    },
+    "propTypes": Object {
+      "actions": Object {
+        "type": "node",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "hideCloseButton": Object {
+        "type": "bool",
+      },
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "kind": Object {
+        "args": Array [
+          Array [
+            "error",
+            "info",
+            "success",
+            "warning",
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOf",
+      },
+      "lowContrast": Object {
+        "type": "bool",
+      },
+      "notificationType": Object {
+        "type": "string",
+      },
+      "onCloseButtonClick": Object {
+        "type": "func",
+      },
+      "role": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "statusIconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "subtitle": Object {
+        "type": "node",
+      },
+      "title": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+    },
+  },
+  "InteractiveTag" => Object {
+    "defaultProps": Object {
+      "isSelected": false,
+      "onRemove": null,
+      "removable": false,
+      "removeBtnLabel": "Remove",
+      "type": "gray",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "filter": Object {
+        "type": "bool",
+      },
+      "isSelected": Object {
+        "type": "bool",
+      },
+      "onRemove": Object {
+        "type": "func",
+      },
+      "removable": Object {
+        "type": "bool",
+      },
+      "removeBtnLabel": Object {
+        "type": "string",
+      },
+      "title": Object {
+        "type": "string",
+      },
+      "type": Object {
+        "args": Array [
+          Array [
+            "red",
+            "magenta",
+            "purple",
+            "blue",
+            "cyan",
+            "teal",
+            "green",
+            "gray",
+            "cool-gray",
+            "warm-gray",
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOf",
+      },
+    },
+  },
+  "Link" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "inline": Object {
+        "type": "bool",
+      },
+      "visited": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "ListItem" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "Loading" => Object {
+    "defaultProps": Object {
+      "active": true,
+      "description": "Active loading indicator",
+      "small": false,
+      "withOverlay": true,
+    },
+    "propTypes": Object {
+      "active": Object {
+        "type": "bool",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "description": Object {
+        "type": "string",
+      },
+      "small": Object {
+        "type": "bool",
+      },
+      "withOverlay": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "LoadingMessage" => Object {
+    "defaultProps": Object {
+      "active": true,
+      "children": null,
+      "className": "",
+      "small": false,
+      "withOverlay": true,
+    },
+    "propTypes": Object {
+      "active": Object {
+        "type": "bool",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "small": Object {
+        "type": "bool",
+      },
+      "withOverlay": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "Modal" => Object {
+    "defaultProps": Object {
+      "hasScrollingContent": false,
+      "iconDescription": "close the modal",
+      "modalHeading": "",
+      "modalLabel": "",
+      "onKeyDown": [Function],
+      "onRequestClose": [Function],
+      "onRequestSubmit": [Function],
+      "passiveModal": false,
+      "primaryButtonDisabled": false,
+      "selectorPrimaryFocus": "[data-modal-primary-focus]",
+    },
+    "propTypes": Object {
+      "aria-label": [Function],
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "danger": Object {
+        "type": "bool",
+      },
+      "focusTrap": [Function],
+      "hasForm": Object {
+        "type": "bool",
+      },
+      "hasScrollingContent": Object {
+        "type": "bool",
+      },
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "modalAriaLabel": Object {
+        "type": "string",
+      },
+      "modalHeading": Object {
+        "type": "node",
+      },
+      "modalLabel": Object {
+        "type": "node",
+      },
+      "onKeyDown": Object {
+        "type": "func",
+      },
+      "onRequestClose": Object {
+        "type": "func",
+      },
+      "onRequestSubmit": Object {
+        "type": "func",
+      },
+      "onSecondarySubmit": Object {
+        "type": "func",
+      },
+      "open": Object {
+        "type": "bool",
+      },
+      "passiveModal": Object {
+        "type": "bool",
+      },
+      "primaryButtonDisabled": Object {
+        "type": "bool",
+      },
+      "primaryButtonText": Object {
+        "type": "string",
+      },
+      "secondaryButtonText": Object {
+        "type": "string",
+      },
+      "selectorPrimaryFocus": Object {
+        "type": "string",
+      },
+      "selectorsFloatingMenus": Object {
+        "args": Array [
+          Object {
+            "type": "string",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "shouldSubmitOnEnter": Object {
+        "type": "bool",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "xs",
+            "sm",
+            "lg",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
+  "ModalWrapper" => Object {
+    "defaultProps": Object {
+      "disabled": false,
+      "onKeyDown": [Function],
+      "primaryButtonText": "Save",
+      "secondaryButtonText": "Cancel",
+      "selectorPrimaryFocus": "[data-modal-primary-focus]",
+      "triggerButtonIconDescription": "Provide icon description if icon is used",
+      "triggerButtonKind": "primary",
+    },
+    "propTypes": Object {
+      "buttonTriggerClassName": Object {
+        "type": "string",
+      },
+      "buttonTriggerText": Object {
+        "type": "node",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "handleOpen": Object {
+        "type": "func",
+      },
+      "handleSubmit": Object {
+        "type": "func",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "modalBeforeContent": Object {
+        "type": "bool",
+      },
+      "modalHeading": Object {
+        "type": "string",
+      },
+      "modalLabel": Object {
+        "type": "string",
+      },
+      "modalText": Object {
+        "type": "string",
+      },
+      "passiveModal": Object {
+        "type": "bool",
+      },
+      "primaryButtonText": Object {
+        "type": "string",
+      },
+      "renderTriggerButtonIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "secondaryButtonText": Object {
+        "type": "string",
+      },
+      "shouldCloseAfterSubmit": Object {
+        "type": "bool",
+      },
+      "status": Object {
+        "type": "string",
+      },
+      "triggerButtonIconDescription": Object {
+        "type": "string",
+      },
+      "triggerButtonKind": Object {
+        "args": Array [
+          Array [
+            "primary",
+            "secondary",
+            "danger",
+            "ghost",
+            "danger--primary",
+            "tertiary",
+            "ghost-danger",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "withHeader": Object {
+        "type": "bool",
       },
     },
   },
@@ -3407,6 +4650,136 @@ Map {
       },
     },
   },
+  "Nav" => Object {
+    "defaultProps": Object {
+      "activeHref": undefined,
+      "children": null,
+      "className": "",
+      "heading": null,
+    },
+    "propTypes": Object {
+      "activeHref": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "heading": Object {
+        "type": "string",
+      },
+      "label": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+    },
+  },
+  "NavItem" => Object {
+    "defaultProps": Object {
+      "activeHref": "#",
+      "children": null,
+      "className": "",
+      "current": null,
+      "disabled": false,
+      "element": "a",
+      "handleItemSelect": null,
+      "href": undefined,
+      "id": "security--nav__list__item",
+      "label": "",
+      "link": true,
+      "onClick": [Function],
+      "onKeyPress": [Function],
+      "tabIndex": 0,
+    },
+    "propTypes": Object {
+      "activeHref": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "current": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "element": Object {
+        "type": "elementType",
+      },
+      "handleItemSelect": Object {
+        "type": "func",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "label": Object {
+        "type": "string",
+      },
+      "link": Object {
+        "type": "bool",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "onKeyPress": Object {
+        "type": "func",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+    },
+  },
+  "NavList" => Object {
+    "defaultProps": Object {
+      "activeHref": "#",
+      "children": null,
+      "className": "",
+      "id": "",
+      "isExpandedOnPageload": false,
+      "onItemClick": [Function],
+      "onListClick": [Function],
+      "tabIndex": 0,
+      "title": "",
+    },
+    "propTypes": Object {
+      "activeHref": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "isExpandedOnPageload": Object {
+        "type": "bool",
+      },
+      "onItemClick": Object {
+        "type": "func",
+      },
+      "onListClick": Object {
+        "type": "func",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+      "title": Object {
+        "type": "string",
+      },
+    },
+  },
   "NonEntitledSection" => Object {
     "defaultProps": Object {
       "backgroundImage": null,
@@ -3461,69 +4834,6 @@ Map {
       },
     },
   },
-  "InlineNotification" => Object {
-    "defaultProps": Object {
-      "hideCloseButton": false,
-      "iconDescription": "closes notification",
-      "notificationType": "inline",
-      "onCloseButtonClick": [Function],
-      "role": "alert",
-    },
-    "propTypes": Object {
-      "actions": Object {
-        "type": "node",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "hideCloseButton": Object {
-        "type": "bool",
-      },
-      "iconDescription": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "kind": Object {
-        "args": Array [
-          Array [
-            "error",
-            "info",
-            "success",
-            "warning",
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOf",
-      },
-      "lowContrast": Object {
-        "type": "bool",
-      },
-      "notificationType": Object {
-        "type": "string",
-      },
-      "onCloseButtonClick": Object {
-        "type": "func",
-      },
-      "role": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "statusIconDescription": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "subtitle": Object {
-        "type": "node",
-      },
-      "title": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-    },
-  },
   "NotificationActionButton" => Object {
     "propTypes": Object {
       "children": Object {
@@ -3537,17 +4847,62 @@ Map {
       },
     },
   },
-  "ToastNotification" => Object {
+  "NotificationButton" => Object {
     "defaultProps": Object {
-      "caption": "provide a caption",
-      "hideCloseButton": false,
-      "iconDescription": "closes notification",
-      "kind": "error",
+      "ariaLabel": "close notification",
+      "iconDescription": "close icon",
       "notificationType": "toast",
-      "onCloseButtonClick": [Function],
-      "role": "alert",
-      "timeout": 0,
-      "title": "provide a title",
+      "renderIcon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
+      "type": "button",
+    },
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "type": "string",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "name": Object {
+        "type": "string",
+      },
+      "notificationType": Object {
+        "args": Array [
+          Array [
+            "toast",
+            "inline",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "type": Object {
+        "type": "string",
+      },
+    },
+  },
+  "NotificationTextDetails" => Object {
+    "defaultProps": Object {
+      "caption": "caption",
+      "notificationType": "toast",
+      "title": "title",
     },
     "propTypes": Object {
       "caption": Object {
@@ -3556,53 +4911,19 @@ Map {
       "children": Object {
         "type": "node",
       },
-      "className": Object {
-        "type": "string",
-      },
-      "hideCloseButton": Object {
-        "type": "bool",
-      },
-      "iconDescription": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "kind": Object {
+      "notificationType": Object {
         "args": Array [
           Array [
-            "error",
-            "info",
-            "success",
-            "warning",
+            "toast",
+            "inline",
           ],
         ],
-        "isRequired": true,
         "type": "oneOf",
-      },
-      "lowContrast": Object {
-        "type": "bool",
-      },
-      "notificationType": Object {
-        "type": "string",
-      },
-      "onCloseButtonClick": Object {
-        "type": "func",
-      },
-      "role": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "statusIconDescription": Object {
-        "isRequired": true,
-        "type": "string",
       },
       "subtitle": Object {
         "type": "node",
       },
-      "timeout": Object {
-        "type": "number",
-      },
       "title": Object {
-        "isRequired": true,
         "type": "string",
       },
     },
@@ -3618,6 +4939,132 @@ Map {
       },
       "hideLabel": Object {
         "type": "bool",
+      },
+    },
+  },
+  "OrderedList" => Object {
+    "defaultProps": Object {
+      "nested": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "nested": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "OverflowMenu" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "render": [Function],
+  },
+  "OverflowMenuItem" => Object {
+    "defaultProps": Object {
+      "disabled": false,
+      "hasDivider": false,
+      "isDelete": false,
+      "itemText": "Provide itemText",
+      "onClick": [Function],
+      "onKeyDown": [Function],
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "closeMenu": Object {
+        "type": "func",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "hasDivider": Object {
+        "type": "bool",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "isDelete": Object {
+        "type": "bool",
+      },
+      "itemText": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "onFocus": Object {
+        "type": "func",
+      },
+      "onKeyDown": Object {
+        "type": "func",
+      },
+      "onKeyUp": Object {
+        "type": "func",
+      },
+      "onMouseDown": Object {
+        "type": "func",
+      },
+      "onMouseEnter": Object {
+        "type": "func",
+      },
+      "onMouseLeave": Object {
+        "type": "func",
+      },
+      "onMouseUp": Object {
+        "type": "func",
+      },
+      "primaryFocus": Object {
+        "type": "bool",
+      },
+      "requireTitle": Object {
+        "type": "bool",
+      },
+      "wrapperClassName": Object {
+        "type": "string",
+      },
+    },
+  },
+  "PageSelector" => Object {
+    "defaultProps": Object {
+      "className": null,
+      "id": 1,
+      "labelText": "Current page number",
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "currentPage": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+      "id": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "labelText": Object {
+        "type": "string",
+      },
+      "totalPages": Object {
+        "isRequired": true,
+        "type": "number",
       },
     },
   },
@@ -4203,6 +5650,47 @@ Map {
       },
     },
   },
+  "ProfileImage" => Object {
+    "defaultProps": Object {
+      "className": null,
+      "large": false,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "large": Object {
+        "type": "bool",
+      },
+      "profile": Object {
+        "args": Array [
+          Object {
+            "image_url": Object {
+              "type": "string",
+            },
+            "name": Object {
+              "args": Array [
+                Object {
+                  "first_name": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "surname": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+          },
+        ],
+        "isRequired": true,
+        "type": "shape",
+      },
+    },
+  },
   "ProgressIndicator" => Object {
     "defaultProps": Object {
       "currentIndex": 0,
@@ -4222,6 +5710,13 @@ Map {
       },
       "vertical": Object {
         "type": "bool",
+      },
+    },
+  },
+  "ProgressIndicatorSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
       },
     },
   },
@@ -4276,9 +5771,200 @@ Map {
       },
     },
   },
-  "ProgressIndicatorSkeleton" => Object {
+  "RadioButton" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "render": [Function],
+  },
+  "RadioButtonGroup" => Object {
+    "defaultProps": Object {
+      "labelPosition": "right",
+      "onChange": [Function],
+      "orientation": "horizontal",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "defaultSelected": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "labelPosition": Object {
+        "args": Array [
+          Array [
+            "left",
+            "right",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "name": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "orientation": Object {
+        "args": Array [
+          Array [
+            "horizontal",
+            "vertical",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "valueSelected": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+    },
+  },
+  "RadioButtonSkeleton" => Object {
     "propTypes": Object {
       "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "RadioTile" => Object {
+    "defaultProps": Object {
+      "light": false,
+      "onChange": [Function],
+      "tabIndex": 0,
+    },
+    "propTypes": Object {
+      "checked": Object {
+        "type": "bool",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "defaultChecked": Object {
+        "type": "bool",
+      },
+      "iconDescription": [Function],
+      "id": Object {
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "name": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+      "value": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOfType",
+      },
+    },
+  },
+  "ScrollGradient" => Object {
+    "ScrollDirection": Object {
+      "X": "X",
+      "Y": "Y",
+    },
+    "ScrollStates": Object {
+      "END": "END",
+      "INITIAL": "INITIAL",
+      "NONE": "NONE",
+      "STARTED": "STARTED",
+    },
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+      "direction": "Y",
+      "getScrollElementRef": [Function],
+      "hideStartGradient": false,
+      "onScroll": [Function],
+      "scrollElementClassName": undefined,
+    },
+    "getScrollState": Object {},
+    "propTypes": Object {
+      "children": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "node",
+            },
+            Object {
+              "args": Array [
+                Object {
+                  "type": "node",
+                },
+              ],
+              "type": "arrayOf",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "color": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "direction": Object {
+        "args": Array [
+          Array [
+            "X",
+            "Y",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "getScrollElementRef": Object {
+        "type": "func",
+      },
+      "hideStartGradient": Object {
+        "type": "bool",
+      },
+      "onScroll": Object {
+        "type": "func",
+      },
+      "scrollElementClassName": Object {
         "type": "string",
       },
     },
@@ -4349,63 +6035,6 @@ Map {
           ],
         ],
         "type": "oneOfType",
-      },
-    },
-  },
-  "SearchSkeleton" => Object {
-    "defaultProps": Object {
-      "small": false,
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "small": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "SearchFilterButton" => Object {
-    "defaultProps": Object {
-      "iconDescription": "filter",
-      "labelText": "Search",
-    },
-    "propTypes": Object {
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "string",
-      },
-    },
-  },
-  "SearchLayoutButton" => Object {
-    "defaultProps": Object {
-      "iconDescriptionGrid": "grid",
-      "iconDescriptionList": "list",
-      "labelText": "Filter",
-    },
-    "propTypes": Object {
-      "format": Object {
-        "args": Array [
-          Array [
-            "list",
-            "grid",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "iconDescriptionGrid": Object {
-        "type": "string",
-      },
-      "iconDescriptionList": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "string",
-      },
-      "onChangeFormat": Object {
-        "type": "func",
       },
     },
   },
@@ -4493,6 +6122,1361 @@ Map {
       },
     },
   },
+  "SearchFilterButton" => Object {
+    "defaultProps": Object {
+      "iconDescription": "filter",
+      "labelText": "Search",
+    },
+    "propTypes": Object {
+      "iconDescription": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "string",
+      },
+    },
+  },
+  "SearchLayoutButton" => Object {
+    "defaultProps": Object {
+      "iconDescriptionGrid": "grid",
+      "iconDescriptionList": "list",
+      "labelText": "Filter",
+    },
+    "propTypes": Object {
+      "format": Object {
+        "args": Array [
+          Array [
+            "list",
+            "grid",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "iconDescriptionGrid": Object {
+        "type": "string",
+      },
+      "iconDescriptionList": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "string",
+      },
+      "onChangeFormat": Object {
+        "type": "func",
+      },
+    },
+  },
+  "SearchSkeleton" => Object {
+    "defaultProps": Object {
+      "small": false,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "small": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "Select" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "defaultProps": Object {
+      "disabled": false,
+      "helperText": "",
+      "inline": false,
+      "invalid": false,
+      "invalidText": "",
+      "labelText": "Select",
+      "light": false,
+      "size": "",
+    },
+    "displayName": "Select",
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "defaultValue": Object {
+        "type": "any",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "helperText": Object {
+        "type": "node",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+      "iconDescription": [Function],
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "inline": Object {
+        "type": "bool",
+      },
+      "invalid": Object {
+        "type": "bool",
+      },
+      "invalidText": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "node",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "noLabel": Object {
+        "type": "bool",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "sm",
+            "xl",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+    "render": [Function],
+  },
+  "SelectItem" => Object {
+    "defaultProps": Object {
+      "disabled": false,
+      "hidden": false,
+      "text": "",
+      "value": "",
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "hidden": Object {
+        "type": "bool",
+      },
+      "text": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "value": Object {
+        "isRequired": true,
+        "type": "any",
+      },
+    },
+  },
+  "SelectItemGroup" => Object {
+    "defaultProps": Object {
+      "disabled": false,
+      "label": "Provide label",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "label": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+    },
+  },
+  "SelectSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "SelectableTile" => Object {
+    "defaultProps": Object {
+      "handleClick": [Function],
+      "handleKeyDown": [Function],
+      "light": false,
+      "onChange": [Function],
+      "selected": false,
+      "tabIndex": 0,
+      "title": "title",
+      "value": "value",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "iconDescription": [Function],
+      "id": Object {
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "name": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "selected": Object {
+        "type": "bool",
+      },
+      "tabIndex": Object {
+        "type": "number",
+      },
+      "title": Object {
+        "type": "string",
+      },
+      "value": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOfType",
+      },
+    },
+  },
+  "Shell" => Object {
+    "defaultProps": Object {
+      "header": Object {
+        "className": null,
+        "notifications": Array [],
+        "onNotificationClear": [Function],
+        "profile": null,
+        "renderLoginAndSignup": [Function],
+        "showEditProfile": true,
+        "showNotifications": true,
+        "totalNotifications": 0,
+      },
+      "profile": null,
+      "renderAddons": Array [],
+      "returnToBanner": null,
+      "skipToContent": null,
+      "toolbar": Object {},
+    },
+    "propTypes": Object {
+      "header": Object {
+        "args": Array [
+          Object {
+            "accounts": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "id": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "name": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
+            "className": Object {
+              "type": "string",
+            },
+            "labels": Object {
+              "args": Array [
+                Object {
+                  "brand": Object {
+                    "args": Array [
+                      Object {
+                        "company": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "domain": Object {
+                          "type": "string",
+                        },
+                        "product": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                  "notifications": Object {
+                    "args": Array [
+                      Object {
+                        "button": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "clear": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "clear_all": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "link": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "preferences": Object {
+                          "type": "string",
+                        },
+                        "success": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "title": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "today": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "via": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                  "profile": Object {
+                    "args": Array [
+                      Object {
+                        "account": Object {
+                          "type": "string",
+                        },
+                        "edit_profile": Object {
+                          "type": "string",
+                        },
+                        "link": Object {
+                          "type": "string",
+                        },
+                        "registration": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "sign_in": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "sign_out": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+            "links": Object {
+              "args": Array [
+                Object {
+                  "edit_profile": Object {
+                    "type": "string",
+                  },
+                  "notifications_preferences": Object {
+                    "type": "string",
+                  },
+                  "notifications_view_all": Object {
+                    "type": "string",
+                  },
+                  "product": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "profile": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "registration": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "sign_in": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "sign_out": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+            "notifications": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "datetime": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "description": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "href": Object {
+                        "type": "string",
+                      },
+                      "id": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "label": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "product": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "isRequired": true,
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
+            "onAccountClick": Object {
+              "type": "func",
+            },
+            "onNotificationClear": Object {
+              "type": "func",
+            },
+            "profile": Object {
+              "args": Array [
+                Object {
+                  "account": Object {
+                    "args": Array [
+                      Object {
+                        "id": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "name": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "type": "shape",
+                  },
+                  "email": Object {
+                    "type": "string",
+                  },
+                  "image_url": Object {
+                    "type": "string",
+                  },
+                  "name": Object {
+                    "args": Array [
+                      Object {
+                        "first_name": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "surname": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            "renderLoginAndSignup": Object {
+              "type": "func",
+            },
+            "showEditProfile": Object {
+              "type": "bool",
+            },
+            "showNotifications": Object {
+              "type": "bool",
+            },
+            "totalNotifications": Object {
+              "isRequired": true,
+              "type": "number",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "profile": Object {
+        "args": Array [
+          Object {
+            "account": Object {
+              "args": Array [
+                Object {
+                  "id": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "name": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            "email": Object {
+              "type": "string",
+            },
+            "image_url": Object {
+              "type": "string",
+            },
+            "name": Object {
+              "args": Array [
+                Object {
+                  "first_name": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                  "surname": Object {
+                    "isRequired": true,
+                    "type": "string",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "renderAddons": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "render": Object {
+                  "isRequired": true,
+                  "type": "func",
+                },
+                "tooltip": Object {
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
+      },
+      "returnToBanner": Object {
+        "args": Array [
+          Object {
+            "application": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+            "href": Object {
+              "isRequired": true,
+              "type": "string",
+            },
+            "view": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "skipToContent": Object {
+        "args": Array [
+          Object {
+            "href": Object {
+              "type": "string",
+            },
+            "label": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+      "toolbar": Object {
+        "args": Array [
+          Object {
+            "className": Object {
+              "type": "string",
+            },
+            "labels": Object {
+              "args": Array [
+                Object {
+                  "menu": Object {
+                    "args": Array [
+                      Object {
+                        "button": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "tooltip": Object {
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                  "settings": Object {
+                    "args": Array [
+                      Object {
+                        "button": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "tooltip": Object {
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                  "support": Object {
+                    "args": Array [
+                      Object {
+                        "button": Object {
+                          "isRequired": true,
+                          "type": "string",
+                        },
+                        "tooltip": Object {
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "isRequired": true,
+                    "type": "shape",
+                  },
+                },
+              ],
+              "isRequired": true,
+              "type": "shape",
+            },
+            "menu": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "content": Object {
+                        "type": "node",
+                      },
+                      "icon": Object {
+                        "type": "string",
+                      },
+                      "id": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "navigation": Object {
+                        "args": Array [
+                          Object {
+                            "args": Array [
+                              Object {
+                                "children": Object {
+                                  "args": Array [
+                                    Object {
+                                      "args": Array [
+                                        Object {
+                                          "content": Object {
+                                            "type": "node",
+                                          },
+                                          "icon": Object {
+                                            "type": "string",
+                                          },
+                                          "id": Object {
+                                            "isRequired": true,
+                                            "type": "string",
+                                          },
+                                          "isRequired": true,
+                                          "title": Object {
+                                            "isRequired": true,
+                                            "type": "string",
+                                          },
+                                          "type": "string",
+                                        },
+                                      ],
+                                      "type": "shape",
+                                    },
+                                  ],
+                                  "type": "arrayOf",
+                                },
+                                "content": Object {
+                                  "type": "node",
+                                },
+                                "href": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                                "icon": Object {
+                                  "type": "string",
+                                },
+                                "id": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                                "title": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                              },
+                            ],
+                            "type": "shape",
+                          },
+                        ],
+                        "isRequired": true,
+                        "type": "arrayOf",
+                      },
+                      "title": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "isRequired": true,
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
+            "onToggle": Object {
+              "type": "func",
+            },
+            "renderAddons": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "id": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "render": Object {
+                        "isRequired": true,
+                        "type": "func",
+                      },
+                      "tooltip": Object {
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
+            "settings": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "content": Object {
+                        "type": "node",
+                      },
+                      "icon": Object {
+                        "type": "string",
+                      },
+                      "id": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "navigation": Object {
+                        "args": Array [
+                          Object {
+                            "args": Array [
+                              Object {
+                                "children": Object {
+                                  "args": Array [
+                                    Object {
+                                      "args": Array [
+                                        Object {
+                                          "content": Object {
+                                            "type": "node",
+                                          },
+                                          "icon": Object {
+                                            "type": "string",
+                                          },
+                                          "id": Object {
+                                            "isRequired": true,
+                                            "type": "string",
+                                          },
+                                          "isRequired": true,
+                                          "title": Object {
+                                            "isRequired": true,
+                                            "type": "string",
+                                          },
+                                          "type": "string",
+                                        },
+                                      ],
+                                      "type": "shape",
+                                    },
+                                  ],
+                                  "type": "arrayOf",
+                                },
+                                "content": Object {
+                                  "type": "node",
+                                },
+                                "href": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                                "icon": Object {
+                                  "type": "string",
+                                },
+                                "id": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                                "title": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                              },
+                            ],
+                            "type": "shape",
+                          },
+                        ],
+                        "isRequired": true,
+                        "type": "arrayOf",
+                      },
+                      "title": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "isRequired": true,
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
+            "support": Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "content": Object {
+                        "type": "node",
+                      },
+                      "icon": Object {
+                        "type": "string",
+                      },
+                      "id": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                      "navigation": Object {
+                        "args": Array [
+                          Object {
+                            "args": Array [
+                              Object {
+                                "children": Object {
+                                  "args": Array [
+                                    Object {
+                                      "args": Array [
+                                        Object {
+                                          "content": Object {
+                                            "type": "node",
+                                          },
+                                          "icon": Object {
+                                            "type": "string",
+                                          },
+                                          "id": Object {
+                                            "isRequired": true,
+                                            "type": "string",
+                                          },
+                                          "isRequired": true,
+                                          "title": Object {
+                                            "isRequired": true,
+                                            "type": "string",
+                                          },
+                                          "type": "string",
+                                        },
+                                      ],
+                                      "type": "shape",
+                                    },
+                                  ],
+                                  "type": "arrayOf",
+                                },
+                                "content": Object {
+                                  "type": "node",
+                                },
+                                "href": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                                "icon": Object {
+                                  "type": "string",
+                                },
+                                "id": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                                "title": Object {
+                                  "isRequired": true,
+                                  "type": "string",
+                                },
+                              },
+                            ],
+                            "type": "shape",
+                          },
+                        ],
+                        "isRequired": true,
+                        "type": "arrayOf",
+                      },
+                      "title": Object {
+                        "isRequired": true,
+                        "type": "string",
+                      },
+                    },
+                  ],
+                  "isRequired": true,
+                  "type": "shape",
+                },
+              ],
+              "type": "arrayOf",
+            },
+          },
+        ],
+        "type": "shape",
+      },
+    },
+  },
+  "SideNav" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "defaultProps": Object {
+      "addFocusListeners": true,
+      "addMouseListeners": true,
+      "defaultExpanded": false,
+      "isChildOfHeader": true,
+      "isFixedNav": false,
+      "isPersistent": true,
+      "translateById": [Function],
+    },
+    "propTypes": Object {
+      "addFocusListeners": Object {
+        "type": "bool",
+      },
+      "addMouseListeners": Object {
+        "type": "bool",
+      },
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "className": Object {
+        "type": "string",
+      },
+      "defaultExpanded": Object {
+        "type": "bool",
+      },
+      "expanded": Object {
+        "type": "bool",
+      },
+      "isChildOfHeader": Object {
+        "type": "bool",
+      },
+      "isFixedNav": Object {
+        "type": "bool",
+      },
+      "isPersistent": Object {
+        "type": "bool",
+      },
+      "isRail": Object {
+        "type": "bool",
+      },
+      "onToggle": Object {
+        "type": "func",
+      },
+      "translateById": Object {
+        "type": "func",
+      },
+    },
+    "render": [Function],
+  },
+  "SideNavDetails" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "title": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+    },
+  },
+  "SideNavFooter" => Object {
+    "defaultProps": Object {
+      "assistiveText": "Toggle opening or closing the side navigation",
+    },
+    "propTypes": Object {
+      "assistiveText": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "expanded": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+      "onToggle": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+    },
+  },
+  "SideNavHeader" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOfType",
+      },
+    },
+  },
+  "SideNavIcon" => Object {
+    "defaultProps": Object {
+      "small": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "small": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+    },
+  },
+  "SideNavItem" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "large": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "SideNavItems" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "SideNavLink" => Object {
+    "defaultProps": Object {
+      "element": "a",
+      "large": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "element": Object {
+        "type": "elementType",
+      },
+      "isSideNavExpanded": Object {
+        "type": "bool",
+      },
+      "large": Object {
+        "type": "bool",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+    },
+  },
+  "SideNavLinkText" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "SideNavMenu" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "SideNavMenu",
+    "render": [Function],
+  },
+  "SideNavMenuItem" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "isActive": Object {
+        "type": "bool",
+      },
+    },
+    "render": [Function],
+  },
+  "SideNavSwitcher" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "options": Object {
+        "args": Array [
+          Object {
+            "type": "string",
+          },
+        ],
+        "isRequired": true,
+        "type": "arrayOf",
+      },
+    },
+    "render": [Function],
+  },
+  "SkeletonText" => Object {
+    "defaultProps": Object {
+      "heading": false,
+      "lineCount": 3,
+      "paragraph": false,
+      "width": "100%",
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "heading": Object {
+        "type": "bool",
+      },
+      "lineCount": Object {
+        "type": "number",
+      },
+      "paragraph": Object {
+        "type": "bool",
+      },
+      "width": Object {
+        "type": "string",
+      },
+    },
+  },
+  "SkipToContent" => Object {
+    "defaultProps": Object {
+      "children": "Skip to main content",
+      "href": "#main-content",
+      "tabIndex": "0",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "href": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "tabIndex": Object {
+        "type": "string",
+      },
+    },
+  },
+  "Slider" => Object {
+    "defaultProps": Object {
+      "ariaLabelInput": "Slider number input",
+      "disabled": false,
+      "hideTextInput": false,
+      "inputType": "number",
+      "light": false,
+      "maxLabel": "",
+      "minLabel": "",
+      "step": 1,
+      "stepMultiplier": 4,
+    },
+    "propTypes": Object {
+      "ariaLabelInput": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "formatLabel": Object {
+        "type": "func",
+      },
+      "hideTextInput": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "inputType": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "node",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "max": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+      "maxLabel": Object {
+        "type": "string",
+      },
+      "min": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+      "minLabel": Object {
+        "type": "string",
+      },
+      "name": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onRelease": Object {
+        "type": "func",
+      },
+      "step": Object {
+        "type": "number",
+      },
+      "stepMuliplier": [Function],
+      "stepMultiplier": Object {
+        "type": "number",
+      },
+      "value": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+    },
+  },
+  "SliderSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+    },
+  },
   "StackedNotification" => Object {
     "defaultProps": Object {
       "caption": "",
@@ -4574,40 +7558,6 @@ Map {
       },
     },
   },
-  "StatusStep" => Object {
-    "defaultProps": Object {
-      "className": "",
-      "errorMsg": null,
-      "status": "incomplete",
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "description": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "errorMsg": Object {
-        "type": "string",
-      },
-      "label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "status": Object {
-        "args": Array [
-          Array [
-            "complete",
-            "current",
-            "incomplete",
-            "failed",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
   "StatusIndicator" => Object {
     "defaultProps": Object {
       "children": null,
@@ -4654,6 +7604,40 @@ Map {
       },
       "title": Object {
         "type": "string",
+      },
+    },
+  },
+  "StatusStep" => Object {
+    "defaultProps": Object {
+      "className": "",
+      "errorMsg": null,
+      "status": "incomplete",
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "description": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "errorMsg": Object {
+        "type": "string",
+      },
+      "label": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "status": Object {
+        "args": Array [
+          Array [
+            "complete",
+            "current",
+            "incomplete",
+            "failed",
+          ],
+        ],
+        "type": "oneOf",
       },
     },
   },
@@ -4741,23 +7725,81 @@ Map {
       },
     },
   },
-  "Switch" => Object {
-    "$$typeof": Symbol(react.forward_ref),
+  "StructuredListBody" => Object {
     "defaultProps": Object {
-      "onClick": [Function],
       "onKeyDown": [Function],
-      "selected": false,
-      "text": "Provide text",
     },
-    "displayName": "Switch",
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "head": Object {
+        "type": "bool",
+      },
+      "onKeyDown": Object {
+        "type": "func",
+      },
+    },
+  },
+  "StructuredListCell" => Object {
+    "defaultProps": Object {
+      "head": false,
+      "noWrap": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "head": Object {
+        "type": "bool",
+      },
+      "noWrap": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "StructuredListHead" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "StructuredListInput" => Object {
+    "defaultProps": Object {
+      "onChange": [Function],
+      "title": "title",
+      "value": "value",
+    },
     "propTypes": Object {
       "className": Object {
         "type": "string",
       },
-      "index": Object {
-        "type": "number",
+      "defaultChecked": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "type": "string",
       },
       "name": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "title": Object {
+        "type": "string",
+      },
+      "value": Object {
         "args": Array [
           Array [
             Object {
@@ -4768,23 +7810,79 @@ Map {
             },
           ],
         ],
+        "isRequired": true,
         "type": "oneOfType",
       },
-      "onClick": Object {
-        "type": "func",
+    },
+  },
+  "StructuredListRow" => Object {
+    "defaultProps": Object {
+      "head": false,
+      "label": false,
+      "onKeyDown": [Function],
+      "tabIndex": 0,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "head": Object {
+        "type": "bool",
+      },
+      "label": Object {
+        "type": "bool",
       },
       "onKeyDown": Object {
         "type": "func",
       },
-      "selected": Object {
-        "type": "bool",
-      },
-      "text": Object {
-        "isRequired": true,
-        "type": "string",
+      "tabIndex": Object {
+        "type": "number",
       },
     },
-    "render": [Function],
+  },
+  "StructuredListSkeleton" => Object {
+    "defaultProps": Object {
+      "border": false,
+      "rowCount": 5,
+    },
+    "propTypes": Object {
+      "border": Object {
+        "type": "bool",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "rowCount": Object {
+        "type": "number",
+      },
+    },
+  },
+  "StructuredListWrapper" => Object {
+    "defaultProps": Object {
+      "ariaLabel": "Structured list section",
+      "border": false,
+      "selection": false,
+    },
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "type": "string",
+      },
+      "border": Object {
+        "type": "bool",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "selection": Object {
+        "type": "bool",
+      },
+    },
   },
   "SummaryCard" => Object {
     "defaultProps": Object {
@@ -4976,6 +8074,769 @@ Map {
     },
   },
   "SummaryCardSkeleton" => Object {},
+  "Switch" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "defaultProps": Object {
+      "onClick": [Function],
+      "onKeyDown": [Function],
+      "selected": false,
+      "text": "Provide text",
+    },
+    "displayName": "Switch",
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "index": Object {
+        "type": "number",
+      },
+      "name": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "onKeyDown": Object {
+        "type": "func",
+      },
+      "selected": Object {
+        "type": "bool",
+      },
+      "text": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+    },
+    "render": [Function],
+  },
+  "Switcher" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+    "render": [Function],
+  },
+  "SwitcherDivider" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "SwitcherItem" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+    "render": [Function],
+  },
+  "Tab" => Object {
+    "defaultProps": Object {
+      "href": "#",
+      "label": "provide a label",
+      "onClick": [Function],
+      "onKeyDown": [Function],
+      "renderContent": [Function],
+      "role": "presentation",
+      "selected": false,
+      "tabIndex": 0,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "handleTabClick": Object {
+        "type": "func",
+      },
+      "handleTabKeyDown": Object {
+        "type": "func",
+      },
+      "href": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "index": Object {
+        "type": "number",
+      },
+      "label": Object {
+        "type": "node",
+      },
+      "onClick": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+      "onKeyDown": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+      "renderAnchor": Object {
+        "type": "func",
+      },
+      "renderContent": Object {
+        "type": "func",
+      },
+      "role": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "selected": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+      "tabIndex": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+    },
+  },
+  "TabContent" => Object {
+    "defaultProps": Object {
+      "selected": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "selected": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "Table" => Object {
+    "defaultProps": Object {
+      "isSortable": false,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "isSortable": Object {
+        "type": "bool",
+      },
+      "shouldShowBorder": Object {
+        "type": "bool",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "compact",
+            "short",
+            "normal",
+            "tall",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "stickyHeader": Object {
+        "type": "bool",
+      },
+      "useStaticWidth": Object {
+        "type": "bool",
+      },
+      "useZebraStyles": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "TableBatchAction" => Object {
+    "defaultProps": Object {
+      "renderIcon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
+    },
+    "propTypes": Object {
+      "hasIconOnly": Object {
+        "type": "bool",
+      },
+      "iconDescription": [Function],
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+    },
+  },
+  "TableBatchActions" => Object {
+    "defaultProps": Object {
+      "translateWithId": [Function],
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "onCancel": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+      "shouldShowBatchActions": Object {
+        "type": "bool",
+      },
+      "totalSelected": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+      "translateWithId": Object {
+        "type": "func",
+      },
+    },
+    "translationKeys": Array [
+      "carbon.table.batch.cancel",
+      "carbon.table.batch.items.selected",
+      "carbon.table.batch.item.selected",
+    ],
+  },
+  "TableBody" => Object {
+    "defaultProps": Object {
+      "aria-live": "polite",
+    },
+    "propTypes": Object {
+      "aria-live": Object {
+        "args": Array [
+          Array [
+            "polite",
+            "assertive",
+            "off",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableCell" => Object {
+    "displayName": "TableCell",
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableContainer" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "description": Object {
+        "type": "node",
+      },
+      "title": Object {
+        "type": "node",
+      },
+    },
+  },
+  "TableExpandHeader" => Object {
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "expandIconDescription": Object {
+        "type": "string",
+      },
+      "isExpanded": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+      "onExpand": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+    },
+  },
+  "TableExpandRow" => Object {
+    "defaultProps": Object {
+      "expandHeader": "expand",
+    },
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "expandHeader": Object {
+        "type": "string",
+      },
+      "expandIconDescription": Object {
+        "type": "string",
+      },
+      "isExpanded": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+      "onExpand": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+    },
+  },
+  "TableExpandedRow" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "colSpan": Object {
+        "isRequired": true,
+        "type": "number",
+      },
+    },
+  },
+  "TableHead" => Object {
+    "displayName": "TableHead",
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableHeader" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "defaultProps": Object {
+      "isSortable": false,
+      "scope": "col",
+      "translateWithId": [Function],
+    },
+    "displayName": "TableHeader",
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "colSpan": Object {
+        "type": "number",
+      },
+      "isSortHeader": Object {
+        "type": "bool",
+      },
+      "isSortable": Object {
+        "type": "bool",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "scope": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "sortDirection": Object {
+        "args": Array [
+          Array [
+            "NONE",
+            "DESC",
+            "ASC",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "translateWithId": Object {
+        "type": "func",
+      },
+    },
+    "render": [Function],
+    "translationKeys": Array [
+      "carbon.table.header.icon.description",
+    ],
+  },
+  "TableOverflowCell" => Object {
+    "defaultProps": undefined,
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableRow" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableSelectAll" => Object {
+    "defaultProps": Object {
+      "ariaLabel": "Select all rows in the table",
+    },
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "checked": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "indeterminate": Object {
+        "type": "bool",
+      },
+      "name": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "onSelect": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+    },
+  },
+  "TableSelectRow" => Object {
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "checked": Object {
+        "isRequired": true,
+        "type": "bool",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "name": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "onSelect": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+      "radio": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "TableToolbar" => Object {
+    "defaultProps": Object {
+      "aria-label": "data table toolbar",
+    },
+    "propTypes": Object {
+      "aria-label": [Function],
+      "aria-labelledby": [Function],
+      "children": Object {
+        "type": "node",
+      },
+    },
+  },
+  "TableToolbarAction" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "TableToolbarAction",
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "onClick": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+    },
+    "render": [Function],
+  },
+  "TableToolbarContent" => Object {
+    "displayName": "TableToolbarContent",
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableToolbarDownload" => Object {
+    "defaultProps": Object {
+      "filename": "DataTable",
+      "label": "Download",
+      "title": "",
+    },
+    "propTypes": Object {
+      "filename": Object {
+        "type": "string",
+      },
+      "headers": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "header": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "key": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "isRequired": true,
+        "type": "arrayOf",
+      },
+      "label": Object {
+        "type": "string",
+      },
+      "rows": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "id": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "isRequired": true,
+        "type": "arrayOf",
+      },
+      "title": Object {
+        "type": "string",
+      },
+    },
+  },
+  "TableToolbarMenu" => Object {
+    "defaultProps": Object {
+      "iconDescription": "Settings",
+      "renderIcon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
+    },
+    "propTypes": Object {
+      "children": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+    },
+  },
+  "TableToolbarSearch" => Object {
+    "defaultProps": Object {
+      "persistent": false,
+      "tabIndex": "0",
+      "translateWithId": [Function],
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "defaultValue": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "persistant": [Function],
+      "persistent": Object {
+        "type": "bool",
+      },
+      "placeHolderText": Object {
+        "type": "string",
+      },
+      "searchContainerClasses": Object {
+        "type": "string",
+      },
+      "tabIndex": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "translateWithId": Object {
+        "isRequired": true,
+        "type": "func",
+      },
+    },
+  },
+  "Tabs" => Object {
+    "defaultProps": Object {
+      "ariaLabel": "listbox",
+      "iconDescription": "show menu options",
+      "role": "navigation",
+      "selected": 0,
+      "triggerHref": "#",
+      "type": "default",
+    },
+    "propTypes": Object {
+      "ariaLabel": Object {
+        "type": "string",
+      },
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "hidden": Object {
+        "type": "bool",
+      },
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "onKeyDown": Object {
+        "type": "func",
+      },
+      "onSelectionChange": Object {
+        "type": "func",
+      },
+      "role": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "selected": Object {
+        "type": "number",
+      },
+      "tabContentClassName": Object {
+        "type": "string",
+      },
+      "triggerHref": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "type": Object {
+        "args": Array [
+          Array [
+            "default",
+            "container",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
+  "TabsSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
   "Tag" => Object {
     "propTypes": Object {
       "children": Object {
@@ -4989,62 +8850,6 @@ Map {
       },
       "filter": Object {
         "type": "bool",
-      },
-      "title": Object {
-        "type": "string",
-      },
-      "type": Object {
-        "args": Array [
-          Array [
-            "red",
-            "magenta",
-            "purple",
-            "blue",
-            "cyan",
-            "teal",
-            "green",
-            "gray",
-            "cool-gray",
-            "warm-gray",
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOf",
-      },
-    },
-  },
-  "InteractiveTag" => Object {
-    "defaultProps": Object {
-      "isSelected": false,
-      "onRemove": null,
-      "removable": false,
-      "removeBtnLabel": "Remove",
-      "type": "gray",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "filter": Object {
-        "type": "bool",
-      },
-      "isSelected": Object {
-        "type": "bool",
-      },
-      "onRemove": Object {
-        "type": "func",
-      },
-      "removable": Object {
-        "type": "bool",
-      },
-      "removeBtnLabel": Object {
-        "type": "string",
       },
       "title": Object {
         "type": "string",
@@ -5831,6 +9636,104 @@ Map {
       },
     },
   },
+  "TextArea" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "defaultProps": Object {
+      "cols": 50,
+      "disabled": false,
+      "helperText": "",
+      "invalid": false,
+      "invalidText": "",
+      "light": false,
+      "onChange": [Function],
+      "onClick": [Function],
+      "placeholder": "",
+      "rows": 4,
+    },
+    "displayName": "TextArea",
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "cols": Object {
+        "type": "number",
+      },
+      "defaultValue": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "helperText": Object {
+        "type": "node",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "invalid": Object {
+        "type": "bool",
+      },
+      "invalidText": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "placeholder": Object {
+        "type": "string",
+      },
+      "rows": Object {
+        "type": "number",
+      },
+      "value": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+    },
+    "render": [Function],
+  },
+  "TextAreaSkeleton" => Object {
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+    },
+  },
   "TextInput" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "ControlledPasswordInput": Object {
@@ -6148,6 +10051,88 @@ Map {
       },
     },
   },
+  "Tile" => Object {
+    "defaultProps": Object {
+      "light": false,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "TileAboveTheFoldContent" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+    },
+  },
+  "TileBelowTheFoldContent" => Object {
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+    },
+  },
+  "TileGroup" => Object {
+    "defaultProps": Object {
+      "onChange": [Function],
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "defaultSelected": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "legend": Object {
+        "type": "string",
+      },
+      "name": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "valueSelected": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+    },
+  },
   "TimeIndicator" => Object {
     "defaultProps": Object {
       "className": null,
@@ -6162,600 +10147,130 @@ Map {
       },
     },
   },
-  "TrendingCard" => Object {
+  "TimePicker" => Object {
     "defaultProps": Object {
-      "className": null,
-      "element": "a",
-      "subtitle": null,
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "element": Object {
-        "type": "elementType",
-      },
-      "subtitle": Object {
-        "type": "node",
-      },
-      "title": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-    },
-  },
-  "TypeLayout" => Object {
-    "defaultProps": Object {
-      "border": false,
-      "bordered": null,
-      "children": null,
-      "className": "",
-      "size": "md",
-    },
-    "propTypes": Object {
-      "border": Object {
-        "type": "bool",
-      },
-      "bordered": [Function],
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "size": Object {
-        "args": Array [
-          Array [
-            "xs",
-            "sm",
-            "md",
-            "lg",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
-  "TypeLayoutBody" => Object {
-    "defaultProps": Object {
-      "children": null,
-      "className": "",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TypeLayoutCell" => Object {
-    "defaultProps": Object {
-      "children": null,
-      "className": "",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TypeLayoutRow" => Object {
-    "defaultProps": Object {
-      "children": null,
-      "className": "",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Wizard" => Object {
-    "defaultProps": Object {
-      "children": undefined,
-      "focusTrap": true,
-      "initState": Object {},
-      "isOpen": undefined,
-      "isSequential": undefined,
-      "labels": Object {},
-      "onClose": [Function],
-      "onDelete": [Function],
-      "rootNode": <body />,
-      "steps": Array [],
-      "subTitle": "",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "focusTrap": Object {
-        "type": "bool",
-      },
-      "initState": Object {
-        "args": Array [
-          [Function],
-        ],
-        "type": "instanceOf",
-      },
-      "isOpen": Object {
-        "type": "bool",
-      },
-      "isSequential": Object {
-        "type": "bool",
-      },
-      "labels": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Array [
-                Object {
-                  "type": "string",
-                },
-                Object {
-                  "type": "func",
-                },
-                Object {
-                  "type": "object",
-                },
-              ],
-            ],
-            "type": "oneOfType",
-          },
-        ],
-        "type": "objectOf",
-      },
-      "onClose": Object {
-        "type": "func",
-      },
-      "onDelete": Object {
-        "type": "func",
-      },
-      "rootNode": Object {
-        "args": Array [
-          [Function],
-        ],
-        "type": "instanceOf",
-      },
-      "steps": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "next": Object {
-                  "type": "func",
-                },
-                "renderMain": Object {
-                  "type": "func",
-                },
-                "title": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "validate": Object {
-                  "type": "func",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "subTitle": Object {
-        "type": "string",
-      },
-      "title": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-    },
-  },
-  "WizardStep" => Object {
-    "defaultProps": Object {
-      "next": [Function],
-      "renderMain": [Function],
-      "validate": [Function],
-    },
-    "getPropsFromElement": Object {},
-    "propTypes": Object {
-      "next": Object {
-        "type": "func",
-      },
-      "renderMain": Object {
-        "type": "func",
-      },
-      "title": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "validate": Object {
-        "type": "func",
-      },
-    },
-  },
-  "Header" => Object {
-    "defaultProps": Object {
-      "className": null,
-      "notifications": Array [],
-      "onNotificationClear": [Function],
-      "profile": null,
-      "renderLoginAndSignup": [Function],
-      "showEditProfile": true,
-      "showNotifications": true,
-      "totalNotifications": 0,
-    },
-    "propTypes": Object {
-      "accounts": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "name": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "labels": Object {
-        "args": Array [
-          Object {
-            "brand": Object {
-              "args": Array [
-                Object {
-                  "company": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "domain": Object {
-                    "type": "string",
-                  },
-                  "product": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-            "notifications": Object {
-              "args": Array [
-                Object {
-                  "button": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "clear": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "clear_all": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "link": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "preferences": Object {
-                    "type": "string",
-                  },
-                  "success": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "title": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "today": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "via": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-            "profile": Object {
-              "args": Array [
-                Object {
-                  "account": Object {
-                    "type": "string",
-                  },
-                  "edit_profile": Object {
-                    "type": "string",
-                  },
-                  "link": Object {
-                    "type": "string",
-                  },
-                  "registration": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "sign_in": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "sign_out": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-          },
-        ],
-        "isRequired": true,
-        "type": "shape",
-      },
-      "links": Object {
-        "args": Array [
-          Object {
-            "edit_profile": Object {
-              "type": "string",
-            },
-            "notifications_preferences": Object {
-              "type": "string",
-            },
-            "notifications_view_all": Object {
-              "type": "string",
-            },
-            "product": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "profile": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "registration": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "sign_in": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "sign_out": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-          },
-        ],
-        "isRequired": true,
-        "type": "shape",
-      },
-      "notifications": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "datetime": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "description": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "href": Object {
-                  "type": "string",
-                },
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "label": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "product": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-              },
-            ],
-            "isRequired": true,
-            "type": "shape",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "onAccountClick": Object {
-        "type": "func",
-      },
-      "onNotificationClear": Object {
-        "type": "func",
-      },
-      "profile": Object {
-        "args": Array [
-          Object {
-            "account": Object {
-              "args": Array [
-                Object {
-                  "id": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "name": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "type": "shape",
-            },
-            "email": Object {
-              "type": "string",
-            },
-            "image_url": Object {
-              "type": "string",
-            },
-            "name": Object {
-              "args": Array [
-                Object {
-                  "first_name": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "surname": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-          },
-        ],
-        "type": "shape",
-      },
-      "renderLoginAndSignup": Object {
-        "type": "func",
-      },
-      "showEditProfile": Object {
-        "type": "bool",
-      },
-      "showNotifications": Object {
-        "type": "bool",
-      },
-      "totalNotifications": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-    },
-  },
-  "Nav" => Object {
-    "defaultProps": Object {
-      "activeHref": undefined,
-      "children": null,
-      "className": "",
-      "heading": null,
-    },
-    "propTypes": Object {
-      "activeHref": Object {
-        "type": "string",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "heading": Object {
-        "type": "string",
-      },
-      "label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-    },
-  },
-  "NavItem" => Object {
-    "defaultProps": Object {
-      "activeHref": "#",
-      "children": null,
-      "className": "",
-      "current": null,
       "disabled": false,
-      "element": "a",
-      "handleItemSelect": null,
-      "href": undefined,
-      "id": "security--nav__list__item",
-      "label": "",
-      "link": true,
+      "invalid": false,
+      "invalidText": "Invalid time format.",
+      "light": false,
+      "maxLength": 5,
+      "onBlur": [Function],
+      "onChange": [Function],
       "onClick": [Function],
-      "onKeyPress": [Function],
-      "tabIndex": 0,
+      "pattern": "(1[012]|[1-9]):[0-5][0-9](\\\\s)?",
+      "placeholder": "hh:mm",
+      "type": "text",
     },
     "propTypes": Object {
-      "activeHref": Object {
-        "type": "string",
-      },
       "children": Object {
         "type": "node",
       },
       "className": Object {
-        "type": "string",
-      },
-      "current": Object {
         "type": "string",
       },
       "disabled": Object {
         "type": "bool",
       },
-      "element": Object {
-        "type": "elementType",
-      },
-      "handleItemSelect": Object {
-        "type": "func",
-      },
-      "href": Object {
-        "type": "string",
+      "hideLabel": Object {
+        "type": "bool",
       },
       "id": Object {
+        "isRequired": true,
         "type": "string",
       },
-      "label": Object {
-        "type": "string",
-      },
-      "link": Object {
+      "invalid": Object {
         "type": "bool",
+      },
+      "invalidText": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "node",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "maxLength": Object {
+        "type": "number",
+      },
+      "onBlur": Object {
+        "type": "func",
+      },
+      "onChange": Object {
+        "type": "func",
       },
       "onClick": Object {
         "type": "func",
       },
-      "onKeyPress": Object {
-        "type": "func",
+      "pattern": Object {
+        "type": "string",
       },
-      "tabIndex": Object {
-        "type": "number",
+      "placeholder": Object {
+        "type": "string",
+      },
+      "type": Object {
+        "type": "string",
+      },
+      "value": Object {
+        "type": "string",
       },
     },
   },
-  "NavList" => Object {
+  "TimePickerSelect" => Object {
     "defaultProps": Object {
-      "activeHref": "#",
-      "children": null,
-      "className": "",
-      "id": "",
-      "isExpandedOnPageload": false,
-      "onItemClick": [Function],
-      "onListClick": [Function],
-      "tabIndex": 0,
-      "title": "",
+      "disabled": false,
+      "hideLabel": true,
+      "iconDescription": "open list of options",
+      "inline": true,
     },
     "propTypes": Object {
-      "activeHref": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
         "type": "string",
+      },
+      "defaultValue": Object {
+        "type": "any",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "hideLabel": Object {
+        "type": "bool",
+      },
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "inline": Object {
+        "type": "bool",
+      },
+      "labelText": Object {
+        "isRequired": true,
+        "type": "node",
+      },
+    },
+  },
+  "ToastNotification" => Object {
+    "defaultProps": Object {
+      "caption": "provide a caption",
+      "hideCloseButton": false,
+      "iconDescription": "closes notification",
+      "kind": "error",
+      "notificationType": "toast",
+      "onCloseButtonClick": [Function],
+      "role": "alert",
+      "timeout": 0,
+      "title": "provide a title",
+    },
+    "propTypes": Object {
+      "caption": Object {
+        "type": "node",
       },
       "children": Object {
         "type": "node",
@@ -6763,795 +10278,174 @@ Map {
       "className": Object {
         "type": "string",
       },
-      "id": Object {
-        "type": "string",
-      },
-      "isExpandedOnPageload": Object {
+      "hideCloseButton": Object {
         "type": "bool",
       },
-      "onItemClick": Object {
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "kind": Object {
+        "args": Array [
+          Array [
+            "error",
+            "info",
+            "success",
+            "warning",
+          ],
+        ],
+        "isRequired": true,
+        "type": "oneOf",
+      },
+      "lowContrast": Object {
+        "type": "bool",
+      },
+      "notificationType": Object {
+        "type": "string",
+      },
+      "onCloseButtonClick": Object {
         "type": "func",
       },
-      "onListClick": Object {
-        "type": "func",
+      "role": Object {
+        "isRequired": true,
+        "type": "string",
       },
-      "tabIndex": Object {
+      "statusIconDescription": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "subtitle": Object {
+        "type": "node",
+      },
+      "timeout": Object {
         "type": "number",
       },
       "title": Object {
+        "isRequired": true,
         "type": "string",
       },
     },
   },
-  "ProfileImage" => Object {
+  "Toggle" => Object {
     "defaultProps": Object {
-      "className": null,
-      "large": false,
+      "aria-label": "Toggle",
+      "defaultToggled": false,
+      "labelA": "Off",
+      "labelB": "On",
+      "onToggle": [Function],
     },
     "propTypes": Object {
+      "aria-label": Object {
+        "isRequired": true,
+        "type": "string",
+      },
       "className": Object {
         "type": "string",
       },
-      "large": Object {
+      "defaultToggled": Object {
         "type": "bool",
       },
-      "profile": Object {
-        "args": Array [
-          Object {
-            "image_url": Object {
-              "type": "string",
-            },
-            "name": Object {
-              "args": Array [
-                Object {
-                  "first_name": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "surname": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-          },
-        ],
+      "id": Object {
         "isRequired": true,
-        "type": "shape",
+        "type": "string",
+      },
+      "labelA": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "labelB": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "string",
+      },
+      "onToggle": Object {
+        "type": "func",
+      },
+      "toggled": Object {
+        "type": "bool",
       },
     },
   },
-  "Shell" => Object {
+  "ToggleSkeleton" => Object {
     "defaultProps": Object {
-      "header": Object {
-        "className": null,
-        "notifications": Array [],
-        "onNotificationClear": [Function],
-        "profile": null,
-        "renderLoginAndSignup": [Function],
-        "showEditProfile": true,
-        "showNotifications": true,
-        "totalNotifications": 0,
-      },
-      "profile": null,
-      "renderAddons": Array [],
-      "returnToBanner": null,
-      "skipToContent": null,
-      "toolbar": Object {},
+      "aria-label": "Toggle is loading",
     },
     "propTypes": Object {
-      "header": Object {
-        "args": Array [
-          Object {
-            "accounts": Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "name": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "type": "shape",
-                },
-              ],
-              "type": "arrayOf",
-            },
-            "className": Object {
-              "type": "string",
-            },
-            "labels": Object {
-              "args": Array [
-                Object {
-                  "brand": Object {
-                    "args": Array [
-                      Object {
-                        "company": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "domain": Object {
-                          "type": "string",
-                        },
-                        "product": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                  "notifications": Object {
-                    "args": Array [
-                      Object {
-                        "button": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "clear": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "clear_all": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "link": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "preferences": Object {
-                          "type": "string",
-                        },
-                        "success": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "title": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "today": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "via": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                  "profile": Object {
-                    "args": Array [
-                      Object {
-                        "account": Object {
-                          "type": "string",
-                        },
-                        "edit_profile": Object {
-                          "type": "string",
-                        },
-                        "link": Object {
-                          "type": "string",
-                        },
-                        "registration": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "sign_in": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "sign_out": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-            "links": Object {
-              "args": Array [
-                Object {
-                  "edit_profile": Object {
-                    "type": "string",
-                  },
-                  "notifications_preferences": Object {
-                    "type": "string",
-                  },
-                  "notifications_view_all": Object {
-                    "type": "string",
-                  },
-                  "product": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "profile": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "registration": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "sign_in": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "sign_out": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-            "notifications": Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "datetime": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "description": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "href": Object {
-                        "type": "string",
-                      },
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "label": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "product": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "isRequired": true,
-                  "type": "shape",
-                },
-              ],
-              "type": "arrayOf",
-            },
-            "onAccountClick": Object {
-              "type": "func",
-            },
-            "onNotificationClear": Object {
-              "type": "func",
-            },
-            "profile": Object {
-              "args": Array [
-                Object {
-                  "account": Object {
-                    "args": Array [
-                      Object {
-                        "id": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "name": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "type": "shape",
-                  },
-                  "email": Object {
-                    "type": "string",
-                  },
-                  "image_url": Object {
-                    "type": "string",
-                  },
-                  "name": Object {
-                    "args": Array [
-                      Object {
-                        "first_name": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "surname": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                },
-              ],
-              "type": "shape",
-            },
-            "renderLoginAndSignup": Object {
-              "type": "func",
-            },
-            "showEditProfile": Object {
-              "type": "bool",
-            },
-            "showNotifications": Object {
-              "type": "bool",
-            },
-            "totalNotifications": Object {
-              "isRequired": true,
-              "type": "number",
-            },
-          },
-        ],
-        "type": "shape",
+      "aria-label": Object {
+        "isRequired": true,
+        "type": "string",
       },
-      "profile": Object {
-        "args": Array [
-          Object {
-            "account": Object {
-              "args": Array [
-                Object {
-                  "id": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "name": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "type": "shape",
-            },
-            "email": Object {
-              "type": "string",
-            },
-            "image_url": Object {
-              "type": "string",
-            },
-            "name": Object {
-              "args": Array [
-                Object {
-                  "first_name": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                  "surname": Object {
-                    "isRequired": true,
-                    "type": "string",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-          },
-        ],
-        "type": "shape",
+      "className": Object {
+        "type": "string",
       },
-      "renderAddons": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "id": Object {
-                  "isRequired": true,
-                  "type": "string",
-                },
-                "render": Object {
-                  "isRequired": true,
-                  "type": "func",
-                },
-                "tooltip": Object {
-                  "type": "string",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
-        "type": "arrayOf",
+      "id": Object {
+        "type": "string",
       },
-      "returnToBanner": Object {
-        "args": Array [
-          Object {
-            "application": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "href": Object {
-              "isRequired": true,
-              "type": "string",
-            },
-            "view": Object {
-              "type": "string",
-            },
-          },
-        ],
-        "type": "shape",
+      "labelText": Object {
+        "type": "string",
       },
-      "skipToContent": Object {
-        "args": Array [
-          Object {
-            "href": Object {
-              "type": "string",
-            },
-            "label": Object {
-              "type": "string",
-            },
-          },
-        ],
-        "type": "shape",
+    },
+  },
+  "ToggleSmall" => Object {
+    "defaultProps": Object {
+      "defaultToggled": false,
+      "labelA": "Off",
+      "labelB": "On",
+      "onToggle": [Function],
+    },
+    "propTypes": Object {
+      "aria-label": Object {
+        "isRequired": true,
+        "type": "string",
       },
-      "toolbar": Object {
-        "args": Array [
-          Object {
-            "className": Object {
-              "type": "string",
-            },
-            "labels": Object {
-              "args": Array [
-                Object {
-                  "menu": Object {
-                    "args": Array [
-                      Object {
-                        "button": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "tooltip": Object {
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                  "settings": Object {
-                    "args": Array [
-                      Object {
-                        "button": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "tooltip": Object {
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                  "support": Object {
-                    "args": Array [
-                      Object {
-                        "button": Object {
-                          "isRequired": true,
-                          "type": "string",
-                        },
-                        "tooltip": Object {
-                          "type": "string",
-                        },
-                      },
-                    ],
-                    "isRequired": true,
-                    "type": "shape",
-                  },
-                },
-              ],
-              "isRequired": true,
-              "type": "shape",
-            },
-            "menu": Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "content": Object {
-                        "type": "node",
-                      },
-                      "icon": Object {
-                        "type": "string",
-                      },
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "navigation": Object {
-                        "args": Array [
-                          Object {
-                            "args": Array [
-                              Object {
-                                "children": Object {
-                                  "args": Array [
-                                    Object {
-                                      "args": Array [
-                                        Object {
-                                          "content": Object {
-                                            "type": "node",
-                                          },
-                                          "icon": Object {
-                                            "type": "string",
-                                          },
-                                          "id": Object {
-                                            "isRequired": true,
-                                            "type": "string",
-                                          },
-                                          "isRequired": true,
-                                          "title": Object {
-                                            "isRequired": true,
-                                            "type": "string",
-                                          },
-                                          "type": "string",
-                                        },
-                                      ],
-                                      "type": "shape",
-                                    },
-                                  ],
-                                  "type": "arrayOf",
-                                },
-                                "content": Object {
-                                  "type": "node",
-                                },
-                                "href": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                                "icon": Object {
-                                  "type": "string",
-                                },
-                                "id": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                                "title": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                              },
-                            ],
-                            "type": "shape",
-                          },
-                        ],
-                        "isRequired": true,
-                        "type": "arrayOf",
-                      },
-                      "title": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "isRequired": true,
-                  "type": "shape",
-                },
-              ],
-              "type": "arrayOf",
-            },
-            "onToggle": Object {
-              "type": "func",
-            },
-            "renderAddons": Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "render": Object {
-                        "isRequired": true,
-                        "type": "func",
-                      },
-                      "tooltip": Object {
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "type": "shape",
-                },
-              ],
-              "type": "arrayOf",
-            },
-            "settings": Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "content": Object {
-                        "type": "node",
-                      },
-                      "icon": Object {
-                        "type": "string",
-                      },
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "navigation": Object {
-                        "args": Array [
-                          Object {
-                            "args": Array [
-                              Object {
-                                "children": Object {
-                                  "args": Array [
-                                    Object {
-                                      "args": Array [
-                                        Object {
-                                          "content": Object {
-                                            "type": "node",
-                                          },
-                                          "icon": Object {
-                                            "type": "string",
-                                          },
-                                          "id": Object {
-                                            "isRequired": true,
-                                            "type": "string",
-                                          },
-                                          "isRequired": true,
-                                          "title": Object {
-                                            "isRequired": true,
-                                            "type": "string",
-                                          },
-                                          "type": "string",
-                                        },
-                                      ],
-                                      "type": "shape",
-                                    },
-                                  ],
-                                  "type": "arrayOf",
-                                },
-                                "content": Object {
-                                  "type": "node",
-                                },
-                                "href": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                                "icon": Object {
-                                  "type": "string",
-                                },
-                                "id": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                                "title": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                              },
-                            ],
-                            "type": "shape",
-                          },
-                        ],
-                        "isRequired": true,
-                        "type": "arrayOf",
-                      },
-                      "title": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "isRequired": true,
-                  "type": "shape",
-                },
-              ],
-              "type": "arrayOf",
-            },
-            "support": Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "content": Object {
-                        "type": "node",
-                      },
-                      "icon": Object {
-                        "type": "string",
-                      },
-                      "id": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                      "navigation": Object {
-                        "args": Array [
-                          Object {
-                            "args": Array [
-                              Object {
-                                "children": Object {
-                                  "args": Array [
-                                    Object {
-                                      "args": Array [
-                                        Object {
-                                          "content": Object {
-                                            "type": "node",
-                                          },
-                                          "icon": Object {
-                                            "type": "string",
-                                          },
-                                          "id": Object {
-                                            "isRequired": true,
-                                            "type": "string",
-                                          },
-                                          "isRequired": true,
-                                          "title": Object {
-                                            "isRequired": true,
-                                            "type": "string",
-                                          },
-                                          "type": "string",
-                                        },
-                                      ],
-                                      "type": "shape",
-                                    },
-                                  ],
-                                  "type": "arrayOf",
-                                },
-                                "content": Object {
-                                  "type": "node",
-                                },
-                                "href": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                                "icon": Object {
-                                  "type": "string",
-                                },
-                                "id": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                                "title": Object {
-                                  "isRequired": true,
-                                  "type": "string",
-                                },
-                              },
-                            ],
-                            "type": "shape",
-                          },
-                        ],
-                        "isRequired": true,
-                        "type": "arrayOf",
-                      },
-                      "title": Object {
-                        "isRequired": true,
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "isRequired": true,
-                  "type": "shape",
-                },
-              ],
-              "type": "arrayOf",
-            },
-          },
-        ],
-        "type": "shape",
+      "className": Object {
+        "type": "string",
+      },
+      "defaultToggled": Object {
+        "type": "bool",
+      },
+      "id": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "labelA": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "labelB": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "string",
+      },
+      "onToggle": Object {
+        "type": "func",
+      },
+      "toggled": Object {
+        "type": "bool",
+      },
+    },
+  },
+  "ToggleSmallSkeleton" => Object {
+    "defaultProps": Object {
+      "aria-label": "Toggle is loading",
+    },
+    "propTypes": Object {
+      "aria-label": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "id": Object {
+        "type": "string",
+      },
+      "labelText": Object {
+        "type": "string",
       },
     },
   },
@@ -7907,2585 +10801,6 @@ Map {
       },
     },
   },
-  "Accordion" => Object {
-    "defaultProps": Object {
-      "align": "start",
-    },
-    "propTypes": Object {
-      "align": Object {
-        "args": Array [
-          Array [
-            "start",
-            "end",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "AccordionItem" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "onHeadingClick": Object {
-        "type": "func",
-      },
-      "open": Object {
-        "type": "bool",
-      },
-      "renderExpando": Object {
-        "type": "func",
-      },
-      "title": Object {
-        "type": "node",
-      },
-    },
-  },
-  "AccordionSkeleton" => Object {
-    "defaultProps": Object {
-      "align": "end",
-      "count": 4,
-      "open": true,
-    },
-    "propTypes": Object {
-      "align": Object {
-        "args": Array [
-          Array [
-            "start",
-            "end",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "count": Object {
-        "type": "number",
-      },
-      "open": Object {
-        "type": "bool",
-      },
-      "uid": [Function],
-    },
-  },
-  "Breadcrumb" => Object {
-    "propTypes": Object {
-      "aria-label": Object {
-        "type": "string",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "noTrailingSlash": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "BreadcrumbItem" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "isCurrentPage": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "BreadcrumbSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Button" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "kind": "primary",
-      "largeText": null,
-      "loading": false,
-      "renderIcon": undefined,
-      "tabIndex": 0,
-      "type": "button",
-    },
-    "propTypes": Object {
-      "as": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "elementType",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "hasIconOnly": Object {
-        "type": "bool",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "iconDescription": [Function],
-      "kind": Object {
-        "args": Array [
-          Array [
-            "primary",
-            "secondary",
-            "danger",
-            "ghost",
-            "danger--primary",
-            "tertiary",
-            "ghost-danger",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "largeText": [Function],
-      "loading": Object {
-        "type": "bool",
-      },
-      "renderIcon": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "role": Object {
-        "type": "string",
-      },
-      "size": Object {
-        "args": Array [
-          Array [
-            "default",
-            "field",
-            "large",
-            "small",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "small": [Function],
-      "tabIndex": Object {
-        "type": "number",
-      },
-      "tooltipAlignment": Object {
-        "args": Array [
-          Array [
-            "start",
-            "center",
-            "end",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "tooltipPosition": Object {
-        "args": Array [
-          Array [
-            "top",
-            "right",
-            "bottom",
-            "left",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "type": Object {
-        "args": Array [
-          Array [
-            "button",
-            "reset",
-            "submit",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
-  "ButtonSkeleton" => Object {
-    "defaultProps": Object {
-      "small": false,
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "small": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "Checkbox" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {
-      "indeterminate": false,
-      "onChange": [Function],
-    },
-    "displayName": "Checkbox",
-    "propTypes": Object {
-      "checked": Object {
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultChecked": Object {
-        "type": "bool",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "indeterminate": Object {
-        "type": "bool",
-      },
-      "labelText": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "title": Object {
-        "type": "string",
-      },
-      "wrapperClassName": Object {
-        "type": "string",
-      },
-    },
-    "render": [Function],
-  },
-  "CheckboxSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "DatePicker" => Object {
-    "defaultProps": Object {
-      "dateFormat": "m/d/Y",
-      "light": false,
-      "locale": "en",
-      "short": false,
-    },
-    "propTypes": Object {
-      "appendTo": Object {
-        "type": "object",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "dateFormat": Object {
-        "type": "string",
-      },
-      "datePickerType": Object {
-        "args": Array [
-          Array [
-            "simple",
-            "single",
-            "range",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "locale": Object {
-        "args": Array [
-          Array [
-            "ar",
-            "at",
-            "be",
-            "bg",
-            "bn",
-            "cat",
-            "cs",
-            "cy",
-            "da",
-            "de",
-            "en",
-            "en",
-            "eo",
-            "es",
-            "et",
-            "fa",
-            "fi",
-            "fr",
-            "gr",
-            "he",
-            "hi",
-            "hr",
-            "hu",
-            "id",
-            "it",
-            "ja",
-            "ko",
-            "lt",
-            "lv",
-            "mk",
-            "mn",
-            "ms",
-            "my",
-            "nl",
-            "no",
-            "pa",
-            "pl",
-            "pt",
-            "ro",
-            "ru",
-            "si",
-            "sk",
-            "sl",
-            "sq",
-            "sr",
-            "sv",
-            "th",
-            "tr",
-            "uk",
-            "vn",
-            "zh",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "maxDate": Object {
-        "type": "string",
-      },
-      "minDate": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onClose": Object {
-        "type": "func",
-      },
-      "short": Object {
-        "type": "bool",
-      },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Array [
-                      Object {
-                        "type": "string",
-                      },
-                      Object {
-                        "type": "number",
-                      },
-                      Object {
-                        "type": "object",
-                      },
-                    ],
-                  ],
-                  "type": "oneOfType",
-                },
-              ],
-              "type": "arrayOf",
-            },
-            Object {
-              "type": "object",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-    },
-  },
-  "DatePickerInput" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "invalid": false,
-      "onChange": [Function],
-      "onClick": [Function],
-      "pattern": "\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}",
-      "type": "text",
-    },
-    "propTypes": Object {
-      "disabled": Object {
-        "type": "bool",
-      },
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "invalid": Object {
-        "type": "bool",
-      },
-      "labelText": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "pattern": [Function],
-      "type": Object {
-        "type": "string",
-      },
-    },
-  },
-  "DatePickerSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "range": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "Dropdown" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "helperText": "",
-      "itemToElement": null,
-      "itemToString": [Function],
-      "light": false,
-      "titleText": "",
-      "type": "default",
-    },
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "downshiftProps": Object {
-        "args": Array [
-          Object {
-            "breakingChanges": Object {
-              "args": Array [
-                Object {
-                  "resetInputOnSelection": Object {
-                    "type": "bool",
-                  },
-                },
-              ],
-              "type": "shape",
-            },
-            "children": Object {
-              "type": "func",
-            },
-            "defaultHighlightedIndex": Object {
-              "type": "number",
-            },
-            "defaultInputValue": Object {
-              "type": "string",
-            },
-            "defaultIsOpen": Object {
-              "type": "bool",
-            },
-            "defaultSelectedItem": Object {
-              "type": "any",
-            },
-            "environment": Object {
-              "args": Array [
-                Object {
-                  "addEventListener": Object {
-                    "type": "func",
-                  },
-                  "document": Object {
-                    "args": Array [
-                      Object {
-                        "activeElement": Object {
-                          "type": "any",
-                        },
-                        "body": Object {
-                          "type": "any",
-                        },
-                        "getElementById": Object {
-                          "type": "func",
-                        },
-                      },
-                    ],
-                    "type": "shape",
-                  },
-                  "removeEventListener": Object {
-                    "type": "func",
-                  },
-                },
-              ],
-              "type": "shape",
-            },
-            "getA11yStatusMessage": Object {
-              "type": "func",
-            },
-            "highlightedIndex": Object {
-              "type": "number",
-            },
-            "id": Object {
-              "type": "string",
-            },
-            "inputValue": Object {
-              "type": "string",
-            },
-            "isOpen": Object {
-              "type": "bool",
-            },
-            "itemCount": Object {
-              "type": "number",
-            },
-            "itemToString": Object {
-              "type": "func",
-            },
-            "onChange": Object {
-              "type": "func",
-            },
-            "onInputValueChange": Object {
-              "type": "func",
-            },
-            "onOuterClick": Object {
-              "type": "func",
-            },
-            "onSelect": Object {
-              "type": "func",
-            },
-            "onStateChange": Object {
-              "type": "func",
-            },
-            "onUserAction": Object {
-              "type": "func",
-            },
-            "render": Object {
-              "type": "func",
-            },
-            "selectedItem": Object {
-              "type": "any",
-            },
-            "selectedItemChanged": Object {
-              "type": "func",
-            },
-            "stateReducer": Object {
-              "type": "func",
-            },
-          },
-        ],
-        "type": "shape",
-      },
-      "helperText": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "node",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "initialSelectedItem": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "object",
-            },
-            Object {
-              "type": "string",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "inline": Object {
-        "type": "bool",
-      },
-      "invalid": Object {
-        "type": "bool",
-      },
-      "invalidText": Object {
-        "type": "string",
-      },
-      "itemToElement": Object {
-        "type": "func",
-      },
-      "itemToString": Object {
-        "type": "func",
-      },
-      "items": Object {
-        "isRequired": true,
-        "type": "array",
-      },
-      "label": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "selectedItem": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "object",
-            },
-            Object {
-              "type": "string",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "size": Object {
-        "args": Array [
-          Array [
-            "sm",
-            "lg",
-            "xl",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "titleText": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "node",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "translateWithId": Object {
-        "type": "func",
-      },
-      "type": Object {
-        "args": Array [
-          Array [
-            "default",
-            "inline",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
-  "DropdownSkeleton" => Object {
-    "defaultProps": Object {
-      "inline": false,
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "inline": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "FileUploader" => Object {
-    "defaultProps": Object {
-      "accept": Array [],
-      "buttonKind": "primary",
-      "buttonLabel": "",
-      "filenameStatus": "uploading",
-      "iconDescription": "Provide icon description",
-      "multiple": false,
-      "onClick": [Function],
-    },
-    "propTypes": Object {
-      "accept": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "buttonKind": Object {
-        "args": Array [
-          Array [
-            "primary",
-            "secondary",
-            "danger",
-            "ghost",
-            "danger--primary",
-            "tertiary",
-            "ghost-danger",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "buttonLabel": Object {
-        "type": "string",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "filenameStatus": Object {
-        "args": Array [
-          Array [
-            "edit",
-            "complete",
-            "uploading",
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOf",
-      },
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "labelDescription": Object {
-        "type": "string",
-      },
-      "labelTitle": Object {
-        "type": "string",
-      },
-      "multiple": Object {
-        "type": "bool",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-    },
-  },
-  "Filename" => Object {
-    "defaultProps": Object {
-      "iconDescription": "Uploading file",
-      "status": "uploading",
-      "tabIndex": "0",
-    },
-    "propTypes": Object {
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "status": Object {
-        "args": Array [
-          Array [
-            "edit",
-            "complete",
-            "uploading",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "tabIndex": Object {
-        "type": "string",
-      },
-    },
-  },
-  "FileUploaderButton" => Object {
-    "defaultProps": Object {
-      "accept": Array [],
-      "buttonKind": "primary",
-      "disableLabelChanges": false,
-      "disabled": false,
-      "labelText": "Add file",
-      "multiple": false,
-      "onChange": [Function],
-      "onClick": [Function],
-      "role": "button",
-      "tabIndex": 0,
-    },
-    "propTypes": Object {
-      "accept": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "buttonKind": Object {
-        "args": Array [
-          Array [
-            "primary",
-            "secondary",
-            "danger",
-            "ghost",
-            "danger--primary",
-            "tertiary",
-            "ghost-danger",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disableLabelChanges": Object {
-        "type": "bool",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "node",
-      },
-      "listFiles": Object {
-        "type": "bool",
-      },
-      "multiple": Object {
-        "type": "bool",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "role": Object {
-        "type": "string",
-      },
-      "tabIndex": Object {
-        "type": "number",
-      },
-    },
-  },
-  "FileUploaderSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Form" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "FormGroup" => Object {
-    "defaultProps": Object {
-      "invalid": false,
-      "message": false,
-      "messageText": "",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "invalid": Object {
-        "type": "bool",
-      },
-      "legendText": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "message": Object {
-        "type": "bool",
-      },
-      "messageText": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Link" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "inline": Object {
-        "type": "bool",
-      },
-      "visited": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "Loading" => Object {
-    "defaultProps": Object {
-      "active": true,
-      "description": "Active loading indicator",
-      "small": false,
-      "withOverlay": true,
-    },
-    "propTypes": Object {
-      "active": Object {
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "description": Object {
-        "type": "string",
-      },
-      "small": Object {
-        "type": "bool",
-      },
-      "withOverlay": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "LoadingMessage" => Object {
-    "defaultProps": Object {
-      "active": true,
-      "children": null,
-      "className": "",
-      "small": false,
-      "withOverlay": true,
-    },
-    "propTypes": Object {
-      "active": Object {
-        "type": "bool",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "small": Object {
-        "type": "bool",
-      },
-      "withOverlay": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "Modal" => Object {
-    "defaultProps": Object {
-      "hasScrollingContent": false,
-      "iconDescription": "close the modal",
-      "modalHeading": "",
-      "modalLabel": "",
-      "onKeyDown": [Function],
-      "onRequestClose": [Function],
-      "onRequestSubmit": [Function],
-      "passiveModal": false,
-      "primaryButtonDisabled": false,
-      "selectorPrimaryFocus": "[data-modal-primary-focus]",
-    },
-    "propTypes": Object {
-      "aria-label": [Function],
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "danger": Object {
-        "type": "bool",
-      },
-      "focusTrap": [Function],
-      "hasForm": Object {
-        "type": "bool",
-      },
-      "hasScrollingContent": Object {
-        "type": "bool",
-      },
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "modalAriaLabel": Object {
-        "type": "string",
-      },
-      "modalHeading": Object {
-        "type": "node",
-      },
-      "modalLabel": Object {
-        "type": "node",
-      },
-      "onKeyDown": Object {
-        "type": "func",
-      },
-      "onRequestClose": Object {
-        "type": "func",
-      },
-      "onRequestSubmit": Object {
-        "type": "func",
-      },
-      "onSecondarySubmit": Object {
-        "type": "func",
-      },
-      "open": Object {
-        "type": "bool",
-      },
-      "passiveModal": Object {
-        "type": "bool",
-      },
-      "primaryButtonDisabled": Object {
-        "type": "bool",
-      },
-      "primaryButtonText": Object {
-        "type": "string",
-      },
-      "secondaryButtonText": Object {
-        "type": "string",
-      },
-      "selectorPrimaryFocus": Object {
-        "type": "string",
-      },
-      "selectorsFloatingMenus": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "type": "arrayOf",
-      },
-      "shouldSubmitOnEnter": Object {
-        "type": "bool",
-      },
-      "size": Object {
-        "args": Array [
-          Array [
-            "xs",
-            "sm",
-            "lg",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
-  "ModalWrapper" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "onKeyDown": [Function],
-      "primaryButtonText": "Save",
-      "secondaryButtonText": "Cancel",
-      "selectorPrimaryFocus": "[data-modal-primary-focus]",
-      "triggerButtonIconDescription": "Provide icon description if icon is used",
-      "triggerButtonKind": "primary",
-    },
-    "propTypes": Object {
-      "buttonTriggerClassName": Object {
-        "type": "string",
-      },
-      "buttonTriggerText": Object {
-        "type": "node",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "handleOpen": Object {
-        "type": "func",
-      },
-      "handleSubmit": Object {
-        "type": "func",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "modalBeforeContent": Object {
-        "type": "bool",
-      },
-      "modalHeading": Object {
-        "type": "string",
-      },
-      "modalLabel": Object {
-        "type": "string",
-      },
-      "modalText": Object {
-        "type": "string",
-      },
-      "passiveModal": Object {
-        "type": "bool",
-      },
-      "primaryButtonText": Object {
-        "type": "string",
-      },
-      "renderTriggerButtonIcon": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "secondaryButtonText": Object {
-        "type": "string",
-      },
-      "shouldCloseAfterSubmit": Object {
-        "type": "bool",
-      },
-      "status": Object {
-        "type": "string",
-      },
-      "triggerButtonIconDescription": Object {
-        "type": "string",
-      },
-      "triggerButtonKind": Object {
-        "args": Array [
-          Array [
-            "primary",
-            "secondary",
-            "danger",
-            "ghost",
-            "danger--primary",
-            "tertiary",
-            "ghost-danger",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "withHeader": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "OverflowMenu" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "render": [Function],
-  },
-  "OverflowMenuItem" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "hasDivider": false,
-      "isDelete": false,
-      "itemText": "Provide itemText",
-      "onClick": [Function],
-      "onKeyDown": [Function],
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "closeMenu": Object {
-        "type": "func",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "hasDivider": Object {
-        "type": "bool",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "isDelete": Object {
-        "type": "bool",
-      },
-      "itemText": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "onBlur": Object {
-        "type": "func",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "onFocus": Object {
-        "type": "func",
-      },
-      "onKeyDown": Object {
-        "type": "func",
-      },
-      "onKeyUp": Object {
-        "type": "func",
-      },
-      "onMouseDown": Object {
-        "type": "func",
-      },
-      "onMouseEnter": Object {
-        "type": "func",
-      },
-      "onMouseLeave": Object {
-        "type": "func",
-      },
-      "onMouseUp": Object {
-        "type": "func",
-      },
-      "primaryFocus": Object {
-        "type": "bool",
-      },
-      "requireTitle": Object {
-        "type": "bool",
-      },
-      "wrapperClassName": Object {
-        "type": "string",
-      },
-    },
-  },
-  "RadioButton" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "render": [Function],
-  },
-  "RadioButtonSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "RadioButtonGroup" => Object {
-    "defaultProps": Object {
-      "labelPosition": "right",
-      "onChange": [Function],
-      "orientation": "horizontal",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultSelected": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "labelPosition": Object {
-        "args": Array [
-          Array [
-            "left",
-            "right",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "name": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "orientation": Object {
-        "args": Array [
-          Array [
-            "horizontal",
-            "vertical",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "valueSelected": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-    },
-  },
-  "RadioTile" => Object {
-    "defaultProps": Object {
-      "light": false,
-      "onChange": [Function],
-      "tabIndex": 0,
-    },
-    "propTypes": Object {
-      "checked": Object {
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultChecked": Object {
-        "type": "bool",
-      },
-      "iconDescription": [Function],
-      "id": Object {
-        "type": "string",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "tabIndex": Object {
-        "type": "number",
-      },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOfType",
-      },
-    },
-  },
-  "ScrollGradient" => Object {
-    "ScrollDirection": Object {
-      "X": "X",
-      "Y": "Y",
-    },
-    "ScrollStates": Object {
-      "END": "END",
-      "INITIAL": "INITIAL",
-      "NONE": "NONE",
-      "STARTED": "STARTED",
-    },
-    "defaultProps": Object {
-      "children": undefined,
-      "className": undefined,
-      "direction": "Y",
-      "getScrollElementRef": [Function],
-      "hideStartGradient": false,
-      "onScroll": [Function],
-      "scrollElementClassName": undefined,
-    },
-    "getScrollState": Object {},
-    "propTypes": Object {
-      "children": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "node",
-            },
-            Object {
-              "args": Array [
-                Object {
-                  "type": "node",
-                },
-              ],
-              "type": "arrayOf",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "color": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "direction": Object {
-        "args": Array [
-          Array [
-            "X",
-            "Y",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "getScrollElementRef": Object {
-        "type": "func",
-      },
-      "hideStartGradient": Object {
-        "type": "bool",
-      },
-      "onScroll": Object {
-        "type": "func",
-      },
-      "scrollElementClassName": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Select" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {
-      "disabled": false,
-      "helperText": "",
-      "inline": false,
-      "invalid": false,
-      "invalidText": "",
-      "labelText": "Select",
-      "light": false,
-      "size": "",
-    },
-    "displayName": "Select",
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultValue": Object {
-        "type": "any",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "helperText": Object {
-        "type": "node",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-      "iconDescription": [Function],
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "inline": Object {
-        "type": "bool",
-      },
-      "invalid": Object {
-        "type": "bool",
-      },
-      "invalidText": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "node",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "noLabel": Object {
-        "type": "bool",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "size": Object {
-        "args": Array [
-          Array [
-            "sm",
-            "xl",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-    "render": [Function],
-  },
-  "SelectItem" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "hidden": false,
-      "text": "",
-      "value": "",
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "hidden": Object {
-        "type": "bool",
-      },
-      "text": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "value": Object {
-        "isRequired": true,
-        "type": "any",
-      },
-    },
-  },
-  "SelectItemGroup" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "label": "Provide label",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-    },
-  },
-  "SelectSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "SkeletonText" => Object {
-    "defaultProps": Object {
-      "heading": false,
-      "lineCount": 3,
-      "paragraph": false,
-      "width": "100%",
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "heading": Object {
-        "type": "bool",
-      },
-      "lineCount": Object {
-        "type": "number",
-      },
-      "paragraph": Object {
-        "type": "bool",
-      },
-      "width": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Slider" => Object {
-    "defaultProps": Object {
-      "ariaLabelInput": "Slider number input",
-      "disabled": false,
-      "hideTextInput": false,
-      "inputType": "number",
-      "light": false,
-      "maxLabel": "",
-      "minLabel": "",
-      "step": 1,
-      "stepMultiplier": 4,
-    },
-    "propTypes": Object {
-      "ariaLabelInput": Object {
-        "type": "string",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "formatLabel": Object {
-        "type": "func",
-      },
-      "hideTextInput": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "inputType": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "node",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "max": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-      "maxLabel": Object {
-        "type": "string",
-      },
-      "min": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-      "minLabel": Object {
-        "type": "string",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onRelease": Object {
-        "type": "func",
-      },
-      "step": Object {
-        "type": "number",
-      },
-      "stepMuliplier": [Function],
-      "stepMultiplier": Object {
-        "type": "number",
-      },
-      "value": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-    },
-  },
-  "SliderSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "StructuredListBody" => Object {
-    "defaultProps": Object {
-      "onKeyDown": [Function],
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "head": Object {
-        "type": "bool",
-      },
-      "onKeyDown": Object {
-        "type": "func",
-      },
-    },
-  },
-  "StructuredListCell" => Object {
-    "defaultProps": Object {
-      "head": false,
-      "noWrap": false,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "head": Object {
-        "type": "bool",
-      },
-      "noWrap": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "StructuredListHead" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "StructuredListInput" => Object {
-    "defaultProps": Object {
-      "onChange": [Function],
-      "title": "title",
-      "value": "value",
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "defaultChecked": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "title": Object {
-        "type": "string",
-      },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOfType",
-      },
-    },
-  },
-  "StructuredListRow" => Object {
-    "defaultProps": Object {
-      "head": false,
-      "label": false,
-      "onKeyDown": [Function],
-      "tabIndex": 0,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "head": Object {
-        "type": "bool",
-      },
-      "label": Object {
-        "type": "bool",
-      },
-      "onKeyDown": Object {
-        "type": "func",
-      },
-      "tabIndex": Object {
-        "type": "number",
-      },
-    },
-  },
-  "StructuredListWrapper" => Object {
-    "defaultProps": Object {
-      "ariaLabel": "Structured list section",
-      "border": false,
-      "selection": false,
-    },
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "type": "string",
-      },
-      "border": Object {
-        "type": "bool",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "selection": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "StructuredListSkeleton" => Object {
-    "defaultProps": Object {
-      "border": false,
-      "rowCount": 5,
-    },
-    "propTypes": Object {
-      "border": Object {
-        "type": "bool",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "rowCount": Object {
-        "type": "number",
-      },
-    },
-  },
-  "Tabs" => Object {
-    "defaultProps": Object {
-      "ariaLabel": "listbox",
-      "iconDescription": "show menu options",
-      "role": "navigation",
-      "selected": 0,
-      "triggerHref": "#",
-      "type": "default",
-    },
-    "propTypes": Object {
-      "ariaLabel": Object {
-        "type": "string",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "hidden": Object {
-        "type": "bool",
-      },
-      "iconDescription": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "onKeyDown": Object {
-        "type": "func",
-      },
-      "onSelectionChange": Object {
-        "type": "func",
-      },
-      "role": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "selected": Object {
-        "type": "number",
-      },
-      "tabContentClassName": Object {
-        "type": "string",
-      },
-      "triggerHref": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "type": Object {
-        "args": Array [
-          Array [
-            "default",
-            "container",
-          ],
-        ],
-        "type": "oneOf",
-      },
-    },
-  },
-  "Tab" => Object {
-    "defaultProps": Object {
-      "href": "#",
-      "label": "provide a label",
-      "onClick": [Function],
-      "onKeyDown": [Function],
-      "renderContent": [Function],
-      "role": "presentation",
-      "selected": false,
-      "tabIndex": 0,
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "handleTabClick": Object {
-        "type": "func",
-      },
-      "handleTabKeyDown": Object {
-        "type": "func",
-      },
-      "href": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "index": Object {
-        "type": "number",
-      },
-      "label": Object {
-        "type": "node",
-      },
-      "onClick": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-      "onKeyDown": Object {
-        "isRequired": true,
-        "type": "func",
-      },
-      "renderAnchor": Object {
-        "type": "func",
-      },
-      "renderContent": Object {
-        "type": "func",
-      },
-      "role": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "selected": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "tabIndex": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-    },
-  },
-  "TabsSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "Tile" => Object {
-    "defaultProps": Object {
-      "light": false,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "ClickableTile" => Object {
-    "defaultProps": Object {
-      "clicked": false,
-      "handleClick": [Function],
-      "handleKeyDown": [Function],
-      "light": false,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "rel": Object {
-        "type": "string",
-      },
-    },
-  },
-  "SelectableTile" => Object {
-    "defaultProps": Object {
-      "handleClick": [Function],
-      "handleKeyDown": [Function],
-      "light": false,
-      "onChange": [Function],
-      "selected": false,
-      "tabIndex": 0,
-      "title": "title",
-      "value": "value",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "iconDescription": [Function],
-      "id": Object {
-        "type": "string",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "selected": Object {
-        "type": "bool",
-      },
-      "tabIndex": Object {
-        "type": "number",
-      },
-      "title": Object {
-        "type": "string",
-      },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOfType",
-      },
-    },
-  },
-  "ExpandableTile" => Object {
-    "defaultProps": Object {
-      "expanded": false,
-      "handleClick": [Function],
-      "light": false,
-      "onBeforeClick": [Function],
-      "tabIndex": 0,
-      "tileCollapsedIconText": "Interact to expand Tile",
-      "tileExpandedIconText": "Interact to collapse Tile",
-      "tileMaxHeight": 0,
-      "tilePadding": 0,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "expanded": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "onBeforeClick": Object {
-        "type": "func",
-      },
-      "tabIndex": Object {
-        "type": "number",
-      },
-      "tileCollapsedIconText": Object {
-        "type": "string",
-      },
-      "tileExpandedIconText": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TileAboveTheFoldContent" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-    },
-  },
-  "TileBelowTheFoldContent" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-    },
-  },
-  "TileGroup" => Object {
-    "defaultProps": Object {
-      "onChange": [Function],
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultSelected": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "legend": Object {
-        "type": "string",
-      },
-      "name": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "valueSelected": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-    },
-  },
-  "TimePicker" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "invalid": false,
-      "invalidText": "Invalid time format.",
-      "light": false,
-      "maxLength": 5,
-      "onBlur": [Function],
-      "onChange": [Function],
-      "onClick": [Function],
-      "pattern": "(1[012]|[1-9]):[0-5][0-9](\\\\s)?",
-      "placeholder": "hh:mm",
-      "type": "text",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "invalid": Object {
-        "type": "bool",
-      },
-      "invalidText": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "node",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "maxLength": Object {
-        "type": "number",
-      },
-      "onBlur": Object {
-        "type": "func",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "pattern": Object {
-        "type": "string",
-      },
-      "placeholder": Object {
-        "type": "string",
-      },
-      "type": Object {
-        "type": "string",
-      },
-      "value": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TimePickerSelect" => Object {
-    "defaultProps": Object {
-      "disabled": false,
-      "hideLabel": true,
-      "iconDescription": "open list of options",
-      "inline": true,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultValue": Object {
-        "type": "any",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-      "iconDescription": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "inline": Object {
-        "type": "bool",
-      },
-      "labelText": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-    },
-  },
-  "Toggle" => Object {
-    "defaultProps": Object {
-      "aria-label": "Toggle",
-      "defaultToggled": false,
-      "labelA": "Off",
-      "labelB": "On",
-      "onToggle": [Function],
-    },
-    "propTypes": Object {
-      "aria-label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultToggled": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "labelA": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "labelB": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "string",
-      },
-      "onToggle": Object {
-        "type": "func",
-      },
-      "toggled": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "ToggleSkeleton" => Object {
-    "defaultProps": Object {
-      "aria-label": "Toggle is loading",
-    },
-    "propTypes": Object {
-      "aria-label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "string",
-      },
-    },
-  },
-  "TextArea" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {
-      "cols": 50,
-      "disabled": false,
-      "helperText": "",
-      "invalid": false,
-      "invalidText": "",
-      "light": false,
-      "onChange": [Function],
-      "onClick": [Function],
-      "placeholder": "",
-      "rows": 4,
-    },
-    "displayName": "TextArea",
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "cols": Object {
-        "type": "number",
-      },
-      "defaultValue": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "disabled": Object {
-        "type": "bool",
-      },
-      "helperText": Object {
-        "type": "node",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "invalid": Object {
-        "type": "bool",
-      },
-      "invalidText": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "light": Object {
-        "type": "bool",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "onClick": Object {
-        "type": "func",
-      },
-      "placeholder": Object {
-        "type": "string",
-      },
-      "rows": Object {
-        "type": "number",
-      },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-    },
-    "render": [Function],
-  },
-  "TextAreaSkeleton" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "hideLabel": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "ToggleSmall" => Object {
-    "defaultProps": Object {
-      "defaultToggled": false,
-      "labelA": "Off",
-      "labelB": "On",
-      "onToggle": [Function],
-    },
-    "propTypes": Object {
-      "aria-label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "defaultToggled": Object {
-        "type": "bool",
-      },
-      "id": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "labelA": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "labelB": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "string",
-      },
-      "onToggle": Object {
-        "type": "func",
-      },
-      "toggled": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "ToggleSmallSkeleton" => Object {
-    "defaultProps": Object {
-      "aria-label": "Toggle is loading",
-    },
-    "propTypes": Object {
-      "aria-label": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "type": "string",
-      },
-    },
-  },
   "Tooltip" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "render": [Function],
@@ -10588,123 +10903,64 @@ Map {
       },
     },
   },
-  "FormItem" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "FormLabel" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "id": Object {
-        "type": "string",
-      },
-    },
-  },
-  "ListItem" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "NotificationButton" => Object {
+  "TrendingCard" => Object {
     "defaultProps": Object {
-      "ariaLabel": "close notification",
-      "iconDescription": "close icon",
-      "notificationType": "toast",
-      "renderIcon": Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "render": [Function],
-      },
-      "type": "button",
+      "className": null,
+      "element": "a",
+      "subtitle": null,
     },
     "propTypes": Object {
-      "ariaLabel": Object {
-        "type": "string",
-      },
       "className": Object {
         "type": "string",
       },
-      "iconDescription": Object {
-        "type": "string",
-      },
-      "name": Object {
-        "type": "string",
-      },
-      "notificationType": Object {
-        "args": Array [
-          Array [
-            "toast",
-            "inline",
-          ],
-        ],
-        "type": "oneOf",
-      },
-      "renderIcon": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-      "type": Object {
-        "type": "string",
-      },
-    },
-  },
-  "NotificationTextDetails" => Object {
-    "defaultProps": Object {
-      "caption": "caption",
-      "notificationType": "toast",
-      "title": "title",
-    },
-    "propTypes": Object {
-      "caption": Object {
-        "type": "node",
-      },
-      "children": Object {
-        "type": "node",
-      },
-      "notificationType": Object {
-        "args": Array [
-          Array [
-            "toast",
-            "inline",
-          ],
-        ],
-        "type": "oneOf",
+      "element": Object {
+        "type": "elementType",
       },
       "subtitle": Object {
         "type": "node",
       },
       "title": Object {
+        "isRequired": true,
         "type": "string",
       },
     },
   },
-  "OrderedList" => Object {
+  "TypeLayout" => Object {
     "defaultProps": Object {
-      "nested": false,
+      "border": false,
+      "bordered": null,
+      "children": null,
+      "className": "",
+      "size": "md",
+    },
+    "propTypes": Object {
+      "border": Object {
+        "type": "bool",
+      },
+      "bordered": [Function],
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
+  "TypeLayoutBody" => Object {
+    "defaultProps": Object {
+      "children": null,
+      "className": "",
     },
     "propTypes": Object {
       "children": Object {
@@ -10713,14 +10969,12 @@ Map {
       "className": Object {
         "type": "string",
       },
-      "nested": Object {
-        "type": "bool",
-      },
     },
   },
-  "TabContent" => Object {
+  "TypeLayoutCell" => Object {
     "defaultProps": Object {
-      "selected": false,
+      "children": null,
+      "className": "",
     },
     "propTypes": Object {
       "children": Object {
@@ -10729,14 +10983,12 @@ Map {
       "className": Object {
         "type": "string",
       },
-      "selected": Object {
-        "type": "bool",
-      },
     },
   },
-  "UnorderedList" => Object {
+  "TypeLayoutRow" => Object {
     "defaultProps": Object {
-      "nested": false,
+      "children": null,
+      "className": "",
     },
     "propTypes": Object {
       "children": Object {
@@ -10744,9 +10996,6 @@ Map {
       },
       "className": Object {
         "type": "string",
-      },
-      "nested": Object {
-        "type": "bool",
       },
     },
   },
@@ -10845,328 +11094,114 @@ Map {
       },
     },
   },
-  "PageSelector" => Object {
+  "UnorderedList" => Object {
     "defaultProps": Object {
-      "className": null,
-      "id": 1,
-      "labelText": "Current page number",
+      "nested": false,
     },
     "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
       "className": Object {
         "type": "string",
       },
-      "currentPage": Object {
-        "isRequired": true,
-        "type": "number",
+      "nested": Object {
+        "type": "bool",
       },
-      "id": Object {
+    },
+  },
+  "Wizard" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "focusTrap": true,
+      "initState": Object {},
+      "isOpen": undefined,
+      "isSequential": undefined,
+      "labels": Object {},
+      "onClose": [Function],
+      "onDelete": [Function],
+      "rootNode": <body />,
+      "steps": Array [],
+      "subTitle": "",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "focusTrap": Object {
+        "type": "bool",
+      },
+      "initState": Object {
         "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
+          [Function],
         ],
-        "type": "oneOfType",
+        "type": "instanceOf",
       },
-      "labelText": Object {
-        "type": "string",
-      },
-      "totalPages": Object {
-        "isRequired": true,
-        "type": "number",
-      },
-    },
-  },
-  "Content" => Object {
-    "defaultProps": Object {
-      "tagName": "main",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "tagName": Object {
-        "type": "string",
-      },
-    },
-  },
-  "CarbonHeader" => Object {
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "HeaderContainer" => Object {
-    "defaultProps": Object {
-      "isSideNavExpanded": false,
-    },
-    "propTypes": Object {
-      "isSideNavExpanded": Object {
+      "isOpen": Object {
         "type": "bool",
       },
-    },
-  },
-  "HeaderGlobalAction" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "displayName": "HeaderGlobalAction",
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "isActive": Object {
+      "isSequential": Object {
         "type": "bool",
       },
-      "onClick": Object {
+      "labels": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Array [
+                Object {
+                  "type": "string",
+                },
+                Object {
+                  "type": "func",
+                },
+                Object {
+                  "type": "object",
+                },
+              ],
+            ],
+            "type": "oneOfType",
+          },
+        ],
+        "type": "objectOf",
+      },
+      "onClose": Object {
         "type": "func",
       },
-    },
-    "render": [Function],
-  },
-  "HeaderGlobalBar" => Object {
-    "displayName": "HeaderGlobalBar",
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "HeaderMenu" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "displayName": "HeaderMenu",
-    "render": [Function],
-  },
-  "HeaderMenuButton" => Object {
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "className": Object {
-        "type": "string",
-      },
-      "isActive": Object {
-        "type": "bool",
-      },
-      "onClick": Object {
+      "onDelete": Object {
         "type": "func",
       },
-    },
-  },
-  "HeaderMenuItem" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
+      "rootNode": Object {
+        "args": Array [
+          [Function],
+        ],
+        "type": "instanceOf",
       },
-      "className": Object {
-        "type": "string",
+      "steps": Object {
+        "args": Array [
+          Object {
+            "args": Array [
+              Object {
+                "next": Object {
+                  "type": "func",
+                },
+                "renderMain": Object {
+                  "type": "func",
+                },
+                "title": Object {
+                  "isRequired": true,
+                  "type": "string",
+                },
+                "validate": Object {
+                  "type": "func",
+                },
+              },
+            ],
+            "type": "shape",
+          },
+        ],
+        "type": "arrayOf",
       },
-      "element": Object {
-        "type": "elementType",
-      },
-      "isSideNavExpanded": Object {
-        "type": "bool",
-      },
-      "role": Object {
-        "type": "string",
-      },
-    },
-    "render": [Function],
-  },
-  "HeaderName" => Object {
-    "defaultProps": Object {
-      "prefix": "IBM",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "element": Object {
-        "type": "elementType",
-      },
-      "href": Object {
-        "type": "string",
-      },
-      "isSideNavExpanded": Object {
-        "type": "bool",
-      },
-      "prefix": Object {
-        "type": "string",
-      },
-    },
-  },
-  "HeaderNavigation" => Object {
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "HeaderPanel" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "displayName": "HeaderPanel",
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "className": Object {
-        "type": "string",
-      },
-      "expanded": Object {
-        "type": "bool",
-      },
-    },
-    "render": [Function],
-  },
-  "HeaderSideNavItems" => Object {
-    "defaultProps": Object {
-      "hasDivider": false,
-    },
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "hasDivider": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "Switcher" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-    "render": [Function],
-  },
-  "SwitcherItem" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-    "render": [Function],
-  },
-  "SwitcherDivider" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "SkipToContent" => Object {
-    "defaultProps": Object {
-      "children": "Skip to main content",
-      "href": "#main-content",
-      "tabIndex": "0",
-    },
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "href": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "tabIndex": Object {
-        "type": "string",
-      },
-    },
-  },
-  "SideNav" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {
-      "addFocusListeners": true,
-      "addMouseListeners": true,
-      "defaultExpanded": false,
-      "isChildOfHeader": true,
-      "isFixedNav": false,
-      "isPersistent": true,
-      "translateById": [Function],
-    },
-    "propTypes": Object {
-      "addFocusListeners": Object {
-        "type": "bool",
-      },
-      "addMouseListeners": Object {
-        "type": "bool",
-      },
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
-      "className": Object {
-        "type": "string",
-      },
-      "defaultExpanded": Object {
-        "type": "bool",
-      },
-      "expanded": Object {
-        "type": "bool",
-      },
-      "isChildOfHeader": Object {
-        "type": "bool",
-      },
-      "isFixedNav": Object {
-        "type": "bool",
-      },
-      "isPersistent": Object {
-        "type": "bool",
-      },
-      "isRail": Object {
-        "type": "bool",
-      },
-      "onToggle": Object {
-        "type": "func",
-      },
-      "translateById": Object {
-        "type": "func",
-      },
-    },
-    "render": [Function],
-  },
-  "SideNavDetails" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
+      "subTitle": Object {
         "type": "string",
       },
       "title": Object {
@@ -11175,190 +11210,155 @@ Map {
       },
     },
   },
-  "SideNavFooter" => Object {
+  "WizardStep" => Object {
     "defaultProps": Object {
-      "assistiveText": "Toggle opening or closing the side navigation",
+      "next": [Function],
+      "renderMain": [Function],
+      "validate": [Function],
     },
+    "getPropsFromElement": Object {},
     "propTypes": Object {
-      "assistiveText": Object {
+      "next": Object {
+        "type": "func",
+      },
+      "renderMain": Object {
+        "type": "func",
+      },
+      "title": Object {
         "isRequired": true,
         "type": "string",
       },
-      "expanded": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "isSideNavExpanded": Object {
-        "type": "bool",
-      },
-      "onToggle": Object {
-        "isRequired": true,
+      "validate": Object {
         "type": "func",
       },
     },
   },
-  "SideNavHeader" => Object {
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "isSideNavExpanded": Object {
-        "type": "bool",
-      },
-      "renderIcon": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOfType",
-      },
-    },
-  },
-  "SideNavIcon" => Object {
-    "defaultProps": Object {
-      "small": false,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "small": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-    },
-  },
-  "SideNavItem" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "large": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "SideNavItems" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "isSideNavExpanded": Object {
-        "type": "bool",
-      },
-    },
-  },
-  "SideNavLink" => Object {
-    "defaultProps": Object {
-      "element": "a",
-      "large": false,
-    },
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "element": Object {
-        "type": "elementType",
-      },
-      "isSideNavExpanded": Object {
-        "type": "bool",
-      },
-      "large": Object {
-        "type": "bool",
-      },
-      "renderIcon": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "func",
-            },
-            Object {
-              "type": "object",
-            },
-          ],
-        ],
-        "type": "oneOfType",
-      },
-    },
-  },
-  "SideNavLinkText" => Object {
-    "propTypes": Object {
-      "children": Object {
-        "isRequired": true,
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-    },
-  },
-  "SideNavMenu" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "displayName": "SideNavMenu",
-    "render": [Function],
-  },
-  "SideNavMenuItem" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "propTypes": Object {
-      "children": Object {
-        "type": "node",
-      },
-      "className": Object {
-        "type": "string",
-      },
-      "isActive": Object {
-        "type": "bool",
-      },
-    },
-    "render": [Function],
-  },
-  "SideNavSwitcher" => Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "propTypes": Object {
-      "className": Object {
-        "type": "string",
-      },
-      "labelText": Object {
-        "isRequired": true,
-        "type": "string",
-      },
-      "onChange": Object {
-        "type": "func",
-      },
-      "options": Object {
-        "args": Array [
-          Object {
-            "type": "string",
-          },
-        ],
-        "isRequired": true,
-        "type": "arrayOf",
-      },
-    },
-    "render": [Function],
+  "theme" => Object {
+    "active01": "var(--active-01, #525252)",
+    "activeDanger": "var(--active-danger, #750e13)",
+    "activePrimary": "var(--active-primary, #002d9c)",
+    "activeSecondary": "var(--active-secondary, #393939)",
+    "activeTertiary": "var(--active-tertiary, #c6c6c6)",
+    "activeUI": "var(--active-ui, #525252)",
+    "bodyLong01": "var(--body-long-01, [object Object])",
+    "bodyLong02": "var(--body-long-02, [object Object])",
+    "bodyShort01": "var(--body-short-01, [object Object])",
+    "bodyShort02": "var(--body-short-02, [object Object])",
+    "brand01": "var(--brand-01, #0f62fe)",
+    "brand02": "var(--brand-02, #6f6f6f)",
+    "brand03": "var(--brand-03, #ffffff)",
+    "caption01": "var(--caption-01, [object Object])",
+    "code01": "var(--code-01, [object Object])",
+    "code02": "var(--code-02, [object Object])",
+    "container01": "var(--container-01, 1.5rem)",
+    "container02": "var(--container-02, 2rem)",
+    "container03": "var(--container-03, 2.5rem)",
+    "container04": "var(--container-04, 3rem)",
+    "container05": "var(--container-05, 4rem)",
+    "danger": "var(--danger, #da1e28)",
+    "disabled01": "var(--disabled-01, #262626)",
+    "disabled02": "var(--disabled-02, #525252)",
+    "disabled03": "var(--disabled-03, #6f6f6f)",
+    "display01": "var(--display-01, [object Object])",
+    "display02": "var(--display-02, [object Object])",
+    "display03": "var(--display-03, [object Object])",
+    "display04": "var(--display-04, [object Object])",
+    "expressiveHeading01": "var(--expressive-heading-01, [object Object])",
+    "expressiveHeading02": "var(--expressive-heading-02, [object Object])",
+    "expressiveHeading03": "var(--expressive-heading-03, [object Object])",
+    "expressiveHeading04": "var(--expressive-heading-04, [object Object])",
+    "expressiveHeading05": "var(--expressive-heading-05, [object Object])",
+    "expressiveHeading06": "var(--expressive-heading-06, [object Object])",
+    "expressiveParagraph01": "var(--expressive-paragraph-01, [object Object])",
+    "field01": "var(--field-01, #262626)",
+    "field02": "var(--field-02, #393939)",
+    "fluidSpacing01": "var(--fluid-spacing-01, 0)",
+    "fluidSpacing02": "var(--fluid-spacing-02, 2vw)",
+    "fluidSpacing03": "var(--fluid-spacing-03, 5vw)",
+    "fluidSpacing04": "var(--fluid-spacing-04, 10vw)",
+    "focus": "var(--focus, #ffffff)",
+    "heading01": "var(--heading-01, [object Object])",
+    "heading02": "var(--heading-02, [object Object])",
+    "helperText01": "var(--helper-text-01, [object Object])",
+    "highlight": "var(--highlight, #002d9c)",
+    "hoverDanger": "var(--hover-danger, #b81921)",
+    "hoverField": "var(--hover-field, #353535)",
+    "hoverPrimary": "var(--hover-primary, #0353e9)",
+    "hoverPrimaryText": "var(--hover-primary-text, #a6c8ff)",
+    "hoverRow": "var(--hover-row, #353535)",
+    "hoverSecondary": "var(--hover-secondary, #606060)",
+    "hoverSelectedUI": "var(--hover-selected-ui, #4c4c4c)",
+    "hoverTertiary": "var(--hover-tertiary, #f4f4f4)",
+    "hoverUI": "var(--hover-ui, #353535)",
+    "icon01": "var(--icon-01, #f4f4f4)",
+    "icon02": "var(--icon-02, #c6c6c6)",
+    "icon03": "var(--icon-03, #ffffff)",
+    "iconSize01": "var(--icon-size-01, 1rem)",
+    "iconSize02": "var(--icon-size-02, 1.25rem)",
+    "interactive01": "var(--interactive-01, #0f62fe)",
+    "interactive02": "var(--interactive-02, #6f6f6f)",
+    "interactive03": "var(--interactive-03, #ffffff)",
+    "interactive04": "var(--interactive-04, #4589ff)",
+    "inverse01": "var(--inverse-01, #161616)",
+    "inverse02": "var(--inverse-02, #f4f4f4)",
+    "inverseFocusUi": "var(--inverse-focus-ui, #0f62fe)",
+    "inverseHoverUI": "var(--inverse-hover-ui, #e5e5e5)",
+    "inverseLink": "var(--inverse-link, #0f62fe)",
+    "inverseSupport01": "var(--inverse-support-01, #da1e28)",
+    "inverseSupport02": "var(--inverse-support-02, #24a148)",
+    "inverseSupport03": "var(--inverse-support-03, #f1c21b)",
+    "inverseSupport04": "var(--inverse-support-04, #0f62fe)",
+    "label01": "var(--label-01, [object Object])",
+    "layout01": "var(--layout-01, 1rem)",
+    "layout02": "var(--layout-02, 1.5rem)",
+    "layout03": "var(--layout-03, 2rem)",
+    "layout04": "var(--layout-04, 3rem)",
+    "layout05": "var(--layout-05, 4rem)",
+    "layout06": "var(--layout-06, 6rem)",
+    "layout07": "var(--layout-07, 10rem)",
+    "link01": "var(--link-01, #78a9ff)",
+    "overlay01": "var(--overlay-01, rgba(22, 22, 22, 0.7))",
+    "productiveHeading01": "var(--productive-heading-01, [object Object])",
+    "productiveHeading02": "var(--productive-heading-02, [object Object])",
+    "productiveHeading03": "var(--productive-heading-03, [object Object])",
+    "productiveHeading04": "var(--productive-heading-04, [object Object])",
+    "productiveHeading05": "var(--productive-heading-05, [object Object])",
+    "productiveHeading06": "var(--productive-heading-06, [object Object])",
+    "productiveHeading07": "var(--productive-heading-07, [object Object])",
+    "quotation01": "var(--quotation-01, [object Object])",
+    "quotation02": "var(--quotation-02, [object Object])",
+    "selectedUI": "var(--selected-ui, #393939)",
+    "skeleton01": "var(--skeleton-01, #353535)",
+    "skeleton02": "var(--skeleton-02, #393939)",
+    "spacing01": "var(--spacing-01, 0.125rem)",
+    "spacing02": "var(--spacing-02, 0.25rem)",
+    "spacing03": "var(--spacing-03, 0.5rem)",
+    "spacing04": "var(--spacing-04, 0.75rem)",
+    "spacing05": "var(--spacing-05, 1rem)",
+    "spacing06": "var(--spacing-06, 1.5rem)",
+    "spacing07": "var(--spacing-07, 2rem)",
+    "spacing08": "var(--spacing-08, 2.5rem)",
+    "spacing09": "var(--spacing-09, 3rem)",
+    "spacing10": "var(--spacing-10, 4rem)",
+    "spacing11": "var(--spacing-11, 5rem)",
+    "spacing12": "var(--spacing-12, 6rem)",
+    "support01": "var(--support-01, #fa4d56)",
+    "support02": "var(--support-02, #42be65)",
+    "support03": "var(--support-03, #f1c21b)",
+    "support04": "var(--support-04, #4589ff)",
+    "text01": "var(--text-01, #f4f4f4)",
+    "text02": "var(--text-02, #c6c6c6)",
+    "text03": "var(--text-03, #6f6f6f)",
+    "text04": "var(--text-04, #ffffff)",
+    "text05": "var(--text-05, #8d8d8d)",
+    "textError": "var(--text-error, #ff8389)",
+    "ui01": "var(--ui-01, #262626)",
+    "ui02": "var(--ui-02, #393939)",
+    "ui03": "var(--ui-03, #393939)",
+    "ui04": "var(--ui-04, #6f6f6f)",
+    "ui05": "var(--ui-05, #f4f4f4)",
+    "uiBackground": "var(--ui-background, #161616)",
+    "visitedLink": "var(--visited-link, #be95ff)",
   },
 }
 `;

--- a/src/components/__tests__/publicAPI.spec.js
+++ b/src/components/__tests__/publicAPI.spec.js
@@ -6,7 +6,7 @@
  *
  */
 
-const { isValidElementType } = require('react-is');
+import { isValidElementType } from 'react-is';
 
 /**
  * In our Public API test, we try to identify each component and its
@@ -164,13 +164,15 @@ describe('PublicAPI', () => {
     }
 
     // eslint-disable-next-line global-require
-    const Components = require('../../index');
+    const Components = require('../..');
     const PublicAPI = new Map();
 
-    Object.keys(Components).forEach(name => {
-      const Component = Components[name];
-      PublicAPI.set(name, mapComponentToAPI(Component));
-    });
+    Object.keys(Components)
+      .sort()
+      .forEach(name => {
+        const Component = Components[name];
+        PublicAPI.set(name, mapComponentToAPI(Component));
+      });
 
     expect(PublicAPI).toMatchSnapshot();
   });


### PR DESCRIPTION
## Proposed changes

- Sort components before creating snapshot to ignore reorganisation of exports
- Add `jest` script to allow individual file testing