### PR TITLE
feat(carbon): mark carbon core pkgs as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,16 @@
     "yarn": "^1.16.0"
   },
   "peerDependencies": {
+    "@carbon/colors": "10.7.2",
+    "@carbon/grid": "10.8.2",
+    "@carbon/icons-react": "10.8.2",
+    "@carbon/import-once": "10.3.0",
+    "@carbon/layout": "10.7.3",
+    "@carbon/motion": "10.5.2",
+    "@carbon/themes": "10.9.3",
+    "@carbon/type": "10.8.3",
+    "carbon-components": "10.9.3",
+    "carbon-components-react": "7.9.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },


### PR DESCRIPTION
## Affected issues

- Resolves #402 

## Proposed changes

- mark `carbon-components`, `carbon-components-react`, and `@carbon/*` elements packages as peer dependencies