### PR TITLE
chore(accordion): remove unused imported prefix

### DIFF
--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -6,8 +6,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { carbonPrefix } from '../../../globals/namespace';
-
 import { Accordion, AccordionItem } from '../../..';
 
 describe('Accordion', () => {


### PR DESCRIPTION
## Proposed changes

- removed unused import that was causing a linting error