### PR TITLE
fix(scroll-gradient): apply scroll state styles to direct children only

### DIFF
--- a/src/components/ScrollGradient/ScrollGradient.stories.js
+++ b/src/components/ScrollGradient/ScrollGradient.stories.js
@@ -87,8 +87,9 @@ storiesOf(components('ScrollGradient'), module)
         style={style}
         className={className}
       >
-        Content fits completely within content area, so neither scrollbar nor
+        <p>Content fits completely within content area, so neither scrollbar nor
         scroll gradients are necessary.
+        </p>
       </ScrollGradient>
     ),
     {
@@ -107,13 +108,14 @@ storiesOf(components('ScrollGradient'), module)
       className={className}
     >
       <p>Content before the scrollable element.</p>
+
       <ScrollGradient
         color={color('child color (color)', gradientColor)}
-
-        style={{ boxShadow: '0 0 0 1px currentColor', height: '6rem', margin: '1rem 0'}}
+        style={{ height: '6rem', margin: '1rem 0'}}
       >
-        Does not need to scroll.
+        <p>Does not need to scroll so does not have a gradient.</p>
       </ScrollGradient>
+
       <p>Content after the scrollable element.</p>
 
       {children}
@@ -122,7 +124,7 @@ storiesOf(components('ScrollGradient'), module)
   {
     info: {
       text: `
-      This component does not render gradients if the content can fit completely within the allowed area.
+      This story demonstrates that the scroll gradient state of a parent does not affect the scroll state of a child scroll gradient.
     `,
     },
   });

--- a/src/components/ScrollGradient/ScrollGradient.stories.js
+++ b/src/components/ScrollGradient/ScrollGradient.stories.js
@@ -98,4 +98,31 @@ storiesOf(components('ScrollGradient'), module)
       `,
       },
     }
-  );
+  )
+  .add('with internal gradients',
+  () => (
+    <ScrollGradient
+      color={color('color', gradientColor)}
+      style={style}
+      className={className}
+    >
+      <p>Content before the scrollable element.</p>
+      <ScrollGradient
+        color={color('child color (color)', gradientColor)}
+
+        style={{ boxShadow: '0 0 0 1px currentColor', height: '6rem', margin: '1rem 0'}}
+      >
+        Does not need to scroll.
+      </ScrollGradient>
+      <p>Content after the scrollable element.</p>
+
+      {children}
+    </ScrollGradient>
+  ),
+  {
+    info: {
+      text: `
+      This component does not render gradients if the content can fit completely within the allowed area.
+    `,
+    },
+  });

--- a/src/components/ScrollGradient/_index.scss
+++ b/src/components/ScrollGradient/_index.scss
@@ -27,8 +27,8 @@
     width: 100%;
   }
 
-  > &__before,
-  > &__after {
+  &__before,
+  &__after {
     display: block;
     position: absolute;
     opacity: 0;
@@ -37,35 +37,35 @@
   }
 
   &--x {
-    > #{$block}__before,
-    > #{$block}__after {
+    #{$block}__before,
+    #{$block}__after {
       top: 0;
       width: $scroll-gradient__gradient__sizing;
       height: 100%;
     }
 
-    > #{$block}__before {
+    #{$block}__before {
       left: 0;
     }
 
-    > #{$block}__after {
+    #{$block}__after {
       right: 0;
     }
   }
 
   &--y {
-    > #{$block}__before,
-    > #{$block}__after {
+    #{$block}__before,
+    #{$block}__after {
       left: 0;
       height: $scroll-gradient__gradient__sizing;
       width: 100%;
     }
 
-    > #{$block}__before {
+    #{$block}__before {
       top: 0;
     }
 
-    > #{$block}__after {
+    #{$block}__after {
       bottom: 0;
     }
   }

--- a/src/components/ScrollGradient/_index.scss
+++ b/src/components/ScrollGradient/_index.scss
@@ -27,8 +27,8 @@
     width: 100%;
   }
 
-  &__before,
-  &__after {
+  > &__before,
+  > &__after {
     display: block;
     position: absolute;
     opacity: 0;
@@ -37,49 +37,49 @@
   }
 
   &--x {
-    #{$block}__before,
-    #{$block}__after {
+    > #{$block}__before,
+    > #{$block}__after {
       top: 0;
       width: $scroll-gradient__gradient__sizing;
       height: 100%;
     }
 
-    #{$block}__before {
+    > #{$block}__before {
       left: 0;
     }
 
-    #{$block}__after {
+    > #{$block}__after {
       right: 0;
     }
   }
 
   &--y {
-    #{$block}__before,
-    #{$block}__after {
+    > #{$block}__before,
+    > #{$block}__after {
       left: 0;
       height: $scroll-gradient__gradient__sizing;
       width: 100%;
     }
 
-    #{$block}__before {
+    > #{$block}__before {
       top: 0;
     }
 
-    #{$block}__after {
+    > #{$block}__after {
       bottom: 0;
     }
   }
 
   &--initial,
   &--started {
-    #{$block}__after {
+    > #{$block}__after {
       opacity: 1;
     }
   }
 
   &--end,
   &--started {
-    #{$block}__before {
+    > #{$block}__before {
       opacity: 1;
     }
   }

--- a/src/components/TypeLayout/TypeLayout.stories.js
+++ b/src/components/TypeLayout/TypeLayout.stories.js
@@ -13,7 +13,6 @@ import {
   TypeLayoutBody,
   TypeLayoutRow,
   TypeLayoutCell,
-  CodeSnippet,
 } from '../..';
 
 import rows from './_mocks_';
@@ -30,9 +29,7 @@ storiesOf(components('TypeLayout'), module)
               <TypeLayoutCell>{title}</TypeLayoutCell>
               <TypeLayoutCell>
                 <ul>
-                  <li>
-                    <CodeSnippet type="multi">{description}</CodeSnippet>
-                  </li>
+                  <li>{description}</li>
                 </ul>
               </TypeLayoutCell>
             </TypeLayoutRow>

--- a/src/components/TypeLayout/TypeLayout.stories.js
+++ b/src/components/TypeLayout/TypeLayout.stories.js
@@ -13,6 +13,7 @@ import {
   TypeLayoutBody,
   TypeLayoutRow,
   TypeLayoutCell,
+  CodeSnippet,
 } from '../..';
 
 import rows from './_mocks_';
@@ -29,7 +30,9 @@ storiesOf(components('TypeLayout'), module)
               <TypeLayoutCell>{title}</TypeLayoutCell>
               <TypeLayoutCell>
                 <ul>
-                  <li>{description}</li>
+                  <li>
+                    <CodeSnippet type="multi">{description}</CodeSnippet>
+                  </li>
                 </ul>
               </TypeLayoutCell>
             </TypeLayoutRow>


### PR DESCRIPTION
## Proposed changes

- Fix bug that a parent scroll gradient applies gradients on child scroll gradients.

## Testing instructions

- Check out the new story added for the ScrollGradient component
- Notice that the internal scroll gradient does not get its gradient activated by its parent
