### PR TITLE
feat(card-layout): add example card layouts

### DIFF
--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayout.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayout.js
@@ -1,0 +1,33 @@
+/**
+ * @file Card layout.
+ * @copyright IBM Security 2020
+ */
+
+import classnames from 'classnames';
+import { string, node } from 'prop-types';
+import React from 'react';
+
+import { getComponentNamespace } from '../../../globals/namespace';
+
+export const namespace = getComponentNamespace('card-layout');
+
+function UNSTABLE__CardLayout({ children, className, ...other }) {
+  const classes = classnames(namespace, className);
+  return (
+    <div fullWidth condensed className={classes} {...other}>
+      {children}
+    </div>
+  );
+}
+
+UNSTABLE__CardLayout.propTypes = {
+  children: node,
+  className: string,
+};
+
+UNSTABLE__CardLayout.defaultProps = {
+  children: undefined,
+  className: undefined,
+};
+
+export default UNSTABLE__CardLayout;

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayout.stories.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayout.stories.js
@@ -1,0 +1,169 @@
+/**
+ * @file Card layout stories.
+ * @copyright IBM Security 2020
+ */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { disableCentered, patterns } from '../../../../.storybook';
+import {
+  theme,
+  UNSTABLE__CardLayout,
+  UNSTABLE__CardLayoutRow,
+  UNSTABLE__CardLayoutColumn,
+  UNSTABLE__CardLayoutAside,
+  UNSTABLE__CardLayoutMain,
+} from '../../..';
+
+function DemoContent() {
+  return (
+    <div
+      style={{
+        backgroundColor: theme.interactive04,
+        minHeight: '240px',
+        height: '100%',
+        width: '100%',
+      }}
+    >
+      lorem ipsum
+    </div>
+  );
+}
+
+disableCentered(storiesOf(patterns('CardLayout'), module))
+  .add('layout #1', () => (
+    <>
+      <h1 style={{ margin: '16px' }}>Card layout #1</h1>
+      <UNSTABLE__CardLayout>
+        <UNSTABLE__CardLayoutAside
+          style={{
+            minHeight: '483px',
+            height: '100%',
+            backgroundColor: theme.interactive01,
+            width: '100%',
+          }}
+        >
+          lorem ipsum
+        </UNSTABLE__CardLayoutAside>
+        <UNSTABLE__CardLayoutMain>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn size="lg">
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+        </UNSTABLE__CardLayoutMain>
+      </UNSTABLE__CardLayout>
+    </>
+  ))
+  .add('layout #2', () => (
+    <>
+      <h1 style={{ margin: '16px' }}>Card layout #2</h1>
+      <UNSTABLE__CardLayout>
+        <UNSTABLE__CardLayoutAside
+          style={{
+            minHeight: '725px',
+            height: '100%',
+            backgroundColor: theme.interactive01,
+            width: '100%',
+          }}
+        >
+          lorem ipsum
+        </UNSTABLE__CardLayoutAside>
+        <UNSTABLE__CardLayoutMain>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+        </UNSTABLE__CardLayoutMain>
+      </UNSTABLE__CardLayout>
+    </>
+  ))
+  .add('layout #3', () => (
+    <>
+      <h1 style={{ margin: '16px' }}>Card layout #3</h1>
+      <UNSTABLE__CardLayout>
+        <UNSTABLE__CardLayoutMain>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn size="xl">
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+          <UNSTABLE__CardLayoutRow>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+            <UNSTABLE__CardLayoutColumn>
+              <DemoContent />
+            </UNSTABLE__CardLayoutColumn>
+          </UNSTABLE__CardLayoutRow>
+        </UNSTABLE__CardLayoutMain>
+      </UNSTABLE__CardLayout>
+    </>
+  ));

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutAside.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutAside.js
@@ -1,0 +1,32 @@
+/**
+ * @file Card layout aside.
+ * @copyright IBM Security 2020
+ */
+
+import classnames from 'classnames';
+import { string, node } from 'prop-types';
+import React from 'react';
+
+import { namespace } from './UNSTABLE__CardLayout';
+
+function UNSTABLE__CardLayoutAside({ children, className, ...other }) {
+  const classes = classnames(className, `${namespace}__aside`);
+
+  return (
+    <div className={classes} {...other}>
+      {children}
+    </div>
+  );
+}
+
+UNSTABLE__CardLayoutAside.propTypes = {
+  children: node,
+  className: string,
+};
+
+UNSTABLE__CardLayoutAside.defaultProps = {
+  children: undefined,
+  className: undefined,
+};
+
+export default UNSTABLE__CardLayoutAside;

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutColumn.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutColumn.js
@@ -19,14 +19,18 @@ function UNSTABLE__CardLayoutColumn({ children, className, size, ...other }) {
   );
 
   let column;
-  if (size === 'md') {
-    column = 8;
-  } else if (size === 'lg') {
-    column = 12;
-  } else if (size === 'xl') {
-    column = 16;
-  } else {
-    column = 4;
+  switch (size) {
+    case 'md':
+      column = 8;
+      break;
+    case 'lg':
+      column = 12;
+      break;
+    case 'xl':
+      column = 16;
+      break;
+    default:
+      column = 4;
   }
 
   return (

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutColumn.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutColumn.js
@@ -1,0 +1,51 @@
+/**
+ * @file Card layout column.
+ * @copyright IBM Security 2020
+ */
+
+import classnames from 'classnames';
+import { string, node, oneOf } from 'prop-types';
+import React from 'react';
+
+import { Column } from 'carbon-components-react/lib/components/Grid';
+
+import { namespace } from './UNSTABLE__CardLayout';
+
+function UNSTABLE__CardLayoutColumn({ children, className, size, ...other }) {
+  const classes = classnames(
+    className,
+    `${namespace}__column`,
+    `${namespace}__column--${size}`
+  );
+
+  let column;
+  if (size === 'md') {
+    column = 8;
+  } else if (size === 'lg') {
+    column = 12;
+  } else if (size === 'xl') {
+    column = 16;
+  } else {
+    column = 4;
+  }
+
+  return (
+    <Column sm={4} md={4} lg={column} className={classes} {...other}>
+      {children}
+    </Column>
+  );
+}
+
+UNSTABLE__CardLayoutColumn.propTypes = {
+  children: node,
+  className: string,
+  size: oneOf(['sm', 'md', 'lg']),
+};
+
+UNSTABLE__CardLayoutColumn.defaultProps = {
+  children: undefined,
+  className: undefined,
+  size: 'sm',
+};
+
+export default UNSTABLE__CardLayoutColumn;

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutMain.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutMain.js
@@ -1,0 +1,33 @@
+/**
+ * @file Card layout main.
+ * @copyright IBM Security 2020
+ */
+
+import classnames from 'classnames';
+import { string, node } from 'prop-types';
+import React from 'react';
+
+import { Grid } from 'carbon-components-react/lib/components/Grid';
+
+import { namespace } from './UNSTABLE__CardLayout';
+
+function UNSTABLE__CardLayoutMain({ children, className, ...other }) {
+  const classes = classnames(`${namespace}__main`, className);
+  return (
+    <Grid fullWidth condensed className={classes} {...other}>
+      {children}
+    </Grid>
+  );
+}
+
+UNSTABLE__CardLayoutMain.propTypes = {
+  children: node,
+  className: string,
+};
+
+UNSTABLE__CardLayoutMain.defaultProps = {
+  children: undefined,
+  className: undefined,
+};
+
+export default UNSTABLE__CardLayoutMain;

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutRow.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/UNSTABLE__CardLayoutRow.js
@@ -1,0 +1,33 @@
+/**
+ * @file Card layout row.
+ * @copyright IBM Security 2020
+ */
+
+import classnames from 'classnames';
+import { string, node } from 'prop-types';
+import React from 'react';
+
+import { Row } from 'carbon-components-react/lib/components/Grid';
+
+import { namespace } from './UNSTABLE__CardLayout';
+
+function UNSTABLE__CardLayoutRow({ children, className, ...other }) {
+  const classes = classnames(`${namespace}__section`, className);
+  return (
+    <Row className={classes} {...other}>
+      {children}
+    </Row>
+  );
+}
+
+UNSTABLE__CardLayoutRow.propTypes = {
+  children: node,
+  className: string,
+};
+
+UNSTABLE__CardLayoutRow.defaultProps = {
+  children: undefined,
+  className: undefined,
+};
+
+export default UNSTABLE__CardLayoutRow;

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/_index.scss
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/_index.scss
@@ -1,0 +1,13 @@
+////
+/// Card layout styles.
+/// @group details-page-1
+/// @copyright IBM Security 2020
+////
+
+@import '../../Component/mixins';
+
+@import 'mixins';
+
+@include security--component($name: card-layout) {
+  @include card-layout;
+}

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/_mixins.scss
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/_mixins.scss
@@ -1,0 +1,40 @@
+////
+/// Card layout styles.
+/// @group card-layout
+/// @copyright IBM Security 2020
+////
+
+@import '../../../globals/namespace/index';
+@import '../../../globals/layout/index';
+
+@mixin card-layout {
+  display: flex;
+
+  .#{$namespace}card-layout__aside {
+    max-width: 25%;
+    height: 100%;
+    flex-grow: 1;
+    margin-left: $carbon--spacing-05;
+  }
+
+  .#{$namespace}card-layout__main {
+    flex-grow: 1;
+  }
+
+  .#{$namespace}card-layout__aside + .#{$namespace}card-layout__main {
+    .#{$namespace}card-layout__column--sm {
+      max-width: 33.33%;
+      flex: 0 0 33.33%;
+    }
+
+    .#{$namespace}card-layout__column--md {
+      max-width: 66.66%;
+      flex: 0 0 66.66%;
+    }
+
+    .#{$namespace}card-layout__column--lg {
+      max-width: 100%;
+      flex: 0 0 100%;
+    }
+  }
+}

--- a/src/components/LayoutTemplates/UNSTABLE__CardLayout/index.js
+++ b/src/components/LayoutTemplates/UNSTABLE__CardLayout/index.js
@@ -1,0 +1,18 @@
+/**
+ * @file Card layout template 1 entry point.
+ * @copyright IBM Security 2020
+ */
+
+import UNSTABLE__CardLayout from './UNSTABLE__CardLayout';
+import UNSTABLE__CardLayoutRow from './UNSTABLE__CardLayoutRow';
+import UNSTABLE__CardLayoutColumn from './UNSTABLE__CardLayoutColumn';
+import UNSTABLE__CardLayoutAside from './UNSTABLE__CardLayoutAside';
+import UNSTABLE__CardLayoutMain from './UNSTABLE__CardLayoutMain';
+
+export {
+  UNSTABLE__CardLayout,
+  UNSTABLE__CardLayoutRow,
+  UNSTABLE__CardLayoutColumn,
+  UNSTABLE__CardLayoutAside,
+  UNSTABLE__CardLayoutMain,
+};

--- a/src/components/LayoutTemplates/index.js
+++ b/src/components/LayoutTemplates/index.js
@@ -4,6 +4,14 @@
  */
 
 export {
+  UNSTABLE__CardLayout,
+  UNSTABLE__CardLayoutRow,
+  UNSTABLE__CardLayoutColumn,
+  UNSTABLE__CardLayoutAside,
+  UNSTABLE__CardLayoutMain,
+} from './UNSTABLE__CardLayout';
+
+export {
   UNSTABLE__DetailsPage1,
   UNSTABLE__DetailsPage1Main,
   UNSTABLE__DetailsPage1Section,

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -11128,6 +11128,101 @@ Map {
       },
     },
   },
+  "UNSTABLE__CardLayout" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "UNSTABLE__CardLayoutAside" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "UNSTABLE__CardLayoutColumn" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+      "size": "sm",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "sm",
+            "md",
+            "lg",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
+  "UNSTABLE__CardLayoutMain" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "UNSTABLE__CardLayoutRow" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
+  "UNSTABLE__DetailsPage1" => Object {
+    "defaultProps": Object {
+      "children": undefined,
+      "className": undefined,
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
   "UNSTABLE__DetailsPage1Aside" => Object {
     "defaultProps": Object {
       "children": undefined,

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -92,4 +92,5 @@
 @import 'UNSTABLE__Pagination/index';
 
 // Layout templates
+@import 'LayoutTemplates/UNSTABLE__CardLayout/index';
 @import 'LayoutTemplates/UNSTABLE__DetailsPage1/index';

--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,12 @@ export {
 export TabContent from 'carbon-components-react/lib/components/TabContent';
 
 export {
+  UNSTABLE__CardLayout,
+  UNSTABLE__CardLayoutRow,
+  UNSTABLE__CardLayoutColumn,
+  UNSTABLE__CardLayoutAside,
+  UNSTABLE__CardLayoutMain,
+  UNSTABLE__DetailsPage1,
   UNSTABLE__DetailsPage1Main,
   UNSTABLE__DetailsPage1Section,
   UNSTABLE__DetailsPage1SectionTerm,


### PR DESCRIPTION
## Proposed changes

<img width="1079" alt="Screenshot 2020-03-26 at 13 41 35" src="https://user-images.githubusercontent.com/9057921/77939790-4d34b600-727d-11ea-8afb-18c7ee7b098e.png">

- based on the variety of card layouts in the screenshot above, I added 3 general examples (2 with an "aside" that sit outside the grid, one with different sized columns within the grid that should cover most other examples)

### TODO:
- Responsive styling for the "aside" examples. 🤔 
- Tests