### PR TITLE
docs(storybook): update storybook sidebar with package info and version

### DIFF
--- a/.storybook/theme/index.js
+++ b/.storybook/theme/index.js
@@ -9,7 +9,7 @@ import { fontFamilies } from '@carbon/type/lib';
 
 import { create } from '@storybook/theming';
 
-import { name, homepage } from '../../package.json';
+import { name, homepage, version } from '../../package.json';
 
 const { mono, sans } = fontFamilies;
 const { field02, inverse01, activeUI, text01, ui01, ui02 } = g100;
@@ -18,8 +18,7 @@ export default create({
   base: 'dark',
 
   // Brand information.
-  brandImage: require('./lockup.svg'),
-  brandTitle: name,
+  brandTitle: `<img src="${require('./lockup.svg')}" alt="IBM Security" /><br/><br/>${name}<br/>v${version}`,
   brandUrl: homepage,
 
   colorPrimary: activeUI,

--- a/.storybook/theme/index.js
+++ b/.storybook/theme/index.js
@@ -18,7 +18,7 @@ export default create({
   base: 'dark',
 
   // Brand information.
-  brandTitle: `<img src="${require('./lockup.svg')}" alt="IBM Security" /><br/><br/>${name}<br/>v${version}`,
+  brandTitle: `<img src="${require('./lockup.svg')}" alt="IBM Security" /><br/><br/><code>${name}<br/>v${version}</code>`,
   brandUrl: homepage,
 
   colorPrimary: activeUI,


### PR DESCRIPTION
## Affected issues

- Resolves #458

## Proposed changes

(look at top left -- where there's the lockup image etc.)

- move lockup image to `brandName` and also include package info + name
- remove `brandImage` (because it visually overrides `brandName`)

## Testing instructions

Keep in mind that this is how Carbon's storybook looks (see top left): https://react.carbondesignsystem.com

How similar do we want to be?
Should we keep the lockup image?
Should the package name + version be written differently?