### PR TITLE
fix(theme): move ignore list to variables for use across partials

### DIFF
--- a/src/globals/theme/_index.scss
+++ b/src/globals/theme/_index.scss
@@ -12,37 +12,8 @@
 
 @import 'variables';
 
-// Theme ignore list.
-/// @type List<String>
-/// @access private
-$security--theme__ignore-list: ();
-
-/// Security theme.
-/// @type Map<String, Color>
-$security--theme: $carbon--theme--g100 !default;
-
-/// Default theme.
-/// @type Map<String, Color>
-/// @access private
-$-theme: $security--theme;
-
 @if feature-flag-enabled($feature: $theme__name) {
-  // Filter out token that are not colors.
   @each $token, $value in $-theme {
-    $security--theme__ignore-list: if(
-      $condition:
-        type-of(
-          $value: $value,
-        ) ==
-        'color',
-      $if_true: $security--theme__ignore-list,
-      $if_false:
-        append(
-          $list: $security--theme__ignore-list,
-          $val: $token,
-        ),
-    );
-
     // Map the theme tokens as CSS custom properties.
     $-theme: map-merge(
       $map1: $-theme,

--- a/src/globals/theme/_variables.scss
+++ b/src/globals/theme/_variables.scss
@@ -9,6 +9,37 @@
 
 @import '../color/index';
 
+// Theme ignore list.
+/// @type List<String>
+/// @access private
+$security--theme__ignore-list: ();
+
+/// Security theme.
+/// @type Map<String, Color>
+$security--theme: $carbon--theme--g100 !default;
+
+/// Default theme.
+/// @type Map<String, Color>
+/// @access private
+$-theme: $security--theme;
+
+// Filter out token that are not colors.
+@each $token, $value in $-theme {
+  $security--theme__ignore-list: if(
+    $condition:
+      type-of(
+        $value: $value,
+      ) ==
+      'color',
+    $if_true: $security--theme__ignore-list,
+    $if_false:
+      append(
+        $list: $security--theme__ignore-list,
+        $val: $token,
+      ),
+  );
+}
+
 /// 'Cool gray' hover overrides.
 /// @type Map<String, Map>
 /// @access private


### PR DESCRIPTION
## Proposed change

As per SCSS import tests, the proposes to move theme ignore list to variables for use across functions and mixins, and accommodate individual component imports