### PR TITLE
fix(breadcrumb): reset containing `ol` browser defaults

### DIFF
--- a/src/components/Breadcrumb/_index.scss
+++ b/src/components/Breadcrumb/_index.scss
@@ -1,20 +1,23 @@
 ////
 /// Breadcrumb component.
 /// @group breadcrumb
-/// @copyright IBM Security 2019
+/// @copyright IBM Security 2019 - 2020
 ////
 
-@import '@carbon/type/scss/styles';
 @import '@carbon/themes/scss/tokens';
+@import '@carbon/type/scss/styles';
 @import 'carbon-components/scss/components/breadcrumb/breadcrumb';
 
+@import 'carbon-components/scss/globals/scss/css--reset';
 @import 'carbon-components/scss/globals/scss/vars';
 
 @import '../../globals/namespace/index';
 
-/// Carbon style overrides.
 @include export-namespace($name: breadcrumb) {
   .#{$prefix}--breadcrumb {
+    // TODO: Remove when https://github.com/carbon-design-system/carbon/pull/5916 is absorbed.
+    @include reset;
+
     display: flex;
     flex-wrap: wrap;
 


### PR DESCRIPTION
## Affected issue

Workaround for https://github.com/carbon-design-system/carbon/pull/5916

## Proposed change

Add reset to `Breadcrumb` to prevent browser defaults for containing `ol` when the CSS reset is toggled off