### PR TITLE
test: add missing required children props to test renders

### DIFF
--- a/src/components/SummaryCard/SummaryCardBody/__tests__/SummaryCardBody.spec.js
+++ b/src/components/SummaryCard/SummaryCardBody/__tests__/SummaryCardBody.spec.js
@@ -10,7 +10,9 @@ import { SummaryCardBody } from '../../../..';
 
 describe('SummaryCardBody', () => {
   test('should accept a custom class name', () => {
-    const { container } = render(<SummaryCardBody className="custom-class" />);
+    const { container } = render(
+      <SummaryCardBody className="custom-class">test content</SummaryCardBody>
+    );
     expect(container.firstElementChild).toHaveClass('custom-class');
   });
 
@@ -22,7 +24,9 @@ describe('SummaryCardBody', () => {
   });
 
   test('should pass through extra props via spread attribute', () => {
-    const { queryByTestId } = render(<SummaryCardBody data-testid="test-id" />);
+    const { queryByTestId } = render(
+      <SummaryCardBody data-testid="test-id">test content</SummaryCardBody>
+    );
     expect(queryByTestId('test-id')).toBeVisible();
   });
 });

--- a/src/components/SummaryCard/SummaryCardFooter/__tests__/SummaryCardFooter.spec.js
+++ b/src/components/SummaryCard/SummaryCardFooter/__tests__/SummaryCardFooter.spec.js
@@ -11,7 +11,9 @@ import { SummaryCardFooter } from '../../../..';
 describe('SummaryCardFooter', () => {
   test('should accept a custom class name', () => {
     const { container } = render(
-      <SummaryCardFooter className="custom-class" />
+      <SummaryCardFooter className="custom-class">
+        test content
+      </SummaryCardFooter>
     );
     expect(container.firstElementChild).toHaveClass('custom-class');
   });
@@ -25,7 +27,7 @@ describe('SummaryCardFooter', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <SummaryCardFooter data-testid="test-id" />
+      <SummaryCardFooter data-testid="test-id">test content</SummaryCardFooter>
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/TimeIndicator/__tests__/TimeIndicator.spec.js
+++ b/src/components/TimeIndicator/__tests__/TimeIndicator.spec.js
@@ -27,7 +27,9 @@ describe('TimeIndicator', () => {
   });
 
   test('should pass extra props through spread attribute', () => {
-    const { queryByTestId } = render(<TimeIndicator data-testid="test-id" />);
+    const { queryByTestId } = render(
+      <TimeIndicator data-testid="test-id">test content</TimeIndicator>
+    );
     expect(queryByTestId('test-id')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Proposed changes

- Added required prop `children` to test renders for `SummaryCardBody`, `SummaryCardFooter`, and `TimeIndicator` to clear out some proptype errors in test output.