### PR TITLE
chore(filter-panel): prevent unrecognized props from generating warnings in tests

### DIFF
--- a/src/components/FilterPanel/__tests__/FilterPanel.spec.js
+++ b/src/components/FilterPanel/__tests__/FilterPanel.spec.js
@@ -52,14 +52,14 @@ describe('FilterPanel', () => {
   });
 
   test('does not render the legacy filter if filterData is not provided', () => {
-    const { queryByTestId } = render(
-      <FilterPanel {...mockProps} filterData={null} />
-    );
+    const { queryByTestId } = render(<FilterPanel filterData={null} />);
     expect(queryByTestId('legacy-filter-panel')).not.toBeInTheDocument();
   });
 
   test('renders the legacy filter panel', () => {
-    const { getByTestId } = render(<FilterPanel {...mockProps} />);
+    const { getByTestId } = render(
+      <FilterPanel filterData={mockProps.filterData} />
+    );
     expect(getByTestId('legacy-filter-panel')).toBeVisible();
   });
 });


### PR DESCRIPTION
Current `FilterPanel` tests generate some noise due to unrecognized props --

```
 PASS  src/components/FilterPanel/__tests__/FilterPanel.spec.js
  ● Console

    console.error node_modules/react-dom/cjs/react-dom.development.js:530
      Warning: React does not recognize the `MockFilterData` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `mockfilterdata` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in section (created by FilterPanel)
          in FilterPanel
    console.error node_modules/react-dom/cjs/react-dom.development.js:530
      Warning: React does not recognize the `filtersExpandLabel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `filtersexpandlabel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in section (created by FilterPanel)
          in FilterPanel
    console.error node_modules/react-dom/cjs/react-dom.development.js:530
      Warning: React does not recognize the `filtersCollapseLabel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `filterscollapselabel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in section (created by FilterPanel)
          in FilterPanel
    console.error node_modules/react-dom/cjs/react-dom.development.js:530
      Warning: React does not recognize the `noFiltersResultsLabel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `nofiltersresultslabel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in section (created by FilterPanel)
          in FilterPanel
    console.error node_modules/react-dom/cjs/react-dom.development.js:530
      Warning: React does not recognize the `filterSearchLabel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `filtersearchlabel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in section (created by FilterPanel)
          in FilterPanel
```

## Proposed changes

- stop passing through extra props to legacy `FilterPanel` tests
