### PR TITLE
fix(tagwall): accommodate truncated text in tags and filter list items

### DIFF
--- a/src/components/TagWall/TagWall.js
+++ b/src/components/TagWall/TagWall.js
@@ -13,7 +13,7 @@ import * as defaultLabels from '../../globals/nls';
 import defaultItemToString from '../__tools__/defaultItemToString';
 
 import Button from '../Button';
-import InteractiveTag from '../Tag/InteractiveTag';
+import Tag from '../Tag';
 
 const namespace = getComponentNamespace('tag-wall');
 const noop = () => {};
@@ -58,21 +58,25 @@ const TagWall = ({
       {items.map((item, index) => {
         const key = `tag__${index}`;
 
+        const tagClasses = classnames(`${namespace}__tag`, {
+          [`${namespace}__tag--selected`]: item.isSelected,
+        });
+
         return (
-          <InteractiveTag
+          <Tag
             key={key}
-            isSelected={item.isSelected}
+            className={tagClasses}
             onRemove={event => {
               event.stopPropagation();
 
               onChange({ item, type });
             }}
-            removable={!disable}
-            removeBtnLabel={TAG_WALL_REMOVE_BUTTON}
+            filter={!disable}
+            aria-label={TAG_WALL_REMOVE_BUTTON}
             type="gray"
           >
             {itemToString(item)}
-          </InteractiveTag>
+          </Tag>
         );
       })}
       {!addButtonDisabled && (

--- a/src/components/TagWall/_mixins.scss
+++ b/src/components/TagWall/_mixins.scss
@@ -7,12 +7,33 @@
 @import '@carbon/type/scss/index';
 @import '@carbon/layout/scss/spacing';
 
+@import '../../globals/namespace/index';
+
 @mixin tag-wall {
   &__label {
     @include carbon--type-style($name: caption-01);
   }
 
-  > #{$tag--interactive__namespace} {
+  &__tag {
     margin-right: $carbon--spacing-03;
+    max-width: 40ex;
+  }
+
+  // Need to invert Carbon's colors for un-selected tags only:
+  &__tag:not(&__tag--selected) {
+    color: $text-01;
+    background-color: $active-ui;
+
+    // Ensure correct focus outline color when focused:
+    &:focus svg {
+      box-shadow: inset 0 0 0 2px $focus;
+    }
+
+    // Ensure correct svg fill color when NOT interacted with:
+    &:not(:hover) svg,
+    &:not(:focus) svg,
+    &:not(:active) svg {
+      fill: $text-01;
+    }
   }
 }

--- a/src/components/TagWall/_mixins.scss
+++ b/src/components/TagWall/_mixins.scss
@@ -24,16 +24,12 @@
     color: $text-01;
     background-color: $active-ui;
 
-    // Ensure correct focus outline color when focused:
-    &:focus svg {
-      box-shadow: inset 0 0 0 2px $focus;
+    svg:not(:hover) {
+      fill: $text-01;
     }
 
-    // Ensure correct svg fill color when NOT interacted with:
-    &:not(:hover) svg,
-    &:not(:focus) svg,
-    &:not(:active) svg {
-      fill: $text-01;
+    &:focus svg {
+      box-shadow: inset 0 0 0 2px $focus;
     }
   }
 }

--- a/src/components/TagWallFilter/Filter/Filter.js
+++ b/src/components/TagWallFilter/Filter/Filter.js
@@ -135,7 +135,9 @@ class Filter extends React.Component {
             className={`${namespace}__list-item__entry`}
             aria-labelledby={itemProps.id}
           >
-            {itemText}
+            <span className={`${carbonPrefix}text-truncate--end`}>
+              {itemText}
+            </span>
             <span className={`${namespace}__add`}>
               <Icon className={`${namespace}__add__icon`} renderIcon={Add20} />
             </span>

--- a/src/components/Tearsheet/TearsheetSmall/_mixins.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_mixins.scss
@@ -53,6 +53,7 @@
   &__body {
     display: flex;
     min-height: 0;
+    width: 100%;
     margin-bottom: $carbon--layout-06;
     flex-grow: 1;
     overflow: auto;


### PR DESCRIPTION
## Affected issues

- Resolves #511

## Proposed changes

- use Carbon's filterable `Tag` instead of custom `InteractiveTag`
- apply a few color overrides to the `Tag`
- use Carbon's truncation class to truncate items in the filter options list

## Testing instructions

- check out the `TagWall` + `TagWallFilter` storybook demos, inspect a tag or filter option, and change it to a very long entry that needs to be truncated.
