### PR TITLE
fix(tagwall): accommodate truncation in tags and list items

### DIFF
--- a/src/components/TagWall/TagWall.js
+++ b/src/components/TagWall/TagWall.js
@@ -7,7 +7,10 @@ import classnames from 'classnames';
 import { arrayOf, bool, func, shape, string } from 'prop-types';
 import React from 'react';
 
-import { getComponentNamespace } from '../../globals/namespace/index';
+import {
+  carbonPrefix,
+  getComponentNamespace,
+} from '../../globals/namespace/index';
 import * as defaultLabels from '../../globals/nls';
 
 import defaultItemToString from '../__tools__/defaultItemToString';
@@ -71,7 +74,9 @@ const TagWall = ({
             removeBtnLabel={TAG_WALL_REMOVE_BUTTON}
             type="gray"
           >
-            {itemToString(item)}
+            <span className={`${carbonPrefix}text-truncate--end`}>
+              {itemToString(item)}
+            </span>
           </InteractiveTag>
         );
       })}

--- a/src/components/TagWall/TagWall.js
+++ b/src/components/TagWall/TagWall.js
@@ -74,7 +74,10 @@ const TagWall = ({
             removeBtnLabel={TAG_WALL_REMOVE_BUTTON}
             type="gray"
           >
-            <span className={`${carbonPrefix}text-truncate--end`}>
+            <span
+              className={`${carbonPrefix}text-truncate--end`}
+              title={itemToString(item)}
+            >
               {itemToString(item)}
             </span>
           </InteractiveTag>

--- a/src/components/TagWall/__tests__/__snapshots__/TagWall.spec.js.snap
+++ b/src/components/TagWall/__tests__/__snapshots__/TagWall.spec.js.snap
@@ -81,7 +81,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--removable security--tag--interactive--selected"
         >
-          Tag 1
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 1
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -169,7 +173,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--removable security--tag--interactive--selected"
         >
-          Tag 2
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 2
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -257,7 +265,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--removable security--tag--interactive--selected"
         >
-          Tag 3
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 3
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -345,7 +357,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
         >
-          Tag 4
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 4
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -433,7 +449,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
         >
-          Tag 5
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 5
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -521,7 +541,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
         >
-          Tag 6
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 6
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -609,7 +633,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
         >
-          Tag 7
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 7
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -697,7 +725,11 @@ exports[`TagWall Rendering renders 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
         >
-          Tag 8
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 8
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -816,7 +848,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--removable security--tag--interactive--selected"
   >
-    Tag 1
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 1
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -841,7 +877,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--removable security--tag--interactive--selected"
   >
-    Tag 2
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 2
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -866,7 +906,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--removable security--tag--interactive--selected"
   >
-    Tag 3
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 3
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -891,7 +935,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
   >
-    Tag 4
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 4
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -916,7 +964,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
   >
-    Tag 5
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 5
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -941,7 +993,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
   >
-    Tag 6
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 6
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -966,7 +1022,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
   >
-    Tag 7
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 7
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -991,7 +1051,11 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   <span
     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
   >
-    Tag 8
+    <span
+      class="bx--text-truncate--end"
+    >
+      Tag 8
+    </span>
     <button
       aria-label=""
       class="security--tag--interactive__button"
@@ -1104,7 +1168,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--selected"
         >
-          Tag 1
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 1
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1124,7 +1192,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--selected"
         >
-          Tag 2
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 2
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1144,7 +1216,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--selected"
         >
-          Tag 3
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 3
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1164,7 +1240,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default"
         >
-          Tag 4
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 4
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1184,7 +1264,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default"
         >
-          Tag 5
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 5
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1204,7 +1288,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default"
         >
-          Tag 6
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 6
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1224,7 +1312,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default"
         >
-          Tag 7
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 7
+          </span>
         </span>
       </Tag>
     </InteractiveTag>
@@ -1244,7 +1336,11 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default"
         >
-          Tag 8
+          <span
+            className="bx--text-truncate--end"
+          >
+            Tag 8
+          </span>
         </span>
       </Tag>
     </InteractiveTag>

--- a/src/components/TagWall/__tests__/__snapshots__/TagWall.spec.js.snap
+++ b/src/components/TagWall/__tests__/__snapshots__/TagWall.spec.js.snap
@@ -83,6 +83,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 1"
           >
             Tag 1
           </span>
@@ -175,6 +176,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 2"
           >
             Tag 2
           </span>
@@ -267,6 +269,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 3"
           >
             Tag 3
           </span>
@@ -359,6 +362,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 4"
           >
             Tag 4
           </span>
@@ -451,6 +455,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 5"
           >
             Tag 5
           </span>
@@ -543,6 +548,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 6"
           >
             Tag 6
           </span>
@@ -635,6 +641,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 7"
           >
             Tag 7
           </span>
@@ -727,6 +734,7 @@ exports[`TagWall Rendering renders 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 8"
           >
             Tag 8
           </span>
@@ -850,6 +858,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 1"
     >
       Tag 1
     </span>
@@ -879,6 +888,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 2"
     >
       Tag 2
     </span>
@@ -908,6 +918,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 3"
     >
       Tag 3
     </span>
@@ -937,6 +948,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 4"
     >
       Tag 4
     </span>
@@ -966,6 +978,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 5"
     >
       Tag 5
     </span>
@@ -995,6 +1008,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 6"
     >
       Tag 6
     </span>
@@ -1024,6 +1038,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 7"
     >
       Tag 7
     </span>
@@ -1053,6 +1068,7 @@ exports[`TagWall Rendering renders the HTML of the node's subtree 1`] = `
   >
     <span
       class="bx--text-truncate--end"
+      title="Tag 8"
     >
       Tag 8
     </span>
@@ -1170,6 +1186,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 1"
           >
             Tag 1
           </span>
@@ -1194,6 +1211,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 2"
           >
             Tag 2
           </span>
@@ -1218,6 +1236,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 3"
           >
             Tag 3
           </span>
@@ -1242,6 +1261,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 4"
           >
             Tag 4
           </span>
@@ -1266,6 +1286,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 5"
           >
             Tag 5
           </span>
@@ -1290,6 +1311,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 6"
           >
             Tag 6
           </span>
@@ -1314,6 +1336,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 7"
           >
             Tag 7
           </span>
@@ -1338,6 +1361,7 @@ exports[`TagWall Rendering renders the disabled variation 1`] = `
         >
           <span
             className="bx--text-truncate--end"
+            title="Tag 8"
           >
             Tag 8
           </span>

--- a/src/components/TagWall/_mixins.scss
+++ b/src/components/TagWall/_mixins.scss
@@ -6,6 +6,7 @@
 
 @import '@carbon/type/scss/index';
 @import '@carbon/layout/scss/spacing';
+@import 'carbon-components/scss/globals/scss/helper-classes';
 
 @mixin tag-wall {
   &__label {

--- a/src/components/TagWall/_mixins.scss
+++ b/src/components/TagWall/_mixins.scss
@@ -14,5 +14,10 @@
 
   > #{$tag--interactive__namespace} {
     margin-right: $carbon--spacing-03;
+    max-width: 40ex;
+
+    &__button {
+      flex-shrink: 0;
+    }
   }
 }

--- a/src/components/TagWallFilter/Filter/Filter.js
+++ b/src/components/TagWallFilter/Filter/Filter.js
@@ -135,7 +135,10 @@ class Filter extends React.Component {
             className={`${namespace}__list-item__entry`}
             aria-labelledby={itemProps.id}
           >
-            <span className={`${carbonPrefix}text-truncate--end`}>
+            <span
+              className={`${carbonPrefix}text-truncate--end`}
+              title={itemText}
+            >
               {itemText}
             </span>
             <span className={`${namespace}__add`}>

--- a/src/components/TagWallFilter/Filter/Filter.js
+++ b/src/components/TagWallFilter/Filter/Filter.js
@@ -135,7 +135,9 @@ class Filter extends React.Component {
             className={`${namespace}__list-item__entry`}
             aria-labelledby={itemProps.id}
           >
-            {itemText}
+            <span className={`${carbonPrefix}text-truncate--end`}>
+              {itemText}
+            </span>
             <span className={`${namespace}__add`}>
               <Icon className={`${namespace}__add__icon`} renderIcon={Add20} />
             </span>

--- a/src/components/TagWallFilter/Filter/__tests__/__snapshots__/Filter.spec.js.snap
+++ b/src/components/TagWallFilter/Filter/__tests__/__snapshots__/Filter.spec.js.snap
@@ -94,6 +94,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Abuja"
           >
             Abuja
           </span>
@@ -134,6 +135,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Beijing"
           >
             Beijing
           </span>
@@ -174,6 +176,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Berlin"
           >
             Berlin
           </span>
@@ -214,6 +217,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Johannesburg"
           >
             Johannesburg
           </span>
@@ -254,6 +258,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="London"
           >
             London
           </span>
@@ -294,6 +299,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Montreal"
           >
             Montreal
           </span>
@@ -334,6 +340,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="New Delhi"
           >
             New Delhi
           </span>
@@ -374,6 +381,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="New York"
           >
             New York
           </span>
@@ -414,6 +422,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Rio de Janeiro"
           >
             Rio de Janeiro
           </span>
@@ -454,6 +463,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="San Fransisco"
           >
             San Fransisco
           </span>
@@ -494,6 +504,7 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
         >
           <span
             class="bx--text-truncate--end"
+            title="Tokyo"
           >
             Tokyo
           </span>

--- a/src/components/TagWallFilter/Filter/__tests__/__snapshots__/Filter.spec.js.snap
+++ b/src/components/TagWallFilter/Filter/__tests__/__snapshots__/Filter.spec.js.snap
@@ -92,7 +92,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-0"
           class="security--filter__list-item__entry"
         >
-          Abuja
+          <span
+            class="bx--text-truncate--end"
+          >
+            Abuja
+          </span>
           <span
             class="security--filter__add"
           >
@@ -128,7 +132,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-1"
           class="security--filter__list-item__entry"
         >
-          Beijing
+          <span
+            class="bx--text-truncate--end"
+          >
+            Beijing
+          </span>
           <span
             class="security--filter__add"
           >
@@ -164,7 +172,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-2"
           class="security--filter__list-item__entry"
         >
-          Berlin
+          <span
+            class="bx--text-truncate--end"
+          >
+            Berlin
+          </span>
           <span
             class="security--filter__add"
           >
@@ -200,7 +212,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-3"
           class="security--filter__list-item__entry"
         >
-          Johannesburg
+          <span
+            class="bx--text-truncate--end"
+          >
+            Johannesburg
+          </span>
           <span
             class="security--filter__add"
           >
@@ -236,7 +252,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-4"
           class="security--filter__list-item__entry"
         >
-          London
+          <span
+            class="bx--text-truncate--end"
+          >
+            London
+          </span>
           <span
             class="security--filter__add"
           >
@@ -272,7 +292,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-5"
           class="security--filter__list-item__entry"
         >
-          Montreal
+          <span
+            class="bx--text-truncate--end"
+          >
+            Montreal
+          </span>
           <span
             class="security--filter__add"
           >
@@ -308,7 +332,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-6"
           class="security--filter__list-item__entry"
         >
-          New Delhi
+          <span
+            class="bx--text-truncate--end"
+          >
+            New Delhi
+          </span>
           <span
             class="security--filter__add"
           >
@@ -344,7 +372,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-7"
           class="security--filter__list-item__entry"
         >
-          New York
+          <span
+            class="bx--text-truncate--end"
+          >
+            New York
+          </span>
           <span
             class="security--filter__add"
           >
@@ -380,7 +412,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-8"
           class="security--filter__list-item__entry"
         >
-          Rio de Janeiro
+          <span
+            class="bx--text-truncate--end"
+          >
+            Rio de Janeiro
+          </span>
           <span
             class="security--filter__add"
           >
@@ -416,7 +452,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-9"
           class="security--filter__list-item__entry"
         >
-          San Fransisco
+          <span
+            class="bx--text-truncate--end"
+          >
+            San Fransisco
+          </span>
           <span
             class="security--filter__add"
           >
@@ -452,7 +492,11 @@ exports[`Filter render renders the HTML of the node's subtree 1`] = `
           aria-labelledby="downshift-0-item-10"
           class="security--filter__list-item__entry"
         >
-          Tokyo
+          <span
+            class="bx--text-truncate--end"
+          >
+            Tokyo
+          </span>
           <span
             class="security--filter__add"
           >

--- a/src/components/TagWallFilter/Filter/_mixins.scss
+++ b/src/components/TagWallFilter/Filter/_mixins.scss
@@ -7,6 +7,7 @@
 @import '@carbon/layout/scss/spacing';
 @import '@carbon/layout/scss/mini-unit';
 @import '@carbon/themes/scss/tokens';
+@import 'carbon-components/scss/globals/scss/helper-classes';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import '../../../globals/namespace/index';
 

--- a/src/components/TagWallFilter/TagWallFilter.stories.js
+++ b/src/components/TagWallFilter/TagWallFilter.stories.js
@@ -49,7 +49,11 @@ storiesOf(patterns('TagWallFilter'), module).add(
   `TagWall with Filter list for multiselect`,
   () => {
     const selectedItems = object('selectedItems', [
-      { id: 'item-0', label: 'Lima' },
+      {
+        id: 'item-0',
+        label:
+          'Tag that is a very long string and will need to be truncated with an ellipsis',
+      },
     ]);
     const selectedItemsMap = selectedItems.reduce(
       compose(

--- a/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
+++ b/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
@@ -488,7 +488,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                       <span
                         class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                       >
-                        Y
+                        <span
+                          class="bx--text-truncate--end"
+                        >
+                          Y
+                        </span>
                         <button
                           aria-label=""
                           class="security--tag--interactive__button"
@@ -597,7 +601,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                 aria-labelledby="downshift-0-item-0"
                                 class="security--filter__list-item__entry"
                               >
-                                X
+                                <span
+                                  class="bx--text-truncate--end"
+                                >
+                                  X
+                                </span>
                                 <span
                                   class="security--filter__add"
                                 >
@@ -787,7 +795,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                   <span
                                     class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                   >
-                                    Y
+                                    <span
+                                      class="bx--text-truncate--end"
+                                    >
+                                      Y
+                                    </span>
                                     <button
                                       aria-label=""
                                       class="security--tag--interactive__button"
@@ -896,7 +908,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                             aria-labelledby="downshift-0-item-0"
                                             class="security--filter__list-item__entry"
                                           >
-                                            X
+                                            <span
+                                              class="bx--text-truncate--end"
+                                            >
+                                              X
+                                            </span>
                                             <span
                                               class="security--filter__add"
                                             >
@@ -1009,7 +1025,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                     <span
                                       class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                     >
-                                      Y
+                                      <span
+                                        class="bx--text-truncate--end"
+                                      >
+                                        Y
+                                      </span>
                                       <button
                                         aria-label=""
                                         class="security--tag--interactive__button"
@@ -1118,7 +1138,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                               aria-labelledby="downshift-0-item-0"
                                               class="security--filter__list-item__entry"
                                             >
-                                              X
+                                              <span
+                                                class="bx--text-truncate--end"
+                                              >
+                                                X
+                                              </span>
                                               <span
                                                 class="security--filter__add"
                                               >
@@ -1266,7 +1290,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                         <span
                                           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                         >
-                                          Y
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Y
+                                          </span>
                                           <button
                                             aria-label=""
                                             className="security--tag--interactive__button"
@@ -1590,7 +1618,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                                         aria-labelledby="downshift-0-item-0"
                                                         className="security--filter__list-item__entry"
                                                       >
-                                                        X
+                                                        <span
+                                                          className="bx--text-truncate--end"
+                                                        >
+                                                          X
+                                                        </span>
                                                         <span
                                                           className="security--filter__add"
                                                         >
@@ -1890,7 +1922,11 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 2`] = 
         <span
           className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
         >
-          Y
+          <span
+            className="bx--text-truncate--end"
+          >
+            Y
+          </span>
           <button
             aria-label=""
             className="security--tag--interactive__button"
@@ -2227,7 +2263,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                         <span
                           class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                         >
-                          Y
+                          <span
+                            class="bx--text-truncate--end"
+                          >
+                            Y
+                          </span>
                           <button
                             aria-label=""
                             class="security--tag--interactive__button"
@@ -2336,7 +2376,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                   aria-labelledby="downshift-0-item-0"
                                   class="security--filter__list-item__entry"
                                 >
-                                  X
+                                  <span
+                                    class="bx--text-truncate--end"
+                                  >
+                                    X
+                                  </span>
                                   <span
                                     class="security--filter__add"
                                   >
@@ -2440,7 +2484,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                         <span
                           class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                         >
-                          X
+                          <span
+                            class="bx--text-truncate--end"
+                          >
+                            X
+                          </span>
                           <button
                             aria-label=""
                             class="security--tag--interactive__button"
@@ -2549,7 +2597,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                   aria-labelledby="downshift-1-item-0"
                                   class="security--filter__list-item__entry"
                                 >
-                                  Y
+                                  <span
+                                    class="bx--text-truncate--end"
+                                  >
+                                    Y
+                                  </span>
                                   <span
                                     class="security--filter__add"
                                   >
@@ -2739,7 +2791,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                     <span
                                       class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                     >
-                                      Y
+                                      <span
+                                        class="bx--text-truncate--end"
+                                      >
+                                        Y
+                                      </span>
                                       <button
                                         aria-label=""
                                         class="security--tag--interactive__button"
@@ -2848,7 +2904,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                               aria-labelledby="downshift-0-item-0"
                                               class="security--filter__list-item__entry"
                                             >
-                                              X
+                                              <span
+                                                class="bx--text-truncate--end"
+                                              >
+                                                X
+                                              </span>
                                               <span
                                                 class="security--filter__add"
                                               >
@@ -2952,7 +3012,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                     <span
                                       class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                     >
-                                      X
+                                      <span
+                                        class="bx--text-truncate--end"
+                                      >
+                                        X
+                                      </span>
                                       <button
                                         aria-label=""
                                         class="security--tag--interactive__button"
@@ -3061,7 +3125,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                               aria-labelledby="downshift-1-item-0"
                                               class="security--filter__list-item__entry"
                                             >
-                                              Y
+                                              <span
+                                                class="bx--text-truncate--end"
+                                              >
+                                                Y
+                                              </span>
                                               <span
                                                 class="security--filter__add"
                                               >
@@ -3174,7 +3242,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                       <span
                                         class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                       >
-                                        Y
+                                        <span
+                                          class="bx--text-truncate--end"
+                                        >
+                                          Y
+                                        </span>
                                         <button
                                           aria-label=""
                                           class="security--tag--interactive__button"
@@ -3283,7 +3355,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                                 aria-labelledby="downshift-0-item-0"
                                                 class="security--filter__list-item__entry"
                                               >
-                                                X
+                                                <span
+                                                  class="bx--text-truncate--end"
+                                                >
+                                                  X
+                                                </span>
                                                 <span
                                                   class="security--filter__add"
                                                 >
@@ -3387,7 +3463,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                       <span
                                         class="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                       >
-                                        X
+                                        <span
+                                          class="bx--text-truncate--end"
+                                        >
+                                          X
+                                        </span>
                                         <button
                                           aria-label=""
                                           class="security--tag--interactive__button"
@@ -3496,7 +3576,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                                 aria-labelledby="downshift-1-item-0"
                                                 class="security--filter__list-item__entry"
                                               >
-                                                Y
+                                                <span
+                                                  class="bx--text-truncate--end"
+                                                >
+                                                  Y
+                                                </span>
                                                 <span
                                                   class="security--filter__add"
                                                 >
@@ -3644,7 +3728,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                           <span
                                             className="bx--tag bx--tag--gray security--tag--interactive security--tag--interactive--default security--tag--interactive--removable"
                                           >
-                                            X
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              X
+                                            </span>
                                             <button
                                               aria-label=""
                                               className="security--tag--interactive__button"
@@ -3968,7 +4056,11 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                                           aria-labelledby="downshift-1-item-0"
                                                           className="security--filter__list-item__entry"
                                                         >
-                                                          Y
+                                                          <span
+                                                            className="bx--text-truncate--end"
+                                                          >
+                                                            Y
+                                                          </span>
                                                           <span
                                                             className="security--filter__add"
                                                           >

--- a/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
+++ b/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
@@ -490,6 +490,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                       >
                         <span
                           class="bx--text-truncate--end"
+                          title="Y"
                         >
                           Y
                         </span>
@@ -603,6 +604,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                               >
                                 <span
                                   class="bx--text-truncate--end"
+                                  title="X"
                                 >
                                   X
                                 </span>
@@ -797,6 +799,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                   >
                                     <span
                                       class="bx--text-truncate--end"
+                                      title="Y"
                                     >
                                       Y
                                     </span>
@@ -910,6 +913,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                           >
                                             <span
                                               class="bx--text-truncate--end"
+                                              title="X"
                                             >
                                               X
                                             </span>
@@ -1027,6 +1031,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                     >
                                       <span
                                         class="bx--text-truncate--end"
+                                        title="Y"
                                       >
                                         Y
                                       </span>
@@ -1140,6 +1145,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                             >
                                               <span
                                                 class="bx--text-truncate--end"
+                                                title="X"
                                               >
                                                 X
                                               </span>
@@ -1292,6 +1298,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                         >
                                           <span
                                             className="bx--text-truncate--end"
+                                            title="Y"
                                           >
                                             Y
                                           </span>
@@ -1620,6 +1627,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                                       >
                                                         <span
                                                           className="bx--text-truncate--end"
+                                                          title="X"
                                                         >
                                                           X
                                                         </span>
@@ -1924,6 +1932,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 2`] = 
         >
           <span
             className="bx--text-truncate--end"
+            title="Y"
           >
             Y
           </span>
@@ -2265,6 +2274,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                         >
                           <span
                             class="bx--text-truncate--end"
+                            title="Y"
                           >
                             Y
                           </span>
@@ -2378,6 +2388,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                 >
                                   <span
                                     class="bx--text-truncate--end"
+                                    title="X"
                                   >
                                     X
                                   </span>
@@ -2486,6 +2497,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                         >
                           <span
                             class="bx--text-truncate--end"
+                            title="X"
                           >
                             X
                           </span>
@@ -2599,6 +2611,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                 >
                                   <span
                                     class="bx--text-truncate--end"
+                                    title="Y"
                                   >
                                     Y
                                   </span>
@@ -2793,6 +2806,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                     >
                                       <span
                                         class="bx--text-truncate--end"
+                                        title="Y"
                                       >
                                         Y
                                       </span>
@@ -2906,6 +2920,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                             >
                                               <span
                                                 class="bx--text-truncate--end"
+                                                title="X"
                                               >
                                                 X
                                               </span>
@@ -3014,6 +3029,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                     >
                                       <span
                                         class="bx--text-truncate--end"
+                                        title="X"
                                       >
                                         X
                                       </span>
@@ -3127,6 +3143,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                             >
                                               <span
                                                 class="bx--text-truncate--end"
+                                                title="Y"
                                               >
                                                 Y
                                               </span>
@@ -3244,6 +3261,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                       >
                                         <span
                                           class="bx--text-truncate--end"
+                                          title="Y"
                                         >
                                           Y
                                         </span>
@@ -3357,6 +3375,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                               >
                                                 <span
                                                   class="bx--text-truncate--end"
+                                                  title="X"
                                                 >
                                                   X
                                                 </span>
@@ -3465,6 +3484,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                       >
                                         <span
                                           class="bx--text-truncate--end"
+                                          title="X"
                                         >
                                           X
                                         </span>
@@ -3578,6 +3598,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                               >
                                                 <span
                                                   class="bx--text-truncate--end"
+                                                  title="Y"
                                                 >
                                                   Y
                                                 </span>
@@ -3730,6 +3751,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                           >
                                             <span
                                               className="bx--text-truncate--end"
+                                              title="X"
                                             >
                                               X
                                             </span>
@@ -4058,6 +4080,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                                         >
                                                           <span
                                                             className="bx--text-truncate--end"
+                                                            title="Y"
                                                           >
                                                             Y
                                                           </span>

--- a/src/components/Tearsheet/TearsheetSmall/_mixins.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_mixins.scss
@@ -9,6 +9,7 @@
 @import '@carbon/type/scss/index';
 
 @import 'carbon-components/scss/globals/scss/vars';
+@import 'carbon-components/scss/globals/scss/helper-classes';
 
 @import '../../TagWallFilter/Filter/mixins';
 

--- a/src/components/Tearsheet/TearsheetSmall/_mixins.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_mixins.scss
@@ -53,6 +53,7 @@
   &__body {
     display: flex;
     min-height: 0;
+    width: 100%;
     margin-bottom: $carbon--layout-06;
     flex-grow: 1;
     overflow: auto;

--- a/src/components/Tearsheet/TearsheetSmall/_mixins.scss
+++ b/src/components/Tearsheet/TearsheetSmall/_mixins.scss
@@ -9,7 +9,6 @@
 @import '@carbon/type/scss/index';
 
 @import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/globals/scss/helper-classes';
 
 @import '../../TagWallFilter/Filter/mixins';
 


### PR DESCRIPTION
## Affected issues

- Resolves #511 

## Proposed changes

- truncate tags in `TagWall` to 40ex per input from design
- truncate list items in `TagWall` to width of container
- update storybook demo to show what happens with long strings

## Testing instructions

- The `TagWall` demo has a long string now, so you can see how it appears when truncated. You can then remove the tag, returning it the list below, and see how it appears truncated in the list of options.
