### PR TITLE
docs(tearsheet): add id to input in small tearsheet demo

### DIFF
--- a/src/components/Tearsheet/Tearsheet.stories.js
+++ b/src/components/Tearsheet/Tearsheet.stories.js
@@ -51,6 +51,7 @@ const renderMain = () => (
 
     <TextInput
       className={className}
+      id="test-input-id"
       labelText={labelText}
       placeholder={placeholder}
     />


### PR DESCRIPTION
When running the storybook environment locally, you will see the following console error for the `Tearsheet` story:

```
Warning: Failed prop type: The prop `id` is marked as required in `ForwardRef(TextInput)`, but its value is `undefined`.
    in ForwardRef(TextInput) checkPropTypes.js:20
    printWarning checkPropTypes.js:20
    checkPropTypes checkPropTypes.js:82
    React 2
    js Tearsheet.stories.js:70
    js main.8aa11d6e3dab039344c8.bundle.js:31055
    Webpack 19
```


This PR resolves this by adding the missing `id` to the `TextInput` in the `Tearsheet` story.

## Proposed changes

- add `id` to `TextInput` in `Tearsheet` storybook demo

## Testing instructions

You need to run locally to see the error in development.
