### PR TITLE
fix(checkbox): override border color for focus state

### DIFF
--- a/src/components/Checkbox/_index.scss
+++ b/src/components/Checkbox/_index.scss
@@ -4,7 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '@carbon/colors/scss/colors';
+@import '@carbon/themes/scss/tokens';
 @import 'carbon-components/scss/components/checkbox/checkbox';
 @import 'carbon-components/scss/globals/scss/vars';
 

--- a/src/components/Checkbox/_index.scss
+++ b/src/components/Checkbox/_index.scss
@@ -4,17 +4,24 @@
 /// @copyright IBM Security 2019
 ////
 
+@import '@carbon/colors/scss/colors';
 @import 'carbon-components/scss/components/checkbox/checkbox';
-
 @import 'carbon-components/scss/globals/scss/vars';
 
 @import '../../globals/namespace/index';
 
 /// Carbon style overrides.
 @include export-namespace($name: checkbox) {
-  // TODO - remove issue is resolved in Carbon: https://github.com/carbon-design-system/carbon/issues/4074
-  .#{$prefix}--checkbox-label::after {
-    width: 0.575rem;
-    height: 0.3rem;
+  // TODO - remove when issue is resolved & release in Carbon: https://github.com/carbon-design-system/carbon/issues/5984
+  // Unchecked
+  .#{$prefix}--checkbox:focus + .#{$prefix}--checkbox-label::before,
+    .#{$prefix}--checkbox-label__focus::before,
+    // Checked
+    .#{$prefix}--checkbox:checked:focus + .#{$prefix}--checkbox-label::before,
+    .#{$prefix}--checkbox-label[data-contained-checkbox-state='true'].#{$prefix}--checkbox-label__focus::before,
+    // Indeterminate
+    .#{$prefix}--checkbox:indeterminate:focus + .#{$prefix}--checkbox-label::before,
+    .#{$prefix}--checkbox-label[data-contained-checkbox-state='mixed'].#{$prefix}--checkbox-label__focus::before {
+    border-color: $interactive-04;
   }
 }


### PR DESCRIPTION
## Affected issues

- Resolves #517 

## Proposed changes

- Remove old style override that is no longer needed
- Overrides the `border-color` from Carbon to use `$interactive-04` (which is blue40 for dark themes) instead of `$focus` (which is white for dark themes & causing issues). Note that I'm also open to using `$interactive-01` here (blue60 for all themes), but blue40 seemed appropriate because it also matches the link color 🤔 

NOTE: rules here are necessary to override this code block https://github.com/carbon-design-system/carbon/blob/master/packages/components/src/components/checkbox/_checkbox.scss#L148
