### PR TITLE
docs(radio-button): remove checked knob from story so component is interactive

### DIFF
--- a/src/components/RadioButton/RadioButton.stories.js
+++ b/src/components/RadioButton/RadioButton.stories.js
@@ -28,7 +28,6 @@ const radioProps = () => ({
     labelPositions,
     'right'
   ),
-  checked: boolean('Checked (checked)', false),
   disabled: boolean('Disabled (disabled)', false),
   onChange: action('onChange'),
 });


### PR DESCRIPTION
## Proposed changes

- remove `checked` prop knob, which was preventing the component from being interacted with in the storybook demo