### PR TITLE
fix(type-layout): use `ui-03` for subtle border

### DIFF
--- a/src/components/TypeLayout/_index.scss
+++ b/src/components/TypeLayout/_index.scss
@@ -98,7 +98,7 @@
   }
 
   &--bordered &__row {
-    border-bottom: 1px solid $ui-02;
+    border-bottom: 1px solid $ui-03;
 
     &:last-child {
       border-width: 0;


### PR DESCRIPTION
## Affected issue

Resolves #523

## Proposed change

Use `ui-03` for `TypeLayout` border as per Carbon guidance - https://www.carbondesignsystem.com/guidelines/color/usage