### PR TITLE
fix(combo-button): take into account pageYOffset value

### DIFF
--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -28,12 +28,10 @@ const ComboButton = ({ children, className, direction }) => {
   const wrapper = useRef(null);
 
   const getMenuOffset = () => {
-    const { top } = wrapper.current.getBoundingClientRect();
     const isTop = direction === TooltipDirection.TOP;
-    return {
-      top: isTop ? top : top * -1,
-      left: 'auto',
-    };
+    const rect = wrapper.current.getBoundingClientRect();
+    const top = rect.top + window.pageYOffset;
+    return { top: isTop ? top : top * -1, left: 'auto' };
   };
 
   const childrenArray = React.Children.toArray(children).filter(Boolean);

--- a/src/components/ComboButton/ComboButton.stories.js
+++ b/src/components/ComboButton/ComboButton.stories.js
@@ -30,7 +30,7 @@ const props = () => ({
 storiesOf(patterns('ComboButton'), module).add(
   'default',
   () => (
-    <div style={{ width: 300 }}>
+    <div style={{ width: 300, margin: '30rem 0' }}>
       <ComboButton {...props()}>
         <ComboButtonItem href="#" renderIcon={ArrowRight20}>
           Item 1 (becomes primary button and text will be truncated)


### PR DESCRIPTION
## Affected issues

- Resolves #178 

## Proposed changes

- Added `pageYOffset` with top value
- set top and bottom margin in ComboButton story wrapper to simulate scrolling

## Testing instructions

- To replicate the bug locally you must comment out the line `addDecorator(centered)` in `.storybook/config.js`