### PR TITLE
feat(tearsheet): add ability to remove sidebar

### DIFF
--- a/src/components/Tearsheet/Tearsheet.js
+++ b/src/components/Tearsheet/Tearsheet.js
@@ -1,6 +1,6 @@
 /**
  * @file Tearsheet.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import Close20 from '@carbon/icons-react/lib/close/20';
@@ -113,30 +113,37 @@ class Tearsheet extends Component {
                   </div>
                 </Loading>
               )}
-              <section className={`${namespace}__sidebar`}>
-                <h1 className={`${namespace}__sidebar__title`}>
-                  {sidebarTitle}
-                </h1>
-                <p className={`${namespace}__sidebar__subtitle`}>
-                  {sidebarSubtitle}
-                </p>
-                <div className={`${namespace}__sidebar__content`}>
-                  {renderSidebar()}
-                </div>
-                <footer className={`${namespace}__sidebar__footer`}>
-                  {!hideDeleteButton && (
-                    <Button
-                      disabled={isDisabled}
-                      iconDescription={componentLabels.TEARSHEET_DELETE_BUTTON}
-                      kind="ghost-danger"
-                      onClick={onDeleteButtonClick}
-                      renderIcon={icon}
-                    >
-                      {componentLabels.TEARSHEET_DELETE_BUTTON}
-                    </Button>
-                  )}
-                </footer>
-              </section>
+
+              {renderSidebar && (
+                <section className={`${namespace}__sidebar`}>
+                  <h1 className={`${namespace}__sidebar__title`}>
+                    {sidebarTitle}
+                  </h1>
+                  <p className={`${namespace}__sidebar__subtitle`}>
+                    {sidebarSubtitle}
+                  </p>
+
+                  <div className={`${namespace}__sidebar__content`}>
+                    {renderSidebar()}
+                  </div>
+
+                  <footer className={`${namespace}__sidebar__footer`}>
+                    {!hideDeleteButton && (
+                      <Button
+                        disabled={isDisabled}
+                        iconDescription={
+                          componentLabels.TEARSHEET_DELETE_BUTTON
+                        }
+                        kind="ghost-danger"
+                        onClick={onDeleteButtonClick}
+                        renderIcon={icon}
+                      >
+                        {componentLabels.TEARSHEET_DELETE_BUTTON}
+                      </Button>
+                    )}
+                  </footer>
+                </section>
+              )}
 
               <section className={`${namespace}__main`}>
                 {!closeButton.isDisabled && (
@@ -294,8 +301,8 @@ Tearsheet.propTypes = {
 Tearsheet.defaultProps = {
   focusTrap: true,
   selectorPrimaryFocus: '[tearsheet-primary-focus]',
-  renderSidebar: () => null,
   renderMain: () => null,
+  renderSidebar: null,
   rootNode: undefined,
   sidebarTitle: '',
   sidebarSubtitle: '',

--- a/src/components/Tearsheet/Tearsheet.stories.js
+++ b/src/components/Tearsheet/Tearsheet.stories.js
@@ -1,6 +1,6 @@
 /**
  * @file Tearsheet stories.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import { action } from '@storybook/addon-actions';
@@ -26,7 +26,12 @@ import {
 
 import labels from './_mocks_';
 
-const renderSidebar = () => 'Sidebar';
+const { __docgenInfo, defaultProps } = Tearsheet;
+
+const renderSidebar = () =>
+  boolean('Sidebar (renderSidebar)', true)
+    ? () => 'Sidebar'
+    : defaultProps.renderSidebar;
 
 const searchLabel = 'What are you looking for today?';
 
@@ -121,7 +126,7 @@ storiesOf(patterns('Tearsheet'), module)
         focusTrap={boolean('focusTrap', false)}
         selectorPrimaryFocus={selectorPrimaryFocus}
         renderMain={renderMain}
-        renderSidebar={renderSidebar}
+        renderSidebar={renderSidebar()}
         sidebarTitle="Title of setup"
         sidebarSubtitle="5 mins setup"
         mainTitle="Step title"
@@ -174,7 +179,7 @@ storiesOf(patterns('Tearsheet'), module)
       )(Tearsheet);
 
       TearsheetLoadingStory.displayName = getDisplayName(Tearsheet);
-      TearsheetLoadingStory.__docgenInfo = Tearsheet.__docgenInfo;
+      TearsheetLoadingStory.__docgenInfo = __docgenInfo;
 
       return (
         <TearsheetLoadingStory
@@ -182,7 +187,7 @@ storiesOf(patterns('Tearsheet'), module)
           focusTrap={boolean('focusTrap', false)}
           selectorPrimaryFocus={selectorPrimaryFocus}
           renderMain={renderMain}
-          renderSidebar={renderSidebar}
+          renderSidebar={renderSidebar()}
           sidebarTitle="Title of setup"
           sidebarSubtitle="5 mins setup"
           mainTitle="Step title"
@@ -224,7 +229,7 @@ storiesOf(patterns('Tearsheet'), module)
                 focusTrap={boolean('focusTrap', false)}
                 selectorPrimaryFocus={selectorPrimaryFocus}
                 renderMain={renderMain}
-                renderSidebar={renderSidebar}
+                renderSidebar={renderSidebar()}
                 closeButton={{
                   onClick: this.close,
                   label: text('closeButton.label', 'Close'),
@@ -260,7 +265,7 @@ storiesOf(patterns('Tearsheet'), module)
         focusTrap={boolean('focusTrap', false)}
         selectorPrimaryFocus={selector}
         renderMain={renderMain}
-        renderSidebar={renderSidebar}
+        renderSidebar={renderSidebar()}
         sidebarTitle="Title of setup"
         sidebarSubtitle="5 mins setup"
         mainTitle="Step title"

--- a/src/components/Tearsheet/_mixins.scss
+++ b/src/components/Tearsheet/_mixins.scss
@@ -1,7 +1,7 @@
 ////
 /// Tearsheet mixins.
 /// @group tearsheet
-/// @copyright IBM Security 2019
+/// @copyright IBM Security 2019 - 2020
 ////
 
 @import '@carbon/layout/scss/spacing';
@@ -156,7 +156,6 @@ $tearsheet__sizing__dimensions: $carbon--layout-04;
   &__main {
     position: relative;
     display: flex;
-    width: 66%;
     padding-top: $tearsheet__spacing__padding;
     flex: 1;
     flex-direction: column;

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -9808,7 +9808,7 @@ Map {
       "loadingMessage": "",
       "mainTitle": "",
       "renderMain": [Function],
-      "renderSidebar": [Function],
+      "renderSidebar": null,
       "rootNode": undefined,
       "selectorPrimaryFocus": "[tearsheet-primary-focus]",
       "sidebarSubtitle": "",


### PR DESCRIPTION
## Affected issues

Resolves #483

## Proposed changes

Prevent rendering of the `Tearsheet` sidebar if the prop is not passed in

## Testing instructions

Use 'Sidebar' knob in any `Tearsheet` story