### PR TITLE
fix(storybook): add keys to theme components

### DIFF
--- a/.storybook/addons/addon-theme/index.js
+++ b/.storybook/addons/addon-theme/index.js
@@ -61,7 +61,11 @@ class Wrapper extends Component {
     this.setState({ theme });
   };
 
-  render = () => <Theme theme={this.state.theme}>{this.props.children}</Theme>;
+  render = () => (
+    <Theme key={this.state.theme} theme={this.state.theme}>
+      {this.props.children}
+    </Theme>
+  );
 }
 
 export default makeDecorator({

--- a/.storybook/addons/addon-theme/register.js
+++ b/.storybook/addons/addon-theme/register.js
@@ -58,7 +58,12 @@ register(namespace, api =>
   addPanel(`${namespace}/panel`, {
     title,
     render: ({ active }) => (
-      <Theme active={active} api={api} channel={getChannel()} />
+      <Theme
+        key="storybook/theme/panel"
+        active={active}
+        api={api}
+        channel={getChannel()}
+      />
     ),
   })
 );


### PR DESCRIPTION
Right now in development, when viewing the storybook environment, you will see a large warning about a miss `key` value on the top level `Theme`:

![Screen Shot 2020-05-20 at 12 51 15 PM](https://user-images.githubusercontent.com/9057921/82479927-a9a39d00-9a98-11ea-901d-53d52561df7f.png)


## Proposed changes

- the component wrapper `Theme` will have a `key={NAME-OF-THEME}` (this is not the specific missing `key` being flagged but still seems useful, anyway)
- the `Theme` addon panel will have a `key` that matches naming convention of other addon panels -- e.g., `key="storybook/theme/panel"`
