### PR TITLE
fix(card): add spread attribute to component wrapper

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -28,6 +28,7 @@ const Card = ({
   body,
   footer,
   onClick,
+  ...other
 }) => {
   const cardHeader = header && (
     <div className={`${namespace}__header`}>
@@ -77,11 +78,14 @@ const Card = ({
           href={link}
           aria-label={label}
           onClick={onClick}
+          {...other}
         >
           {content}
         </a>
       ) : (
-        <div className={classNames}>{content}</div>
+        <div className={classNames} {...other}>
+          {content}
+        </div>
       )}
     </Fragment>
   );


### PR DESCRIPTION
## Affected issues

- Resolves #542

## Proposed changes

- adds `...other` spread attribute, which would resolve requests like #542 by allowing consumers to pass in additional attributes, like `target="_blank"`
