### PR TITLE
build(storybook): remove static assets from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "lib",
     "dist",
     "scss",
-    "storybook-static",
     "macros"
   ],
   "jest": {


### PR DESCRIPTION
## Affected issue

Resolves #556

## Proposed change

Remove `storybook-static` folder from package artifacts to reduce bundle size.