### PR TITLE
feat(filter-panel): allow for string counts

### DIFF
--- a/src/components/FilterPanel/FilterPanelAccordion/FilterPanelAccordion.js
+++ b/src/components/FilterPanel/FilterPanelAccordion/FilterPanelAccordion.js
@@ -41,7 +41,7 @@ FilterPanelAccordion.propTypes = {
   /**
    * Optional accordion count.
    */
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   /**
    * Function returning a translated text labeling the count for accessibility.

--- a/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordiontItem.js
+++ b/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordiontItem.js
@@ -88,7 +88,7 @@ FilterPanelAccordionItem.propTypes = {
   /**
    * Optional count of unique values.
    */
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   /**
    * Function returning a translated text labeling the count for accessibility.

--- a/src/components/FilterPanel/FilterPanelCheckbox/FilterPanelCheckbox.js
+++ b/src/components/FilterPanel/FilterPanelCheckbox/FilterPanelCheckbox.js
@@ -44,7 +44,7 @@ FilterPanelCheckbox.propTypes = {
   /**
    * Optional count.
    */
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   /**
    * Function returning a translated text labeling the count for accessibility.

--- a/src/components/FilterPanel/FilterPanelCheckbox/FilterPanelCheckbox.stories.js
+++ b/src/components/FilterPanel/FilterPanelCheckbox/FilterPanelCheckbox.stories.js
@@ -5,7 +5,7 @@
 
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { text, number } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 
 import React from 'react';
 
@@ -20,7 +20,7 @@ storiesOf(patterns(`FilterPanel/${FilterPanelCheckbox.name}`), module).add(
   () => (
     <FilterPanelCheckbox
       labelText={text('Checkbox label (labelText)', 'Checkbox label')}
-      count={number('Checkbox count (count)', 10)}
+      count={text('Checkbox count (count)', 10)}
       onChange={action('onChange')}
       id="checkbox-id"
     />

--- a/src/components/FilterPanel/FilterPanelCheckboxWithOverflowMenu/FilterPanelCheckboxWithOverflowMenu.stories.js
+++ b/src/components/FilterPanel/FilterPanelCheckboxWithOverflowMenu/FilterPanelCheckboxWithOverflowMenu.stories.js
@@ -5,7 +5,7 @@
 
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { text, number } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 
 import React from 'react';
 
@@ -23,7 +23,7 @@ storiesOf(
   () => (
     <FilterPanelCheckboxWithOverflowMenu
       labelText={text('Checkbox label (labelText)', 'Checkbox label')}
-      count={number('Checkbox count (count)', 10)}
+      count={text('Checkbox count (count)', 10)}
       onChange={action('onChange')}
       id="checkbox-id"
     >

--- a/src/components/FilterPanel/FilterPanelGroup/FilterPanelGroup.js
+++ b/src/components/FilterPanel/FilterPanelGroup/FilterPanelGroup.js
@@ -42,7 +42,7 @@ FilterPanelGroup.propTypes = {
   /**
    * Optional group count.
    */
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   /**
    * Function returning a translated text labeling the count for accessibility.

--- a/src/components/FilterPanel/FilterPanelLabel/FilterPanelLabel.js
+++ b/src/components/FilterPanel/FilterPanelLabel/FilterPanelLabel.js
@@ -43,7 +43,7 @@ FilterPanelLabel.propTypes = {
   /**
    * Label count.
    */
-  count: PropTypes.number,
+  count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   /**
    * Function returning a translated text labeling the count for accessibility.

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -3132,7 +3132,17 @@ Map {
         "type": "string",
       },
       "count": Object {
-        "type": "number",
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "countLabel": Object {
         "type": "func",
@@ -3164,7 +3174,17 @@ Map {
         "type": "string",
       },
       "count": Object {
-        "type": "number",
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "countLabel": Object {
         "type": "func",
@@ -3195,7 +3215,17 @@ Map {
         "type": "string",
       },
       "count": Object {
-        "type": "number",
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "countLabel": Object {
         "type": "func",
@@ -3253,7 +3283,17 @@ Map {
         "type": "string",
       },
       "count": Object {
-        "type": "number",
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "countLabel": Object {
         "type": "func",
@@ -3312,7 +3352,17 @@ Map {
         "type": "string",
       },
       "count": Object {
-        "type": "number",
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "countLabel": Object {
         "type": "func",
@@ -3341,7 +3391,17 @@ Map {
         "type": "string",
       },
       "count": Object {
-        "type": "number",
+        "args": Array [
+          Array [
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
+        ],
+        "type": "oneOfType",
       },
       "countClassName": Object {
         "type": "string",


### PR DESCRIPTION
## Affected issues

- Resolves #566

## Proposed changes

- Update the prop type for all of the filter panel subcomponents to allow strings for the `count` props

## Testing instructions

- Check out the Storybook story for the `FilterPanelCheckbox` and update the `count` prop knob to include a letter
