### PR TITLE
fix(wizard): add className prop and spread attribute

### DIFF
--- a/src/components/Tearsheet/Tearsheet.js
+++ b/src/components/Tearsheet/Tearsheet.js
@@ -7,6 +7,7 @@ import Close20 from '@carbon/icons-react/lib/close/20';
 import TrashCan20 from '@carbon/icons-react/lib/trash-can/20';
 
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import React, { Component } from 'react';
 
 import Button from '../Button';
@@ -53,6 +54,7 @@ class Tearsheet extends Component {
 
   render() {
     const {
+      className,
       focusTrap,
       selectorPrimaryFocus,
       renderSidebar,
@@ -76,6 +78,7 @@ class Tearsheet extends Component {
         onClick: onDeleteButtonClick,
       },
       labels,
+      ...other
     } = this.props;
 
     const componentLabels = {
@@ -103,8 +106,9 @@ class Tearsheet extends Component {
           >
             <section
               ref={this.containerSection}
-              className={namespace}
+              className={classnames(namespace, className)}
               aria-hidden={false}
+              {...other}
             >
               {this.state.loading && (
                 <Loading className={`${namespace}__loading`}>
@@ -296,9 +300,13 @@ Tearsheet.propTypes = {
 
   /** @type {array} Array of event types to stop propagation. */
   stopPropagationEvents: PropTypes.arrayOf(PropTypes.oneOf(PORTAL_EVENTS)),
+
+  /** Optional class name for the tearsheet wrapper node. */
+  className: PropTypes.string,
 };
 
 Tearsheet.defaultProps = {
+  className: '',
   focusTrap: true,
   selectorPrimaryFocus: '[tearsheet-primary-focus]',
   renderMain: () => null,

--- a/src/components/Tearsheet/__tests__/__snapshots__/Tearsheet.spec.js.snap
+++ b/src/components/Tearsheet/__tests__/__snapshots__/Tearsheet.spec.js.snap
@@ -16,6 +16,9 @@ exports[`Tearsheet should override \`labels\` if button label property provided 
     <section
       aria-hidden={false}
       className="security--tearsheet"
+      isOpen={true}
+      loading={false}
+      loadingMessage=""
     >
       <section
         className="security--tearsheet__sidebar"
@@ -182,6 +185,9 @@ exports[`Tearsheet should render the Tearsheet 1`] = `
     <section
       aria-hidden={false}
       className="security--tearsheet"
+      isOpen={true}
+      loading={false}
+      loadingMessage=""
     >
       <section
         className="security--tearsheet__sidebar"

--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -6,6 +6,7 @@
 /* eslint-disable compat/compat,no-nested-ternary */
 
 import React, { Component, Children } from 'react';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { StepIndicator, Step as SingleStep } from '../..';
 import WizardStep from './WizardStep';
@@ -235,7 +236,7 @@ class Wizard extends Component {
    * Renders the component.
    */
   render() {
-    const { labels } = this.props;
+    const { labels, ...other } = this.props;
     const componentLabels = {
       ...defaultLabels.labels,
       ...labels,
@@ -330,6 +331,8 @@ class Wizard extends Component {
         }}
         loading={this.state.loading}
         loadingMessage={this.props.loadingMessage}
+        className={classnames(namespace, this.props.className)}
+        {...other}
       />
     );
   }
@@ -378,9 +381,13 @@ Wizard.propTypes = {
    * (useful to override default labels)
    */
   labels: defaultLabels.propType,
+
+  /** Optional class name for the wrapper node. */
+  className: PropTypes.string,
 };
 
 Wizard.defaultProps = {
+  className: '',
   focusTrap: true,
   rootNode: isClient() ? document.body : undefined,
   subTitle: '',

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -9924,6 +9924,7 @@ Map {
   },
   "Tearsheet" => Object {
     "defaultProps": Object {
+      "className": "",
       "deleteButton": Object {
         "hide": true,
         "onClick": [Function],
@@ -9949,6 +9950,9 @@ Map {
       },
     },
     "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
       "closeButton": Object {
         "args": Array [
           Object {
@@ -12092,6 +12096,7 @@ Map {
   "Wizard" => Object {
     "defaultProps": Object {
       "children": undefined,
+      "className": "",
       "focusTrap": true,
       "initState": Object {},
       "isOpen": undefined,
@@ -12106,6 +12111,9 @@ Map {
     "propTypes": Object {
       "children": Object {
         "type": "node",
+      },
+      "className": Object {
+        "type": "string",
       },
       "focusTrap": Object {
         "type": "bool",


### PR DESCRIPTION
## Affected issues

- Resolves #565

## Proposed changes

- add `className` prop and spread attribute to `Tearsheet`
- add `className` prop and spread attribute to `Wizard`
