### PR TITLE
feat(decorator): export icons as components, add story and tests

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -4893,16 +4893,20 @@ a.bx--overflow-menu-options__btn::before {
   line-height: 1.25rem;
 }
 
-.security--decorator--unknown .security--decorator__icon {
+.security--decorator--unknown .security--decorator__icon, .security--decorator__icon--unknown {
   fill: var(--icon-02, #c6c6c6);
 }
 
-.security--decorator--low .security--decorator__icon {
+.security--decorator--low .security--decorator__icon, .security--decorator__icon--low {
   fill: var(--support-03, #f1c21b);
 }
 
-.security--decorator--medium .security--decorator__icon {
+.security--decorator--medium .security--decorator__icon, .security--decorator__icon--medium {
   fill: #ff832b;
+}
+
+.security--decorator__icon--high, .security--decorator__icon--critical {
+  fill: var(--support-01, #fa4d56);
 }
 
 .security--decorator--high .security--decorator__icon, .security--decorator--critical .security--decorator__icon {

--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -187,7 +187,7 @@ function generateIconExports(...iconNames) {
         path={icons[iconName]}
         size={size}
         viewBox="0 0 16 16"
-        description={description}
+        aria-label={description}
         {...other}
       />
     );

--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -177,7 +177,7 @@ Decorator.defaultProps = {
 function generateIconExports(...iconNames) {
   const namedExports = {};
   iconNames.forEach(iconName => {
-    const Icon = ({ className, description, size, ...other }) => (
+    const IconComponent = ({ className, description, size, ...other }) => (
       <Icon
         className={classnames(
           `${namespace}__icon--${iconName.toLowerCase()}`,
@@ -191,7 +191,7 @@ function generateIconExports(...iconNames) {
         {...other}
       />
     );
-    Icon.propTypes = {
+    IconComponent.propTypes = {
       /** Optional class name. */
       className: PropTypes.string,
 
@@ -202,7 +202,7 @@ function generateIconExports(...iconNames) {
       description: PropTypes.string.isRequired,
     };
 
-    Icon.defaultProps = {
+    IconComponent.defaultProps = {
       className: '',
       size: 16,
     };
@@ -211,8 +211,8 @@ function generateIconExports(...iconNames) {
     // so that the export is `Decorator.Low` etc.
     const formattedName = iconName.charAt(0).toUpperCase() + iconName.slice(1);
 
-    Icon.displayName = `Decorator.${formattedName}`;
-    namedExports[formattedName] = Icon;
+    IconComponent.displayName = `Decorator.${formattedName}`;
+    namedExports[formattedName] = IconComponent;
   });
   return namedExports;
 }

--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -1,6 +1,6 @@
 /**
  * @file Decorator
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019-2020
  */
 
 import React, { Component, Fragment } from 'react';
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 
 import deprecate from 'carbon-components-react/lib/prop-types/deprecate';
 
-import { getDecoratorProps, namespace } from './constants';
+import { getDecoratorProps, namespace, icons } from './constants';
 
 import Icon from '../../Icon';
 
@@ -169,5 +169,54 @@ Decorator.defaultProps = {
       ? `Score ${score} out of ${scoreThresholds.slice(-1)[0]}`
       : 'No score',
 };
+
+/**
+ * Generate exports for individual severity icon types.
+ * @param {array} iconNames array of icon names
+ */
+function generateIconExports(...iconNames) {
+  const namedExports = {};
+  iconNames.forEach(iconName => {
+    const Icon = ({ className, description, size, ...other }) => (
+      <Icon
+        className={classnames(
+          `${namespace}__icon--${iconName.toLowerCase()}`,
+          className
+        )}
+        fillRule="evenodd"
+        path={icons[iconName]}
+        size={size}
+        viewBox="0 0 16 16"
+        description={description}
+        {...other}
+      />
+    );
+    Icon.propTypes = {
+      /** Optional class name. */
+      className: PropTypes.string,
+
+      /** Icon size. */
+      size: PropTypes.oneOf([12, 16]),
+
+      /** The icon description. */
+      description: PropTypes.string.isRequired,
+    };
+
+    Icon.defaultProps = {
+      className: '',
+      size: 16,
+    };
+
+    // Capitalize first character of icon name
+    // so that the export is `Decorator.Low` etc.
+    const formattedName = iconName.charAt(0).toUpperCase() + iconName.slice(1);
+
+    Icon.displayName = `Decorator.${formattedName}`;
+    namedExports[formattedName] = Icon;
+  });
+  return namedExports;
+}
+
+Object.assign(Decorator, generateIconExports(...Object.keys(icons)));
 
 export default Decorator;

--- a/src/components/DataDecorator/Decorator/Decorator.stories.js
+++ b/src/components/DataDecorator/Decorator/Decorator.stories.js
@@ -61,4 +61,18 @@ storiesOf(components('Decorator'), module)
         <Decorator {...storyProps()} onClick={action('onClick')} />
       </p>
     </>
+  ))
+  .add('Icons', () => (
+    <>
+      <p className="bx--type-body-long-01">
+        You can use Decorator icons as separate components.
+      </p>
+      <p>
+        <Decorator.Unknown description="unknown severity" />
+        <Decorator.Low description="low severity" />
+        <Decorator.Medium description="medium severity" />
+        <Decorator.High description="high severity" />
+        <Decorator.Critical description="critical severity" />
+      </p>
+    </>
   ));

--- a/src/components/DataDecorator/Decorator/__tests__/Decorator.spec.js
+++ b/src/components/DataDecorator/Decorator/__tests__/Decorator.spec.js
@@ -9,7 +9,7 @@ import userEvent from '@testing-library/user-event';
 
 import { Decorator } from '../../../..';
 
-import { namespace } from '../constants';
+import { namespace, icons } from '../constants';
 
 describe('Decorator', () => {
   test('should have no Axe or DAP violations when rendered as a button', async () => {
@@ -133,5 +133,70 @@ describe('Decorator', () => {
       <Decorator type="IP" value="10.0.0.0" inline />
     );
     expect(container.firstElementChild).toHaveClass(`${namespace}--inline`);
+  });
+});
+
+Object.keys(icons).forEach(icon => {
+  // Capitalize first character of icon name
+  // to correctly call component name (like `Decorator.Low`, etc.)
+  const formattedName = icon.charAt(0).toUpperCase() + icon.slice(1);
+  const className = `${namespace}__icon--${icon}`;
+
+  const Component = Decorator[formattedName];
+
+  describe(`Decorator.${formattedName}`, () => {
+    test('should have no Axe or DAP violations', async () => {
+      const main = document.createElement('main');
+      render(<Component description={`${formattedName} severity`} />, {
+        // DAP requires a landmark '<main>' in the DOM:
+        container: document.body.appendChild(main),
+      });
+
+      await expect(document.body).toHaveNoAxeViolations();
+      await expect(document.body).toHaveNoDAPViolations(
+        `Decorator.${formattedName}`
+      );
+    });
+
+    test('should apply accessible `aria-label` with `description` prop', () => {
+      const { getByLabelText } = render(
+        <Component description={`${formattedName} severity`} />
+      );
+      expect(getByLabelText(`${formattedName} severity`)).toBeVisible();
+    });
+
+    test('should add a custom class', () => {
+      render(
+        <Component
+          className="custom-class"
+          description={`${formattedName} severity`}
+        />
+      );
+      expect(document.querySelector(`.${className}`)).toHaveClass(
+        'custom-class'
+      );
+    });
+
+    test('should pass through extra props via spread attribute', () => {
+      const { queryByTestId } = render(
+        <Component
+          data-testid="test-id"
+          description={`${formattedName} severity`}
+        />
+      );
+      expect(queryByTestId('test-id')).toBeVisible();
+    });
+
+    test('should set `height` and `width` with `size` prop', () => {
+      render(<Component size={12} description={`${formattedName} severity`} />);
+      expect(document.querySelector(`.${className}`)).toHaveAttribute(
+        'height',
+        '12'
+      );
+      expect(document.querySelector(`.${className}`)).toHaveAttribute(
+        'width',
+        '12'
+      );
+    });
   });
 });

--- a/src/components/DataDecorator/_mixins.scss
+++ b/src/components/DataDecorator/_mixins.scss
@@ -134,20 +134,25 @@
     }
   }
 
-  &--unknown #{$root}__icon {
+  &--unknown #{$root}__icon,
+  &__icon--unknown {
     fill: $icon-02;
   }
 
-  &--low #{$root}__icon {
+  &--low #{$root}__icon,
+  &__icon--low {
     fill: $support-03;
   }
 
-  &--medium #{$root}__icon {
+  &--medium #{$root}__icon,
+  &__icon--medium {
     fill: $carbon--orange-40;
   }
 
   &--high,
-  &--critical {
+  &__icon--high,
+  &--critical,
+  &__icon--critical {
     #{$root}__icon {
       fill: $support-01;
     }

--- a/src/components/DataDecorator/_mixins.scss
+++ b/src/components/DataDecorator/_mixins.scss
@@ -149,10 +149,13 @@
     fill: $carbon--orange-40;
   }
 
-  &--high,
   &__icon--high,
-  &--critical,
   &__icon--critical {
+    fill: $support-01;
+  }
+
+  &--high,
+  &--critical {
     #{$root}__icon {
       fill: $support-01;
     }

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -2307,6 +2307,31 @@ Map {
     },
   },
   "Decorator" => Object {
+    "critical": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Critical",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
     "defaultProps": Object {
       "active": false,
       "className": "",
@@ -2323,6 +2348,81 @@ Map {
         10,
       ],
       "title": "",
+    },
+    "high": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.High",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
+    "low": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Low",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
+    "medium": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Medium",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
     },
     "propTypes": Object {
       "active": Object {
@@ -2361,6 +2461,31 @@ Map {
       "value": Object {
         "isRequired": true,
         "type": "string",
+      },
+    },
+    "unknown": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Unknown",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
       },
     },
   },

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -2307,12 +2307,112 @@ Map {
     },
   },
   "Decorator" => Object {
-    "critical": Object {
+    "Critical": Object {
       "defaultProps": Object {
         "className": "",
         "size": 16,
       },
       "displayName": "Decorator.Critical",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
+    "High": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.High",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
+    "Low": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Low",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
+    "Medium": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Medium",
+      "propTypes": Object {
+        "className": Object {
+          "type": "string",
+        },
+        "description": Object {
+          "isRequired": true,
+          "type": "string",
+        },
+        "size": Object {
+          "args": Array [
+            Array [
+              12,
+              16,
+            ],
+          ],
+          "type": "oneOf",
+        },
+      },
+    },
+    "Unknown": Object {
+      "defaultProps": Object {
+        "className": "",
+        "size": 16,
+      },
+      "displayName": "Decorator.Unknown",
       "propTypes": Object {
         "className": Object {
           "type": "string",
@@ -2348,81 +2448,6 @@ Map {
         10,
       ],
       "title": "",
-    },
-    "high": Object {
-      "defaultProps": Object {
-        "className": "",
-        "size": 16,
-      },
-      "displayName": "Decorator.High",
-      "propTypes": Object {
-        "className": Object {
-          "type": "string",
-        },
-        "description": Object {
-          "isRequired": true,
-          "type": "string",
-        },
-        "size": Object {
-          "args": Array [
-            Array [
-              12,
-              16,
-            ],
-          ],
-          "type": "oneOf",
-        },
-      },
-    },
-    "low": Object {
-      "defaultProps": Object {
-        "className": "",
-        "size": 16,
-      },
-      "displayName": "Decorator.Low",
-      "propTypes": Object {
-        "className": Object {
-          "type": "string",
-        },
-        "description": Object {
-          "isRequired": true,
-          "type": "string",
-        },
-        "size": Object {
-          "args": Array [
-            Array [
-              12,
-              16,
-            ],
-          ],
-          "type": "oneOf",
-        },
-      },
-    },
-    "medium": Object {
-      "defaultProps": Object {
-        "className": "",
-        "size": 16,
-      },
-      "displayName": "Decorator.Medium",
-      "propTypes": Object {
-        "className": Object {
-          "type": "string",
-        },
-        "description": Object {
-          "isRequired": true,
-          "type": "string",
-        },
-        "size": Object {
-          "args": Array [
-            Array [
-              12,
-              16,
-            ],
-          ],
-          "type": "oneOf",
-        },
-      },
     },
     "propTypes": Object {
       "active": Object {
@@ -2461,31 +2486,6 @@ Map {
       "value": Object {
         "isRequired": true,
         "type": "string",
-      },
-    },
-    "unknown": Object {
-      "defaultProps": Object {
-        "className": "",
-        "size": 16,
-      },
-      "displayName": "Decorator.Unknown",
-      "propTypes": Object {
-        "className": Object {
-          "type": "string",
-        },
-        "description": Object {
-          "isRequired": true,
-          "type": "string",
-        },
-        "size": Object {
-          "args": Array [
-            Array [
-              12,
-              16,
-            ],
-          ],
-          "type": "oneOf",
-        },
       },
     },
   },


### PR DESCRIPTION
## Affected issues

- Resolves #479

## Proposed changes

- export icons as separate components (i.e., `<Decorator.Low />`,  `<Decorator.High />`, etc.)
- add tests for new icon exports
- add new story to display new icon components

## Testing instructions

- see new story (`Decorator` > `Icons` story)
- see tests & output
