### PR TITLE
feat(search-bar): allow custom sort order for scopes

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -82,6 +82,9 @@ export default class SearchBar extends React.Component {
 
     /** @type {func} Callback function for translating MultiSelect's child ListBoxMenuIcon SVG title. */
     translateWithId: PropTypes.func, // eslint-disable-line react/require-default-props
+
+    /** Optional custom sorting. For more information, see: https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/MultiSelect/tools/sorting.js */
+    sortItems: PropTypes.func, // eslint-disable-line react/require-default-props
   };
 
   static defaultProps = {
@@ -146,6 +149,7 @@ export default class SearchBar extends React.Component {
       scopesTypeLabel,
       selectedScopes,
       translateWithId,
+      sortItems,
     } = this.props;
 
     if (scopes.length === 0) return null;
@@ -161,6 +165,7 @@ export default class SearchBar extends React.Component {
         items={scopes}
         itemToString={scopeToString}
         translateWithId={translateWithId}
+        sortItems={sortItems}
       />
     );
   }

--- a/src/components/SearchBar/SearchBar.stories.js
+++ b/src/components/SearchBar/SearchBar.stories.js
@@ -95,6 +95,22 @@ storiesOf(patterns('SearchBar'), module)
       translateWithId={id => translationIds[id]}
     />
   ))
+  .add(
+    'Unsorted scopes',
+    () => (
+      <SearchBarWithStateHandlers
+        {...regular()}
+        {...scopesProps()}
+        translateWithId={id => translationIds[id]}
+        sortItems={items => items}
+      />
+    ),
+    {
+      info: {
+        text: `By default, the scopes in the \`SearchBar\` will be sorted in ascending alphabetical order, and "selected" scopes will be moved to the top of the sort order. You can pass in a function for a custom sort order via the \`sortOrder\` prop. To completely remove the default sorting, follow this story example by setting the \`sortOrder\` prop to \`sortItems={(items) => items}\``,
+      },
+    }
+  )
   .add('Selected scopes', () => (
     <SearchBarWithStateHandlers
       {...regular()}

--- a/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
@@ -15,15 +15,15 @@ exports[`SearchBar Rendering disables the submit button with no selected scopes 
     items={
       Array [
         Object {
-          "id": 0,
-          "name": "Scope 1",
-        },
-        Object {
-          "id": 1,
+          "id": "scope-2",
           "name": "Scope 2",
         },
         Object {
-          "id": 2,
+          "id": "scope-1",
+          "name": "Scope 1",
+        },
+        Object {
+          "id": "scope-3",
           "name": "Scope 3",
         },
       ]
@@ -173,15 +173,15 @@ exports[`SearchBar Rendering renders scopes 1`] = `
     items={
       Array [
         Object {
-          "id": 0,
-          "name": "Scope 1",
-        },
-        Object {
-          "id": 1,
+          "id": "scope-2",
           "name": "Scope 2",
         },
         Object {
-          "id": 2,
+          "id": "scope-1",
+          "name": "Scope 1",
+        },
+        Object {
+          "id": "scope-3",
           "name": "Scope 3",
         },
       ]
@@ -236,8 +236,8 @@ exports[`SearchBar Rendering renders selected scopes 1`] = `
     initialSelectedItems={
       Array [
         Object {
-          "id": 0,
-          "name": "Scope 1",
+          "id": "scope-2",
+          "name": "Scope 2",
         },
       ]
     }
@@ -245,15 +245,15 @@ exports[`SearchBar Rendering renders selected scopes 1`] = `
     items={
       Array [
         Object {
-          "id": 0,
-          "name": "Scope 1",
-        },
-        Object {
-          "id": 1,
+          "id": "scope-2",
           "name": "Scope 2",
         },
         Object {
-          "id": 2,
+          "id": "scope-1",
+          "name": "Scope 1",
+        },
+        Object {
+          "id": "scope-3",
           "name": "Scope 3",
         },
       ]

--- a/src/components/SearchBar/_mocks_/index.js
+++ b/src/components/SearchBar/_mocks_/index.js
@@ -3,9 +3,20 @@
  * @copyright IBM Security 2019
  */
 
-const scopes = new Array(3)
-  .fill()
-  .map((name = 'Scope', id) => ({ id, name: `${name} ${id + 1}` }));
+const scopes = [
+  {
+    id: 'scope-2',
+    name: 'Scope 2',
+  },
+  {
+    id: 'scope-1',
+    name: 'Scope 1',
+  },
+  {
+    id: 'scope-3',
+    name: 'Scope 3',
+  },
+];
 
 export default {
   submitLabel: 'Submit',

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -6874,6 +6874,9 @@ Map {
         ],
         "type": "arrayOf",
       },
+      "sortItems": Object {
+        "type": "func",
+      },
       "submitLabel": Object {
         "isRequired": true,
         "type": "string",


### PR DESCRIPTION
## Affected issues

- Resolves #596 

## Proposed changes

- allow `sortOrder` prop
- add story demo showing how to "unset" the default `sortOrder`
- update `SearchBar` mocks to use an unsorted array for better demos
