### PR TITLE
fix(tearsheet-small): pass through isLoading, provide examples for making content non-interactive when loading

### DIFF
--- a/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
+++ b/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
@@ -1779,6 +1779,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                           </footer>
                           <IconButton
                             className="security--tearsheet--small__button--close"
+                            disabled={false}
                             iconClassName=""
                             iconSize={20}
                             label="Close"
@@ -1798,6 +1799,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                             <button
                               aria-label="Close"
                               className="security--button--icon security--tearsheet--small__button--close security--button--icon--lg"
+                              disabled={false}
                               onClick={[MockFunction]}
                             >
                               <Icon
@@ -4223,6 +4225,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                             </footer>
                             <IconButton
                               className="security--tearsheet--small__button--close"
+                              disabled={false}
                               iconClassName=""
                               iconSize={20}
                               label="Close"
@@ -4242,6 +4245,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                               <button
                                 aria-label="Close"
                                 className="security--button--icon security--tearsheet--small__button--close security--button--icon--lg"
+                                disabled={false}
                                 onClick={[MockFunction]}
                               >
                                 <Icon

--- a/src/components/Tearsheet/Tearsheet.js
+++ b/src/components/Tearsheet/Tearsheet.js
@@ -84,8 +84,6 @@ class Tearsheet extends Component {
       ...other
     } = this.props;
 
-    const tabIndex = this.state.loading ? -1 : 0;
-
     const componentLabels = {
       ...defaultLabels.labels,
       ...labels,
@@ -142,14 +140,13 @@ class Tearsheet extends Component {
                   <footer className={`${namespace}__sidebar__footer`}>
                     {!hideDeleteButton && (
                       <Button
-                        disabled={isDisabled}
+                        disabled={isDisabled || this.state.loading}
                         iconDescription={
                           componentLabels.TEARSHEET_DELETE_BUTTON
                         }
                         kind="ghost-danger"
                         onClick={onDeleteButtonClick}
                         renderIcon={icon}
-                        tabIndex={tabIndex}
                       >
                         {componentLabels.TEARSHEET_DELETE_BUTTON}
                       </Button>
@@ -170,7 +167,7 @@ class Tearsheet extends Component {
                     renderIcon={Close20}
                     size="lg"
                     tooltip={false}
-                    tabIndex={tabIndex}
+                    disabled={this.state.loading}
                   />
                 )}
                 <h1 className={`${namespace}__main__title`}>{mainTitle}</h1>
@@ -191,11 +188,10 @@ class Tearsheet extends Component {
                     <div className={`${namespace}__container__start`}>
                       <Button
                         className={`${namespace}__button--tertiary`}
-                        disabled={isDisabled}
+                        disabled={isDisabled || this.state.loading}
                         kind="ghost"
                         onClick={tertiaryButton.onClick}
                         size="large"
-                        tabIndex={tabIndex}
                       >
                         {componentLabels.TEARSHEET_TERTIARY_BUTTON}
                         {tertiaryButton.secondaryText.length > 0 && (
@@ -212,21 +208,21 @@ class Tearsheet extends Component {
                     {!secondaryButton.isDisabled && (
                       <Button
                         className={`${namespace}__button ${namespace}__button--secondary`}
-                        disabled={secondaryButton.isDisabled}
+                        disabled={
+                          secondaryButton.isDisabled || this.state.loading
+                        }
                         kind="secondary"
                         onClick={secondaryButton.onClick}
                         size="large"
-                        tabIndex={tabIndex}
                       >
                         {componentLabels.TEARSHEET_SECONDARY_BUTTON}
                       </Button>
                     )}
                     <Button
                       className={`${namespace}__button`}
-                      disabled={primaryButton.isDisabled}
+                      disabled={primaryButton.isDisabled || this.state.loading}
                       onClick={primaryButton.onClick}
                       size="large"
-                      tabIndex={tabIndex}
                     >
                       {componentLabels.TEARSHEET_PRIMARY_BUTTON}
                     </Button>

--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.js
@@ -121,7 +121,7 @@ class TearsheetSmall extends PureComponent {
                       [`${namespace}__scroll-gradient__content`]: !flush,
                     })}
                   >
-                    {this.renderBody()}
+                    {this.renderBody({ isLoading: this.state.loading })}
                   </div>
                 </ScrollGradient>
               </section>
@@ -129,7 +129,7 @@ class TearsheetSmall extends PureComponent {
                 {!secondaryButton.hide && (
                   <Button
                     className={`${namespace}__footer__button ${namespace}__footer__button--secondary`}
-                    disabled={secondaryButton.isDisabled}
+                    disabled={secondaryButton.isDisabled || this.state.loading}
                     kind="secondary"
                     onClick={secondaryButton.onClick}
                     size="large"
@@ -140,7 +140,7 @@ class TearsheetSmall extends PureComponent {
                 {!primaryButton.hide && (
                   <Button
                     className={`${namespace}__footer__button`}
-                    disabled={primaryButton.isDisabled}
+                    disabled={primaryButton.isDisabled || this.state.loading}
                     onClick={primaryButton.onClick}
                     size="large"
                   >
@@ -156,6 +156,7 @@ class TearsheetSmall extends PureComponent {
                   renderIcon={Close20}
                   size="lg"
                   tooltip={false}
+                  disabled={this.state.loading}
                 />
               )}
             </section>

--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
@@ -177,7 +177,7 @@ storiesOf(patterns('TearsheetSmall'), module)
         isOpen
         loading={loading}
         labels={labels}
-        body={({ ...isLoading }) => (
+        body={isLoading => (
           <>
             <p>
               Whenever the TearsheetSmall is loading, please use{' '}
@@ -209,7 +209,7 @@ storiesOf(patterns('TearsheetSmall'), module)
                 {/* eslint-disable-next-line react/jsx-indent */}
                 {`
             <TearSheetSmall
-              body={({ ...isLoading }) => (
+              body={(isLoading) => (
                 <Button disabled={isLoading}>
                   Example button.
                 </Button>

--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
@@ -12,7 +12,12 @@ import { compose, getDisplayName, lifecycle } from 'recompose';
 
 import { patterns } from '../../../../.storybook';
 
-import { Button, TearsheetSmall } from '../../..';
+import {
+  Button,
+  CodeSnippet,
+  CodeSnippetSkeleton,
+  TearsheetSmall,
+} from '../../..';
 
 import {
   buttons,
@@ -129,13 +134,13 @@ storiesOf(patterns('TearsheetSmall'), module)
               this.setState({
                 loadingMessage: 'Processing request...',
               }),
-            3000
+            300000
           );
 
-          this.complete = setTimeout(
-            () => this.setState({ loading: !loading }),
-            5000
-          );
+          // this.complete = setTimeout(
+          //   () => this.setState({ loading: !loading }),
+          //   5000
+          // );
         },
         componentWillUnmount() {
           clearTimeout(this.startRequest);
@@ -172,6 +177,64 @@ storiesOf(patterns('TearsheetSmall'), module)
         isOpen
         loading={loading}
         labels={labels}
+        body={({ ...isLoading }) => (
+          <>
+            <p>
+              Whenever the TearsheetSmall is loading, please use{' '}
+              <CodeSnippet type="inline" light tabIndex={isLoading ? -1 : 0}>
+                isLoading
+              </CodeSnippet>{' '}
+              via the{' '}
+              <CodeSnippet type="inline" light tabIndex={isLoading ? -1 : 0}>
+                renderMain
+              </CodeSnippet>{' '}
+              render prop to prevent users from tabbing through focussable
+              content (such as form inputs, buttons, and links) while the
+              TearsheetSmall is loading. For example, you can selectively load
+              skeleton components, or you can set
+              <CodeSnippet type="inline" light tabIndex={isLoading ? -1 : 0}>
+                disabled
+              </CodeSnippet>
+              or{' '}
+              <CodeSnippet type="inline" light tabIndex={isLoading ? -1 : 0}>
+                tabIndex={-1}
+              </CodeSnippet>{' '}
+              on interactive elements.
+            </p>
+            <p>Here are some examples:</p>
+            {isLoading ? (
+              <CodeSnippetSkeleton type="multi" />
+            ) : (
+              <CodeSnippet light type="multi">
+                {/* eslint-disable-next-line react/jsx-indent */}
+                {`
+            <TearSheetSmall
+              body={({ ...isLoading }) => (
+                <Button disabled={isLoading}>
+                  Example button.
+                </Button>
+                <CodeSnippet tabIndex={isLoading ? -1 : 0}>
+                  Example snippet with no copy button.
+                </CodeSnippet>
+                {isLoading ? (
+                  <CodeSnippetSkeleton type="multi" />
+                ) : (
+                  <CodeSnippet type="multi">
+                    Exampe snippet with a copy button.
+                  </CodeSnippet>
+                )}
+              )}
+            />
+            `}
+              </CodeSnippet>
+            )}
+            <br />
+            <p>
+              For more examples, please review the &quot;Story&quot; tab in the
+              Storybook panel below to the see this demo&apos; source code.
+            </p>
+          </>
+        )}
       />
     );
   })

--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
@@ -134,13 +134,13 @@ storiesOf(patterns('TearsheetSmall'), module)
               this.setState({
                 loadingMessage: 'Processing request...',
               }),
-            300000
+            3000
           );
 
-          // this.complete = setTimeout(
-          //   () => this.setState({ loading: !loading }),
-          //   5000
-          // );
+          this.complete = setTimeout(
+            () => this.setState({ loading: !loading }),
+            5000
+          );
         },
         componentWillUnmount() {
           clearTimeout(this.startRequest);

--- a/src/components/Tearsheet/TearsheetSmall/__tests__/__snapshots__/TearsheetSmall.spec.js.snap
+++ b/src/components/Tearsheet/TearsheetSmall/__tests__/__snapshots__/TearsheetSmall.spec.js.snap
@@ -79,6 +79,7 @@ exports[`TearsheetSmall renders 1`] = `
       </footer>
       <IconButton
         className="security--tearsheet--small__button--close"
+        disabled={false}
         iconClassName=""
         iconSize={20}
         label="Close"
@@ -242,7 +243,7 @@ exports[`TearsheetSmall renders loading state 1`] = `
       >
         <Button
           className="security--tearsheet--small__footer__button security--tearsheet--small__footer__button--secondary"
-          disabled={false}
+          disabled={true}
           kind="secondary"
           largeText={null}
           loading={false}
@@ -255,7 +256,7 @@ exports[`TearsheetSmall renders loading state 1`] = `
         </Button>
         <Button
           className="security--tearsheet--small__footer__button"
-          disabled={false}
+          disabled={true}
           kind="primary"
           largeText={null}
           loading={false}
@@ -269,6 +270,7 @@ exports[`TearsheetSmall renders loading state 1`] = `
       </footer>
       <IconButton
         className="security--tearsheet--small__button--close"
+        disabled={true}
         iconClassName=""
         iconSize={20}
         label="Close"
@@ -369,6 +371,7 @@ exports[`TearsheetSmall should override \`labels\` if button label property prov
       </footer>
       <IconButton
         className="security--tearsheet--small__button--close"
+        disabled={false}
         iconClassName=""
         iconSize={20}
         label="Close - prop"

--- a/src/components/Tearsheet/__tests__/__snapshots__/Tearsheet.spec.js.snap
+++ b/src/components/Tearsheet/__tests__/__snapshots__/Tearsheet.spec.js.snap
@@ -77,6 +77,7 @@ exports[`Tearsheet should override \`labels\` if button label property provided 
       >
         <IconButton
           className="security--tearsheet__button--close"
+          disabled={false}
           iconClassName=""
           iconSize={20}
           label="Close - prop"
@@ -90,7 +91,6 @@ exports[`Tearsheet should override \`labels\` if button label property provided 
           }
           size="lg"
           state={false}
-          tabIndex={0}
           tooltip={false}
           tooltipDirection="bottom"
         />
@@ -246,6 +246,7 @@ exports[`Tearsheet should render the Tearsheet 1`] = `
       >
         <IconButton
           className="security--tearsheet__button--close"
+          disabled={false}
           iconClassName=""
           iconSize={20}
           label="Close"
@@ -259,7 +260,6 @@ exports[`Tearsheet should render the Tearsheet 1`] = `
           }
           size="lg"
           state={false}
-          tabIndex={0}
           tooltip={false}
           tooltipDirection="bottom"
         />


### PR DESCRIPTION
## Affected issues

- Resolves #601 

## Proposed changes

Similar approach as #576 -
- pass through `isLoading` with loading state so that it can be used to making interactive elements non-interactive while `TearsheetSmall` is loading
- provide guidance for using `isLoading`
- make sure that all `TearsheetSmall` buttons are set to `disabled={true}` whenever loading state is active, so that they cannot be tabbed to in the background

Cleanup:
- in the `Tearsheet`, replace usage of `tabIndex` with the `disabled` attribute to make elements non-interactive during loading state
