### PR TITLE
docs(icon-button-bar): include example with box-shadow between icons

### DIFF
--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -8,6 +8,7 @@ import { storiesOf } from '@storybook/react';
 import { select, number, boolean } from '@storybook/addon-knobs';
 
 import React from 'react';
+import { gray } from '@carbon/colors';
 import Add16 from '@carbon/icons-react/lib/add/16';
 import Add20 from '@carbon/icons-react/lib/add/20';
 import Add24 from '@carbon/icons-react/lib/add/24';
@@ -59,6 +60,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
         iconClassName,
         label: `${label} 2`,
         onClick: action('onClick'),
+        style: { boxShadow: `-1px 0 0 ${gray[40]}` },
         renderIcon:
           size === 'sm'
             ? Edit16


### PR DESCRIPTION
## Affected issues

- Resolves #568 

## Proposed changes

- demonstrate how to add a divide between two icon buttons (not including the overflow menu button)

NOTE: a divider on either side of the overflow menu button would need a style override, since the overflow button is different from the ordinary icon buttons in this component)

