### PR TITLE
fix(wizard): update prop destructuring and prevent title attr leaking

### DIFF
--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -219,6 +219,7 @@ class Wizard extends Component {
             disabled={!valid}
             handleItemSelect={this.handleItemSelect}
             link={false}
+            title={title}
           >
             {title}
           </NavItem>
@@ -231,6 +232,7 @@ class Wizard extends Component {
             key={title}
             disabled={index > currentStep}
             label={title}
+            title={title}
           />
         ))}
       </ProgressIndicator>
@@ -241,7 +243,7 @@ class Wizard extends Component {
    * Renders the component.
    */
   render() {
-    const { labels, ...other } = this.props;
+    const { labels, focusTrap, title, subTitle, ...other } = this.props;
     const componentLabels = {
       ...defaultLabels.labels,
       ...labels,
@@ -308,7 +310,6 @@ class Wizard extends Component {
       TEARSHEET_TERTIARY_BUTTON: componentLabels.WIZARD_TERTIARY_BUTTON,
     };
 
-    const { focusTrap, title, subTitle } = this.props;
     const renderMain = () =>
       this.currentStep.renderMain(
         this.state.componentState,

--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -219,7 +219,6 @@ class Wizard extends Component {
             disabled={!valid}
             handleItemSelect={this.handleItemSelect}
             link={false}
-            title={title}
           >
             {title}
           </NavItem>
@@ -232,7 +231,6 @@ class Wizard extends Component {
             key={title}
             disabled={index > currentStep}
             label={title}
-            title={title}
           />
         ))}
       </ProgressIndicator>


### PR DESCRIPTION
## Affected issues

- Related to #617 but does not completely resolve it  

If you look at the `Wizard` right now and hover over almost any part of it, a default tooltip will appear with the title text. Right now the `title` prop is being leaked as a `title` attribute to the inner `Tearsheet`, which doesn't seem intended.

## Proposed changes

- destructured props in the same spot
- avoid leaking `title` prop to `title` attribute
