### PR TITLE
feat(icon-button-bar): add divider prop with demo and tests

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -8156,7 +8156,6 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
 }
 
 .security--icon-button-bar__divider {
-  background-color: transparent;
   width: 3px;
   display: flex;
   justify-content: center;

--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -8155,6 +8155,18 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
   width: 4rem;
 }
 
+.security--icon-button-bar__divider {
+  background-color: transparent;
+  width: 3px;
+  display: flex;
+  justify-content: center;
+}
+
+.security--icon-button-bar__divider__inner {
+  background-color: var(--ui-03, #393939);
+  width: 1px;
+}
+
 @keyframes rotate {
   0% {
     transform: rotate(0deg);

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -45,7 +45,7 @@ const IconButtonBar = ({
     <Fragment key={action.label || `${namespace}__button--icon--${index}`}>
       {(action.divider === 'left' || action.divider === 'sides') && (
         <span className={`${namespace}__divider`} aria-hidden>
-          <span className={`${namespace}__divider__inner`} aria-hidden />
+          <span className={`${namespace}__divider__inner`} />
         </span>
       )}
       <IconButton
@@ -56,7 +56,7 @@ const IconButtonBar = ({
       />
       {(action.divider === 'right' || action.divider === 'sides') && (
         <span className={`${namespace}__divider`} aria-hidden>
-          <span className={`${namespace}__divider__inner`} aria-hidden />
+          <span className={`${namespace}__divider__inner`} />
         </span>
       )}
     </Fragment>

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -42,13 +42,25 @@ const IconButtonBar = ({
   );
 
   const renderIconButton = action => (
-    <IconButton
-      {...action}
-      key={action.label || `${namespace}__button--icon`}
-      size={size}
-      tooltip={tooltip}
-      tooltipDirection={iconTooltipDirection}
-    />
+    <>
+      {(action.border === 'left' || action.border === 'sides') && (
+        <span className={`${namespace}__divider`} aria-hidden>
+          <span className={`${namespace}__divider__inner`} aria-hidden />
+        </span>
+      )}
+      <IconButton
+        {...action}
+        key={action.label || `${namespace}__button--icon`}
+        size={size}
+        tooltip={tooltip}
+        tooltipDirection={iconTooltipDirection}
+      />
+      {(action.border === 'right' || action.border === 'sides') && (
+        <span className={`${namespace}__divider`} aria-hidden>
+          <span className={`${namespace}__divider__inner`} aria-hidden />
+        </span>
+      )}
+    </>
   );
 
   const renderMenuItems = () => {
@@ -107,6 +119,7 @@ IconButtonBar.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       ...propTypes,
+      border: PropTypes.oneOf(['left', 'right', 'sides']),
     })
   ),
 

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -43,7 +43,7 @@ const IconButtonBar = ({
 
   const renderIconButton = action => (
     <>
-      {(action.border === 'left' || action.border === 'sides') && (
+      {(action.divider === 'left' || action.divider === 'sides') && (
         <span className={`${namespace}__divider`} aria-hidden>
           <span className={`${namespace}__divider__inner`} aria-hidden />
         </span>
@@ -55,7 +55,7 @@ const IconButtonBar = ({
         tooltip={tooltip}
         tooltipDirection={iconTooltipDirection}
       />
-      {(action.border === 'right' || action.border === 'sides') && (
+      {(action.divider === 'right' || action.divider === 'sides') && (
         <span className={`${namespace}__divider`} aria-hidden>
           <span className={`${namespace}__divider__inner`} aria-hidden />
         </span>
@@ -119,7 +119,7 @@ IconButtonBar.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       ...propTypes,
-      border: PropTypes.oneOf(['left', 'right', 'sides']),
+      divider: PropTypes.oneOf(['left', 'right', 'sides']),
     })
   ),
 

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -14,7 +14,7 @@ import { OverflowMenu, OverflowMenuItem } from '../..';
 import IconButton from '../IconButton';
 import { getComponentNamespace } from '../../globals/namespace';
 
-const namespace = getComponentNamespace('icon-button-bar');
+export const namespace = getComponentNamespace('icon-button-bar');
 const { propTypes } = IconButton;
 
 const IconButtonBar = ({
@@ -41,8 +41,8 @@ const IconButtonBar = ({
     }
   );
 
-  const renderIconButton = action => (
-    <>
+  const renderIconButton = (action, index) => (
+    <Fragment key={action.label || `${namespace}__button--icon--${index}`}>
       {(action.divider === 'left' || action.divider === 'sides') && (
         <span className={`${namespace}__divider`} aria-hidden>
           <span className={`${namespace}__divider__inner`} aria-hidden />
@@ -50,7 +50,6 @@ const IconButtonBar = ({
       )}
       <IconButton
         {...action}
-        key={action.label || `${namespace}__button--icon`}
         size={size}
         tooltip={tooltip}
         tooltipDirection={iconTooltipDirection}
@@ -60,7 +59,7 @@ const IconButtonBar = ({
           <span className={`${namespace}__divider__inner`} aria-hidden />
         </span>
       )}
-    </>
+    </Fragment>
   );
 
   const renderMenuItems = () => {

--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -60,11 +60,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
       },
       {
         className,
-        divider: select(
-          'Icon 2 divider (divider)',
-          ['left', 'right', 'sides'],
-          'right'
-        ),
+        divider: undefined,
         disabled: false,
         iconClassName,
         label: `${label} 2`,

--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -40,6 +40,11 @@ storiesOf(patterns('IconButtonBar'), module).add(
     const actions = [
       {
         className,
+        border: select(
+          'Icon 1 border (border)',
+          ['left', 'right', 'sides'],
+          'sides'
+        ),
         disabled: false,
         iconClassName,
         label: `${label} 1`,
@@ -55,6 +60,11 @@ storiesOf(patterns('IconButtonBar'), module).add(
       },
       {
         className,
+        border: select(
+          'Icon 2 border (border)',
+          ['left', 'right', 'sides'],
+          'right'
+        ),
         disabled: false,
         iconClassName,
         label: `${label} 2`,

--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -40,7 +40,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
     const actions = [
       {
         className,
-        border: select(
+        divider: select(
           'Icon 1 border (border)',
           ['left', 'right', 'sides'],
           'sides'
@@ -60,7 +60,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
       },
       {
         className,
-        border: select(
+        divider: select(
           'Icon 2 border (border)',
           ['left', 'right', 'sides'],
           'right'

--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -35,13 +35,13 @@ import { TooltipDirection } from '../IconButton/IconButton';
 storiesOf(patterns('IconButtonBar'), module).add(
   'default',
   () => {
-    const size = select('size', sizes, sizes[0]);
+    const size = select('size', sizes, 'sm');
     /* eslint-disable no-nested-ternary */
     const actions = [
       {
         className,
         divider: select(
-          'Icon 1 border (border)',
+          'Icon 1 divider (divider)',
           ['left', 'right', 'sides'],
           'sides'
         ),
@@ -61,7 +61,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
       {
         className,
         divider: select(
-          'Icon 2 border (border)',
+          'Icon 2 divider (divider)',
           ['left', 'right', 'sides'],
           'right'
         ),

--- a/src/components/IconButtonBar/__tests__/IconButtonBar.spec.js
+++ b/src/components/IconButtonBar/__tests__/IconButtonBar.spec.js
@@ -3,6 +3,7 @@
  * @copyright IBM Security 2019
  */
 
+import { render } from '@testing-library/react';
 import { shallow } from 'enzyme';
 import React from 'react';
 import Add16 from '@carbon/icons-react/lib/add/16';
@@ -18,9 +19,12 @@ import {
   sizes,
 } from '../../IconButton/_mocks_';
 
+import { namespace } from '../IconButtonBar';
+
 const actions = [
   {
     className,
+    divider: 'left',
     disabled: false,
     iconClassName,
     label: `${label} 1`,
@@ -29,6 +33,7 @@ const actions = [
   },
   {
     className,
+    divider: 'right',
     disabled: false,
     iconClassName,
     label: `${label} 2`,
@@ -37,6 +42,7 @@ const actions = [
   },
   {
     className,
+    divider: 'sides',
     disabled: false,
     iconClassName,
     label: `${label} 3`,
@@ -53,15 +59,10 @@ const actions = [
   },
 ];
 
-let iconButtonBar;
-
-beforeEach(() => {
-  iconButtonBar = shallow(<IconButtonBar actions={actions} />);
-});
-
 describe('IconButtonBar', () => {
   sizes.forEach(size => {
     it(`renders the '${size}' variation`, () => {
+      const iconButtonBar = shallow(<IconButtonBar actions={actions} />);
       iconButtonBar.setProps({ size });
       expect(iconButtonBar).toMatchSnapshot();
     });
@@ -69,8 +70,66 @@ describe('IconButtonBar', () => {
 
   [1, 2, 3, 4, 5].forEach(length => {
     it(`renders the length of '${length}' variation`, () => {
+      const iconButtonBar = shallow(<IconButtonBar actions={actions} />);
       iconButtonBar.setProps({ length });
       expect(iconButtonBar).toMatchSnapshot();
     });
+  });
+
+  it('renders a divider on the left', () => {
+    const { getByLabelText } = render(
+      <IconButtonBar
+        actions={[
+          {
+            divider: 'left',
+            label: 'Test label',
+            onClick: () => {},
+            renderIcon: Edit16,
+          },
+        ]}
+      />
+    );
+    expect(getByLabelText('Test label').previousSibling).toHaveClass(
+      `${namespace}__divider`
+    );
+  });
+
+  it('renders a divider on the right', () => {
+    const { getByLabelText } = render(
+      <IconButtonBar
+        actions={[
+          {
+            divider: 'right',
+            label: 'Test label',
+            onClick: () => {},
+            renderIcon: Edit16,
+          },
+        ]}
+      />
+    );
+    expect(getByLabelText('Test label').nextSibling).toHaveClass(
+      `${namespace}__divider`
+    );
+  });
+
+  it('renders a divider on both sides of a button', () => {
+    const { getByLabelText } = render(
+      <IconButtonBar
+        actions={[
+          {
+            divider: 'sides',
+            label: 'Test label',
+            onClick: () => {},
+            renderIcon: Edit16,
+          },
+        ]}
+      />
+    );
+    expect(getByLabelText('Test label').previousSibling).toHaveClass(
+      `${namespace}__divider`
+    );
+    expect(getByLabelText('Test label').nextSibling).toHaveClass(
+      `${namespace}__divider`
+    );
   });
 });

--- a/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
+++ b/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
@@ -4,12 +4,21 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--lg"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -27,9 +36,9 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -44,6 +53,15 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <ForwardRef(OverflowMenu)
     className="security--icon-button-bar__overflow-menu"
     direction="top"
@@ -84,12 +102,21 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--md"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -107,9 +134,9 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -124,6 +151,15 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <ForwardRef(OverflowMenu)
     className="security--icon-button-bar__overflow-menu"
     direction="top"
@@ -164,12 +200,21 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--sm"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -187,9 +232,9 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -204,6 +249,15 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <ForwardRef(OverflowMenu)
     className="security--icon-button-bar__overflow-menu"
     direction="top"
@@ -244,12 +298,21 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--xl"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -267,9 +330,9 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -284,6 +347,15 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <ForwardRef(OverflowMenu)
     className="security--icon-button-bar__overflow-menu"
     direction="top"
@@ -384,12 +456,21 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--lg"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -454,12 +535,21 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--lg"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -477,9 +567,9 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -494,6 +584,15 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <ForwardRef(OverflowMenu)
     className="security--icon-button-bar__overflow-menu"
     direction="top"
@@ -534,12 +633,21 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--lg"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -557,9 +665,9 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -574,12 +682,30 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="sides"
     iconClassName="class"
     iconSize={20}
-    key="Label 3"
     label="Label 3"
     onClick={[Function]}
     path={null}
@@ -594,12 +720,20 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
     iconClassName="class"
     iconSize={20}
-    key="Label 4"
     label="Label 4"
     onClick={[Function]}
     path={null}
@@ -621,12 +755,21 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
 <div
   className="security--icon-button-bar security--icon-button-bar--lg"
 >
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="left"
     iconClassName="class"
     iconSize={20}
-    key="Label 1"
     label="Label 1"
     onClick={[Function]}
     path={null}
@@ -644,9 +787,9 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
   <IconButton
     className="class"
     disabled={false}
+    divider="right"
     iconClassName="class"
     iconSize={20}
-    key="Label 2"
     label="Label 2"
     onClick={[Function]}
     path={null}
@@ -661,12 +804,30 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
+    divider="sides"
     iconClassName="class"
     iconSize={20}
-    key="Label 3"
     label="Label 3"
     onClick={[Function]}
     path={null}
@@ -681,12 +842,20 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
     tooltip={true}
     tooltipDirection="top"
   />
+  <span
+    aria-hidden={true}
+    className="security--icon-button-bar__divider"
+  >
+    <span
+      aria-hidden={true}
+      className="security--icon-button-bar__divider__inner"
+    />
+  </span>
   <IconButton
     className="class"
     disabled={false}
     iconClassName="class"
     iconSize={20}
-    key="Label 4"
     label="Label 4"
     onClick={[Function]}
     path={null}

--- a/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
+++ b/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
@@ -9,7 +9,6 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -58,7 +57,6 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -107,7 +105,6 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -156,7 +153,6 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -205,7 +201,6 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -254,7 +249,6 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -303,7 +297,6 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -352,7 +345,6 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -461,7 +453,6 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -540,7 +531,6 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -589,7 +579,6 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -638,7 +627,6 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -687,7 +675,6 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -696,7 +683,6 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -725,7 +711,6 @@ exports[`IconButtonBar renders the length of '4' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -760,7 +745,6 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -809,7 +793,6 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -818,7 +801,6 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>
@@ -847,7 +829,6 @@ exports[`IconButtonBar renders the length of '5' variation 1`] = `
     className="security--icon-button-bar__divider"
   >
     <span
-      aria-hidden={true}
       className="security--icon-button-bar__divider__inner"
     />
   </span>

--- a/src/components/IconButtonBar/_index.scss
+++ b/src/components/IconButtonBar/_index.scss
@@ -51,7 +51,7 @@
   }
 
   &__divider {
-    background-color: transparent;
+    // divider should remain transparent
     width: 3px;
     display: flex;
     justify-content: center;

--- a/src/components/IconButtonBar/_index.scss
+++ b/src/components/IconButtonBar/_index.scss
@@ -51,8 +51,8 @@
   }
 
   &__divider {
-    width: 3px;
     background-color: transparent;
+    width: 3px;
     display: flex;
     justify-content: center;
   }

--- a/src/components/IconButtonBar/_index.scss
+++ b/src/components/IconButtonBar/_index.scss
@@ -49,4 +49,16 @@
       width: $icon-button-bar__sizing__dimensions;
     }
   }
+
+  &__divider {
+    width: 3px;
+    background-color: transparent;
+    display: flex;
+    justify-content: center;
+  }
+
+  &__divider__inner {
+    background-color: $ui-03;
+    width: 1px;
+  }
 }

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -4377,6 +4377,16 @@ Map {
                 "className": Object {
                   "type": "string",
                 },
+                "divider": Object {
+                  "args": Array [
+                    Array [
+                      "left",
+                      "right",
+                      "sides",
+                    ],
+                  ],
+                  "type": "oneOf",
+                },
                 "iconClassName": Object {
                   "type": "string",
                 },


### PR DESCRIPTION
## Affected issues

- Resolves #568 

## Proposed changes

- add `divider` prop that renders a divider element on either side of an icon button, depending on prop value
- add storybook knobs/demo for new prop
- add tests for new prop

## Testing instructions

- <!-- List of instructions for reviewer to test that proposed changes in this PR work properly -->
