### PR TITLE
test(components): update a11y tests to use renderWithinLandmark

### DIFF
--- a/config/jest/helpers/renderWithinLandmark.js
+++ b/config/jest/helpers/renderWithinLandmark.js
@@ -1,0 +1,18 @@
+/**
+ * @file Helper to render jsx in a landmark element.
+ * @copyright IBM Security 2020
+ */
+
+import { render } from '@testing-library/react';
+
+function renderWithinLandmark(jsxExpression) {
+  // DAP requires a landmark '<main>' in the DOM:
+  const container = document.createElement('main');
+  document.body.appendChild(container);
+
+  return render(jsxExpression, {
+    container,
+  });
+}
+
+export default renderWithinLandmark;

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -14,27 +14,25 @@ Use this structure for automated accessibility tests:
 
 ```jsx
 test('should have no Axe or DAP violations', async () => {
-  const main = document.createElement('main');
-  render(<Component />, {
-    // DAP requires a landmark '<main>' in the DOM:
-    container: document.body.appendChild(main),
-  });
+  const { container } = render(<Component />);
 
-  await expect(document.body).toHaveNoAxeViolations();
-  await expect(document.body).toHaveNoDAPViolations('ComponentName');
+  await expect(container).toHaveNoAxeViolations();
+  await expect(container).toHaveNoDAPViolations('ComponentName');
 });
 
 test('should have no Axe or DAP violations with component variation', async () => {
-  const main = document.createElement('main');
-  render(<Component variationProp={value} />, {
-    // DAP requires a landmark '<main>' in the DOM:
-    container: document.body.appendChild(main),
-  });
+  const { container } = render(<Component variationProp={value} />);
 
-  await expect(document.body).toHaveNoAxeViolations();
-  await expect(document.body).toHaveNoDAPViolations(
-    'ComponentName with variation'
-  );
+  await expect(container).toHaveNoAxeViolations();
+  await expect(container).toHaveNoDAPViolations('ComponentName with variation');
+});
+
+test('should have no Axe or DAP violations with component variation that should be wrapped in a landmark node', async () => {
+  // `renderWithinLandmark` can be used to wrap a component in a `main` node:
+  const { container } = renderWithinLandmark(<Component />);
+
+  await expect(container).toHaveNoAxeViolations();
+  await expect(container).toHaveNoDAPViolations('ComponentName');
 });
 ```
 
@@ -45,7 +43,7 @@ test('should have no Axe or DAP violations with component variation', async () =
 
 #### DAP requirements
 
-- DAP requires that components be rendered inside a valid landmark element, which is why the `container` is a `main` node. This extra step may not be required if the component is already wrapped in a `main` or another significant HTML landmark element.
+- DAP requires that components be rendered inside a valid landmark element. Use the `renderWithinLandmark` helper to wrap a component in a landmark `main` node.
 - DAP requires a unique id per test within a given component. (Hence, "ComponentName" and "ComponentName with variation")
 
 ## User events

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -7,6 +7,7 @@ import Add16 from '@carbon/icons-react/lib/add/16';
 import { ButtonKinds } from 'carbon-components-react/lib/prop-types/types';
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Button } from '../../..';
 import { carbonPrefix } from '../../../globals/namespace';
@@ -14,18 +15,13 @@ import { namespace } from '../Button';
 
 describe('Button', () => {
   test('should have no Axe or DAP violations when `loading`', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <Button loading iconDescription="test button icon description">
         test loading button
-      </Button>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </Button>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Button that is loading');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Button that is loading');
   });
 
   test('should add custom class', () => {

--- a/src/components/Card/CardSkeleton/__tests__/CardSkeleton.spec.js
+++ b/src/components/Card/CardSkeleton/__tests__/CardSkeleton.spec.js
@@ -3,19 +3,15 @@
  * @copyright IBM Security 2020
  */
 
-import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import { CardSkeleton } from '../../../..';
 
 describe('CardSkeleton', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<CardSkeleton />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('CardSkeleton');
+    const { container } = renderWithinLandmark(<CardSkeleton />);
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('CardSkeleton');
   });
 });

--- a/src/components/Card/__tests__/Card.spec.js
+++ b/src/components/Card/__tests__/Card.spec.js
@@ -6,15 +6,15 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Card } from '../../..';
 
 import { icon } from '../../_mocks_';
 
-describe('Card', () => {
+describe('Card2', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <Card
         header={{
           image: icon,
@@ -28,32 +28,23 @@ describe('Card', () => {
         footer={{
           children: <span>test footer</span>,
         }}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Card');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Card');
   });
 
   test('should have no Axe or DAP violations when rendered as a link', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <Card
         header={{
           title: 'test title',
         }}
         link="#"
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Card as a link');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Card as a link');
   });
 
   test('should invoke click mock when card is clicked', () => {

--- a/src/components/DataDecorator/Decorator/__tests__/Decorator.spec.js
+++ b/src/components/DataDecorator/Decorator/__tests__/Decorator.spec.js
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Decorator } from '../../../..';
 
@@ -13,36 +14,30 @@ import { namespace, icons } from '../constants';
 
 describe('Decorator', () => {
   test('should have no Axe or DAP violations when rendered as a button', async () => {
-    const main = document.createElement('main');
-    render(<Decorator type="IP" value="10.0.0.0" score={0} />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
+    const { container } = renderWithinLandmark(
+      <Decorator type="IP" value="10.0.0.0" score={0} />
+    );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Decorator as a button');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Decorator as a button');
   });
 
   test('should have no Axe or DAP violations when rendered as a link', async () => {
-    const main = document.createElement('main');
-    render(<Decorator type="IP" value="10.0.0.0" score={0} href="#" />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
+    const { container } = renderWithinLandmark(
+      <Decorator type="IP" value="10.0.0.0" score={0} href="#" />
+    );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Decorator as a link');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Decorator as a link');
   });
 
   test('should have no Axe or DAP violations when inert', async () => {
-    const main = document.createElement('main');
-    render(<Decorator type="IP" value="10.0.0.0" score={0} invert />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
+    const { container } = renderWithinLandmark(
+      <Decorator type="IP" value="10.0.0.0" score={0} invert />
+    );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Decorator as inert');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Decorator as inert');
   });
 
   test('should apply a score', () => {
@@ -146,14 +141,12 @@ Object.keys(icons).forEach(icon => {
 
   describe(`Decorator.${formattedName}`, () => {
     test('should have no Axe or DAP violations', async () => {
-      const main = document.createElement('main');
-      render(<Component description={`${formattedName} severity`} />, {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      });
+      const { container } = renderWithinLandmark(
+        <Component description={`${formattedName} severity`} />
+      );
 
-      await expect(document.body).toHaveNoAxeViolations();
-      await expect(document.body).toHaveNoDAPViolations(
+      await expect(container).toHaveNoAxeViolations();
+      await expect(container).toHaveNoDAPViolations(
         `Decorator.${formattedName}`
       );
     });

--- a/src/components/DataDecorator/__tests__/DataDecorator.spec.js
+++ b/src/components/DataDecorator/__tests__/DataDecorator.spec.js
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Button, DataDecorator } from '../../..';
 
@@ -13,31 +14,24 @@ import { namespace as panelNamespace } from '../../PanelV2/PanelV2';
 
 describe('DataDecorator', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<DataDecorator type="IP" value="10.0.0.0" score={0} href="#" />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
+    const { container } = renderWithinLandmark(
+      <DataDecorator type="IP" value="10.0.0.0" score={0} href="#" />
+    );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('DataDecorator');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('DataDecorator');
   });
 
   test('should have no Axe or DAP violations with an open panel', async () => {
-    const main = document.createElement('main');
-    const { getByText } = render(
-      <DataDecorator type="IP" value="10.0.0.0" score={0} href="#" />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+    const { container, getByText } = renderWithinLandmark(
+      <DataDecorator type="IP" value="10.0.0.0" score={0} href="#" />
     );
 
     // Click on the data decorator to open the connected panel:
     userEvent.click(getByText(/10.0.0.0/i).closest('button'));
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'DataDecorator with open panel'
     );
   });

--- a/src/components/ErrorPage/__tests__/ErrorPage.spec.js
+++ b/src/components/ErrorPage/__tests__/ErrorPage.spec.js
@@ -5,13 +5,13 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { ErrorPage } from '../../..';
 
 describe('ErrorPage', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <ErrorPage
         statusCode={404}
         title="test title"
@@ -29,15 +29,11 @@ describe('ErrorPage', () => {
             href: '#',
           },
         ]}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('ErrorPage');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('ErrorPage');
   });
 
   test('should apply a title via `title`', () => {

--- a/src/components/ExternalLink/__tests__/ExternalLink.spec.js
+++ b/src/components/ExternalLink/__tests__/ExternalLink.spec.js
@@ -5,23 +5,17 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { ExternalLink } from '../../..';
 
 describe('ExternalLink', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
-      <ExternalLink href="https://www.ibm.com/security">
-        test link
-      </ExternalLink>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+    const { container } = renderWithinLandmark(
+      <ExternalLink href="https://www.ibm.com/security">test link</ExternalLink>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('ExternalLink');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('ExternalLink');
   });
 
   test('should add children as link text', () => {

--- a/src/components/FilterPanel/FilterPanelAccordion/__tests__/FilterPanelAccordion.spec.js
+++ b/src/components/FilterPanel/FilterPanelAccordion/__tests__/FilterPanelAccordion.spec.js
@@ -5,24 +5,17 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelAccordion from '../FilterPanelAccordion';
 
 describe('FilterPanelAccordion', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
-      <FilterPanelAccordion
-        heading="test accordion title"
-        title="test title"
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+    const { container } = renderWithinLandmark(
+      <FilterPanelAccordion heading="test accordion title" title="test title" />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('FilterPanelAccordion');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanelAccordion');
   });
 
   test('renders with a title attribute', () => {

--- a/src/components/FilterPanel/FilterPanelAccordionItem/__tests__/FilterPanelAccordionItem.spec.js
+++ b/src/components/FilterPanel/FilterPanelAccordionItem/__tests__/FilterPanelAccordionItem.spec.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelAccordionItem from '../FilterPanelAccordiontItem';
 
@@ -23,8 +24,7 @@ const createChildChildren = length =>
 
 describe('FilterPanelAccordionItem', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       // `FilterPanelAccordionItem` would be
       // wrapped by `FilterPanelAccordion`, which
       // renders as an unordered list:
@@ -35,16 +35,10 @@ describe('FilterPanelAccordionItem', () => {
         <FilterPanelAccordionItem heading="test-item-2" title="test-item-2">
           {createChildChildren(11)}
         </FilterPanelAccordionItem>
-      </ul>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </ul>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
-      'FilterPanelAccordionItem'
-    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanelAccordionItem');
   });
 
   test('renders with a title attribute', () => {

--- a/src/components/FilterPanel/FilterPanelCheckbox/__tests__/FilterPanelCheckbox.spec.js
+++ b/src/components/FilterPanel/FilterPanelCheckbox/__tests__/FilterPanelCheckbox.spec.js
@@ -6,21 +6,17 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelCheckbox from '../FilterPanelCheckbox';
 
 describe('FilterPanelCheckbox', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
-      <FilterPanelCheckbox labelText="test checkbox" id="test-checkbox-id" />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+    const { container } = renderWithinLandmark(
+      <FilterPanelCheckbox labelText="test checkbox" id="test-checkbox-id" />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('FilterPanelCheckbox');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanelCheckbox');
   });
 
   test('adds custom class name', () => {

--- a/src/components/FilterPanel/FilterPanelCheckboxWithOverflowMenu/__tests__/FilterPanelCheckboxWithOverflowMenu.spec.js
+++ b/src/components/FilterPanel/FilterPanelCheckboxWithOverflowMenu/__tests__/FilterPanelCheckboxWithOverflowMenu.spec.js
@@ -11,25 +11,21 @@ import {
   screen,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelCheckboxWithOverflowMenu from '../FilterPanelCheckboxWithOverflowMenu';
 import OverflowMenuItem from '../../../OverflowMenuItem';
 
 describe(FilterPanelCheckboxWithOverflowMenu.name, () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <FilterPanelCheckboxWithOverflowMenu
         labelText="test checkbox"
         id="test-checkbox-id"
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       `${FilterPanelCheckboxWithOverflowMenu.name}-default`
     );
   });
@@ -38,7 +34,7 @@ describe(FilterPanelCheckboxWithOverflowMenu.name, () => {
     const main = document.createElement('main');
     main.setAttribute('data-floating-menu-container', 'true');
 
-    render(
+    const { container } = render(
       <FilterPanelCheckboxWithOverflowMenu
         labelText="checkbox label"
         overflowMenuAriaLabel="filter selection options"
@@ -47,18 +43,14 @@ describe(FilterPanelCheckboxWithOverflowMenu.name, () => {
       >
         <OverflowMenuItem primaryFocus itemText="option 1" />
         <OverflowMenuItem itemText="option 2" />
-      </FilterPanelCheckboxWithOverflowMenu>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </FilterPanelCheckboxWithOverflowMenu>
     );
 
     // Open overflow menu and waitFor for options to appear on the DOM.
     fireEvent.mouseEnter(screen.getByLabelText(/checkbox label/i));
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       `${FilterPanelCheckboxWithOverflowMenu.name}-open`
     );
   });

--- a/src/components/FilterPanel/FilterPanelGroup/__tests__/FilterPanelGroup.spec.js
+++ b/src/components/FilterPanel/FilterPanelGroup/__tests__/FilterPanelGroup.spec.js
@@ -5,21 +5,17 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelGroup from '../FilterPanelGroup';
 
 describe('FilterPanelGroup', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
-      <FilterPanelGroup heading="test filter group" title="test title" />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+    const { container } = renderWithinLandmark(
+      <FilterPanelGroup heading="test filter group" title="test title" />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('FilterPanelGroup');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanelGroup');
   });
 
   test('renders with a title attribute', () => {

--- a/src/components/FilterPanel/FilterPanelLabel/__tests__/FilterPanelLabel.spec.js
+++ b/src/components/FilterPanel/FilterPanelLabel/__tests__/FilterPanelLabel.spec.js
@@ -5,18 +5,17 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelLabel from '../FilterPanelLabel';
 
 describe('FilterPanelLabel', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<FilterPanelLabel count={100}>custom label</FilterPanelLabel>, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('FilterPanelGroup');
+    const { container } = renderWithinLandmark(
+      <FilterPanelLabel count={100}>custom label</FilterPanelLabel>
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanelGroup');
   });
 
   test('renders with children', () => {

--- a/src/components/FilterPanel/FilterPanelSearch/__tests__/FilterSearch.spec.js
+++ b/src/components/FilterPanel/FilterPanelSearch/__tests__/FilterSearch.spec.js
@@ -6,19 +6,18 @@
 import React from 'react';
 import { render, wait, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanelSearch from '../FilterPanelSearch';
 import Checkbox from '../../../Checkbox';
 
 describe('FilterPanelSearch', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<FilterPanelSearch labelText="search label" />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('FilterPanelSearch');
+    const { container } = renderWithinLandmark(
+      <FilterPanelSearch labelText="search label" />
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanelSearch');
   });
 
   test('adds custom class name', () => {

--- a/src/components/FilterPanel/__tests__/FilterPanel.spec.js
+++ b/src/components/FilterPanel/__tests__/FilterPanel.spec.js
@@ -5,19 +5,18 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import FilterPanel from '..';
 import * as mockProps from '../_mocks_';
 
 describe('FilterPanel', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<FilterPanel title="test title" />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('FilterPanel');
+    const { container } = renderWithinLandmark(
+      <FilterPanel title="test title" />
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('FilterPanel');
   });
 
   test('renders without a title or content by default', () => {

--- a/src/components/ICA/ICASkeleton/__tests__/ICASkeleton.spec.js
+++ b/src/components/ICA/ICASkeleton/__tests__/ICASkeleton.spec.js
@@ -4,18 +4,15 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import ICASkeleton from '../ICASkeleton';
 
 describe('ICASkeleton', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<ICASkeleton />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('ICASkeleton');
+    const { container } = renderWithinLandmark(<ICASkeleton />);
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('ICASkeleton');
   });
 });

--- a/src/components/ICA/__tests__/ICA.spec.js
+++ b/src/components/ICA/__tests__/ICA.spec.js
@@ -5,19 +5,18 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { ICA } from '../../..';
 import { Locales } from '../ICA';
 
 describe('ICA', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<ICA label="test ICA" total={10} value={5} />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('ICA');
+    const { container } = renderWithinLandmark(
+      <ICA label="test ICA" total={10} value={5} />
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('ICA');
   });
 
   test('should render en dash when `value` is `null`', () => {

--- a/src/components/Loading/LoadingMessage/__tests__/LoadingMessage.spec.js
+++ b/src/components/Loading/LoadingMessage/__tests__/LoadingMessage.spec.js
@@ -5,6 +5,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import { LoadingMessage } from '../../../..';
 
@@ -12,47 +13,35 @@ import { carbonPrefix } from '../../../../globals/namespace';
 
 describe('LoadingMessage', () => {
   test('should have no Axe or DAP violations with overlay', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <LoadingMessage active withOverlay>
         test message
-      </LoadingMessage>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </LoadingMessage>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'LoadingMessage with overlay'
     );
   });
 
   test('should have no Axe or DAP violations without overlay', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <LoadingMessage active withOverlay={false}>
         test message
-      </LoadingMessage>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </LoadingMessage>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'LoadingMessage without overlay'
     );
   });
 
   test('should have no Axe or DAP violations when inactive', async () => {
-    const main = document.createElement('main');
-    render(<LoadingMessage active={false}>test message</LoadingMessage>, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    const { container } = renderWithinLandmark(
+      <LoadingMessage active={false}>test message</LoadingMessage>
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'LoadingMessage when inactive'
     );
   });

--- a/src/components/NonEntitledSection/__tests__/NonEntitledSection.spec.js
+++ b/src/components/NonEntitledSection/__tests__/NonEntitledSection.spec.js
@@ -5,14 +5,14 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { icon } from '../../_mocks_';
 import { NonEntitledSection } from '../../..';
 
 describe('NonEntitledSection', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <NonEntitledSection
         title="test title"
         subTitle="test subtitle"
@@ -30,15 +30,11 @@ describe('NonEntitledSection', () => {
             icon,
           },
         ]}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('NonEntitledSection');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('NonEntitledSection');
   });
 
   test('should apply a title via `title`', () => {

--- a/src/components/PanelV2/__tests__/PanelV2.spec.js
+++ b/src/components/PanelV2/__tests__/PanelV2.spec.js
@@ -7,13 +7,13 @@ import Add16 from '@carbon/icons-react/lib/add/16';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Button, PanelV2, PanelContent } from '../../..';
 
 describe('PanelV2', () => {
   test('should have no Axe or DAP violations with custom footer via `renderFooter`', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <PanelV2
         title="test title"
         subtitle="test subtitle"
@@ -23,21 +23,14 @@ describe('PanelV2', () => {
         renderFooter={() => <Button>test footer button</Button>}
       >
         <PanelContent>test content</PanelContent>
-      </PanelV2>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </PanelV2>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
-      'PanelV2 with renderFooter'
-    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('PanelV2 with renderFooter');
   });
 
   test('should have no Axe or DAP violations with `title` or `subtitle` as a `node`', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <PanelV2
         title={<span>test title</span>}
         subtitle={<span>test subtitle</span>}
@@ -46,21 +39,16 @@ describe('PanelV2', () => {
         }}
       >
         <PanelContent>test content</PanelContent>
-      </PanelV2>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </PanelV2>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'PanelV2 with title or subtitle as node'
     );
   });
 
   test('should have no Axe or DAP violations when there is scrolling content', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <PanelV2
         // Note that title (or subtitle) should be provided here
         // to generate a valid `aria-labelledBy` for tabbable scrolling content:
@@ -77,21 +65,16 @@ describe('PanelV2', () => {
           test content text
           <Button>test content button</Button>
         </PanelContent>
-      </PanelV2>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </PanelV2>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'PanelV2 with hasScrollingContent'
     );
   });
 
   test('should have no Axe or DAP violations with deprecated `primaryButton` & `secondaryButton`', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <PanelV2
         title="test title"
         subtitle="test subtitle"
@@ -108,14 +91,10 @@ describe('PanelV2', () => {
         }}
       >
         <PanelContent>test content</PanelContent>
-      </PanelV2>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </PanelV2>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'PanelV2 with deprecated props'
     );
   });

--- a/src/components/Pill/__tests__/Pill.spec.js
+++ b/src/components/Pill/__tests__/Pill.spec.js
@@ -6,19 +6,18 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Pill } from '../../..';
 import { namespace } from '../Pill';
 
 describe('Pill', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<Pill value="127.0.0.1" type="IP" />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Pill');
+    const { container } = renderWithinLandmark(
+      <Pill value="127.0.0.1" type="IP" />
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Pill');
   });
 
   test('should add a custom class', () => {

--- a/src/components/Portal/__tests__/Portal.spec.js
+++ b/src/components/Portal/__tests__/Portal.spec.js
@@ -5,13 +5,13 @@
 
 import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Portal } from '../../..';
 
 describe('Portal', () => {
   test('should have no Axe or DAP violations with overlay', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <div>
         <section>
           <button>test button outside portal</button>
@@ -21,19 +21,14 @@ describe('Portal', () => {
             <button>test button inside portal</button>
           </section>
         </Portal>
-      </div>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </div>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Portal with overlay');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Portal with overlay');
   });
 
   test('should have no Axe or DAP violations without overlay', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <div>
         <section>
           <button>test button outside portal</button>
@@ -43,14 +38,10 @@ describe('Portal', () => {
             <button>test button inside portal</button>
           </section>
         </Portal>
-      </div>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </div>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('Portal without overlay');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('Portal without overlay');
   });
 
   test('should remove node from DOM when it is unmounted', () => {

--- a/src/components/ProfileImage/__tests__/ProfileImage.spec.js
+++ b/src/components/ProfileImage/__tests__/ProfileImage.spec.js
@@ -5,6 +5,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { ProfileImage } from '../../..';
 
@@ -12,8 +13,7 @@ import { namespace } from '../ProfileImage';
 
 describe('ProfileImage', () => {
   test('should have no Axe or DAP violations when image is NOT provided', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <ProfileImage
         profile={{
           image_url: null,
@@ -22,21 +22,14 @@ describe('ProfileImage', () => {
             surname: 'User',
           },
         }}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
-      'ProfileImage without image'
-    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('ProfileImage without image');
   });
 
   test('should have no Axe or DAP violations when image is provided', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <ProfileImage
         profile={{
           image_url: 'example.svg',
@@ -45,16 +38,10 @@ describe('ProfileImage', () => {
             surname: 'User',
           },
         }}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
-      'ProfileImage with image'
-    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('ProfileImage with image');
   });
 
   test("should apply an image via the `profile` object's `image_url`", () => {

--- a/src/components/StackedNotification/__tests__/StackedNotification.spec.js
+++ b/src/components/StackedNotification/__tests__/StackedNotification.spec.js
@@ -6,27 +6,23 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { StackedNotification } from '../../..';
 
 describe('StackedNotification', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <StackedNotification
         title="test title"
         subtitle="test subtitle"
         caption="test caption"
         iconDescription="test close button icon"
         statusIconDescription="test status icon"
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('StackedNotification');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('StackedNotification');
   });
 
   test('should add a custom class', () => {

--- a/src/components/StatusIcon/__tests__/StatusIcon.spec.js
+++ b/src/components/StatusIcon/__tests__/StatusIcon.spec.js
@@ -5,6 +5,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import StatusIcon, { namespace, STATUS, SIZE } from '../StatusIcon';
 
@@ -13,26 +14,22 @@ import { carbonPrefix } from '../../../globals/namespace';
 describe('StatusIcon', () => {
   STATUS.forEach(status =>
     test(`should have no Axe or DAP violations when \`status\` is  '${status}'`, async () => {
-      const main = document.createElement('main');
-      render(<StatusIcon status={status} message="test message" />, {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      });
-      await expect(document.body).toHaveNoAxeViolations();
-      await expect(document.body).toHaveNoDAPViolations(
+      const { container } = render(
+        <StatusIcon status={status} message="test message" />
+      );
+      await expect(container).toHaveNoAxeViolations();
+      await expect(container).toHaveNoDAPViolations(
         `StatusIcon with ${status} status`
       );
     })
   );
 
   test('should have no Axe or DAP violations when `status` is  `undefined`', async () => {
-    const main = document.createElement('main');
-    render(<StatusIcon message="test message" />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    const { container } = renderWithinLandmark(
+      <StatusIcon message="test message" />
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'StatusIcon with `undefined` status'
     );
   });

--- a/src/components/StatusIndicator/StatusStep/__tests__/StatusStep.spec.js
+++ b/src/components/StatusIndicator/StatusStep/__tests__/StatusStep.spec.js
@@ -5,6 +5,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import { StatusStep } from '../../../..';
 
@@ -13,8 +14,7 @@ import { STATUS } from '../StatusStep';
 describe('StatusStep', () => {
   Object.values(STATUS).forEach(status =>
     test(`should have no Axe or DAP violations when \`status\` is  '${status}'`, async () => {
-      const main = document.createElement('main');
-      render(
+      const { container } = renderWithinLandmark(
         <ul>
           <StatusStep
             label="test-label"
@@ -22,14 +22,10 @@ describe('StatusStep', () => {
             errorMsg="test error"
             description="test description"
           />
-        </ul>,
-        {
-          // DAP requires a landmark '<main>' in the DOM:
-          container: document.body.appendChild(main),
-        }
+        </ul>
       );
-      await expect(document.body).toHaveNoAxeViolations();
-      await expect(document.body).toHaveNoDAPViolations(
+      await expect(container).toHaveNoAxeViolations();
+      await expect(container).toHaveNoDAPViolations(
         `StatusStep with ${status} status`
       );
     })

--- a/src/components/StatusIndicator/__tests__/StatusIndicator.spec.js
+++ b/src/components/StatusIndicator/__tests__/StatusIndicator.spec.js
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { StatusIndicator, StatusStep } from '../../..';
 
@@ -13,8 +14,7 @@ import { STATUS } from '../StatusStep/StatusStep';
 
 describe('StatusIndicator', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <StatusIndicator
         title="test title"
         retry={{
@@ -39,14 +39,10 @@ describe('StatusIndicator', () => {
           label="test-label-4"
           description="test description 4"
         />
-      </StatusIndicator>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </StatusIndicator>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(`StatusIndicator`);
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(`StatusIndicator`);
   });
 
   test('should add a custom class', () => {

--- a/src/components/StepIndicator/__tests__/StepIndicator.spec.js
+++ b/src/components/StepIndicator/__tests__/StepIndicator.spec.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { Step, StepIndicator } from '../../..';
 
@@ -12,19 +13,14 @@ import { carbonPrefix } from '../../../globals/namespace';
 
 describe('StepIndicator', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <StepIndicator currentIndex={1}>
         <Step label="test label 1" description="test description 1" />
         <Step label="test label 2" description="test description 2" />
-      </StepIndicator>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </StepIndicator>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('StepIndicator');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('StepIndicator');
   });
 
   test('should add a custom class to the parent component', () => {

--- a/src/components/StringFormatter/__tests__/StringFormatter.spec.js
+++ b/src/components/StringFormatter/__tests__/StringFormatter.spec.js
@@ -5,27 +5,23 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { StringFormatter } from '../../..';
 import { namespace } from '../StringFormatter';
 
 describe('StringFormatter', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <StringFormatter
         value="This is a long test string that would normally be truncated."
         truncate
         lines={2}
         width="50px"
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('StringFormatter');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('StringFormatter');
   });
 
   test('should add a custom class', () => {

--- a/src/components/SummaryCard/SummaryCardContainer/__tests__/SummaryCardContainer.spec.js
+++ b/src/components/SummaryCard/SummaryCardContainer/__tests__/SummaryCardContainer.spec.js
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { Fragment } from 'react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import {
   SummaryCard,
@@ -27,8 +28,7 @@ const summaryCards = [
 
 describe('SummaryCardContainer', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <SummaryCardContainer
         render={({ getBatchActionProps, getSelectionProps, summaryCards }) => (
           <Fragment>
@@ -53,20 +53,15 @@ describe('SummaryCardContainer', () => {
           </Fragment>
         )}
         summaryCards={summaryCards}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('SummaryCardContainer');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('SummaryCardContainer');
   });
 
   test('should have no Axe or DAP violations when cards are selected', async () => {
-    const main = document.createElement('main');
-    const { getByText } = render(
+    const { container, getByText } = render(
       <SummaryCardContainer
         render={({ getBatchActionProps, getSelectionProps, summaryCards }) => (
           <Fragment>
@@ -91,11 +86,7 @@ describe('SummaryCardContainer', () => {
           </Fragment>
         )}
         summaryCards={summaryCards}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
 
     // Currently there's no way to load the page
@@ -104,8 +95,8 @@ describe('SummaryCardContainer', () => {
     userEvent.click(getByText(/test select 0/i));
     userEvent.click(getByText(/test select 1/i));
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'SummaryCardContainer with selected cards'
     );
   });

--- a/src/components/SummaryCard/SummaryCardSkeleton/__tests__/SummaryCardSkeleton.spec.js
+++ b/src/components/SummaryCard/SummaryCardSkeleton/__tests__/SummaryCardSkeleton.spec.js
@@ -3,19 +3,15 @@
  * @copyright IBM Security 2020
  */
 
-import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import { SummaryCardSkeleton } from '../../../..';
 
 describe('SummaryCardSkeleton', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<SummaryCardSkeleton />, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('SummaryCardSkeleton');
+    const { container } = renderWithinLandmark(<SummaryCardSkeleton />);
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('SummaryCardSkeleton');
   });
 });

--- a/src/components/SummaryCard/__tests__/SummaryCard.spec.js
+++ b/src/components/SummaryCard/__tests__/SummaryCard.spec.js
@@ -7,6 +7,7 @@ import Folder20 from '@carbon/icons-react/lib/folder/20';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import {
   SummaryCard,
@@ -22,8 +23,7 @@ import { namespace as headerNamespace } from '../SummaryCardHeader/SummaryCardHe
 
 describe('SummaryCard', () => {
   test('should have no Axe or DAP violations`', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <SummaryCard>
         <SummaryCardHeader
           title="test summary card title"
@@ -50,19 +50,14 @@ describe('SummaryCard', () => {
             tooltipAlignment="center"
           />
         </SummaryCardFooter>
-      </SummaryCard>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </SummaryCard>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('SummaryCard');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('SummaryCard');
   });
 
   test('should have no Axe or DAP violations when the expandable content is shown`', async () => {
-    const main = document.createElement('main');
-    const { getByText } = render(
+    const { container, getByText } = renderWithinLandmark(
       <SummaryCard>
         <SummaryCardHeader title="test summary card title" />
         <SummaryCardBody>test card body content</SummaryCardBody>
@@ -74,18 +69,14 @@ describe('SummaryCard', () => {
             test button
           </SummaryCardAction>
         </SummaryCardFooter>
-      </SummaryCard>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </SummaryCard>
     );
 
     // Click on the action button to show expanded content.
     userEvent.click(getByText(/test button/i).closest('button'));
 
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(
       'SummaryCard with expandable content'
     );
   });

--- a/src/components/Tag/InteractiveTag/__tests__/InteractiveTag.spec.js
+++ b/src/components/Tag/InteractiveTag/__tests__/InteractiveTag.spec.js
@@ -6,19 +6,18 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
 import { InteractiveTag } from '../../../..';
 import { namespace } from '../InteractiveTag';
 
 describe('InteractiveTag', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<InteractiveTag removable>test tag</InteractiveTag>, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('InteractiveTag');
+    const { container } = renderWithinLandmark(
+      <InteractiveTag removable>test tag</InteractiveTag>
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('InteractiveTag');
   });
 
   test('should add close button with `aria-label` when `removable` is `true`', () => {

--- a/src/components/TimeIndicator/__tests__/TimeIndicator.spec.js
+++ b/src/components/TimeIndicator/__tests__/TimeIndicator.spec.js
@@ -5,18 +5,17 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { TimeIndicator } from '../../..';
 
 describe('TimeIndicator', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(<TimeIndicator>test content</TimeIndicator>, {
-      // DAP requires a landmark '<main>' in the DOM:
-      container: document.body.appendChild(main),
-    });
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('TimeIndicator');
+    const { container } = renderWithinLandmark(
+      <TimeIndicator>test content</TimeIndicator>
+    );
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('TimeIndicator');
   });
 
   test('should add custom class', () => {

--- a/src/components/TrendingCard/__tests__/TrendingCard.spec.js
+++ b/src/components/TrendingCard/__tests__/TrendingCard.spec.js
@@ -5,26 +5,22 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { TrendingCard } from '../../../';
 
 describe('TrendingCard', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <TrendingCard
         // Use an empty `href` to avoid misdirected Axe "skip-link" violation:
         href="#"
         title="test title"
         subtitle={<span>test subtitle</span>}
-      />,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      />
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('TrendingCard');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('TrendingCard');
   });
 
   test('should accept a custom element', () => {

--- a/src/components/TruncatedList/__tests__/TruncatedList.spec.js
+++ b/src/components/TruncatedList/__tests__/TruncatedList.spec.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import TruncatedList from '..';
 import OrderedList from '../../OrderedList';
@@ -16,19 +17,14 @@ const getExpandButtonLabel = (expanded, shown, hidden) =>
 
 describe(TruncatedList.name, () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <>
         <TruncatedList>{createChildrenArray(6)}</TruncatedList>
         <TruncatedList>{createChildrenArray(11)}</TruncatedList>
-      </>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations(TruncatedList.name);
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations(TruncatedList.name);
   });
 
   test('adds custom class name', () => {

--- a/src/components/TypeLayout/__tests__/TypeLayout.spec.js
+++ b/src/components/TypeLayout/__tests__/TypeLayout.spec.js
@@ -5,6 +5,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import {
   TypeLayout,
@@ -19,8 +20,7 @@ const sizes = ['xs', 'sm', 'md', 'lg'];
 
 describe('TypeLayout', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <TypeLayout>
         <TypeLayoutBody>
           <TypeLayoutRow>
@@ -32,14 +32,10 @@ describe('TypeLayout', () => {
             <TypeLayoutCell>test cell content 2</TypeLayoutCell>
           </TypeLayoutRow>
         </TypeLayoutBody>
-      </TypeLayout>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </TypeLayout>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('TypeLayout');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('TypeLayout');
   });
 
   test('should add a custom class to each component', () => {

--- a/src/components/UNSTABLE__Pagination/__tests__/Pagination.spec.js
+++ b/src/components/UNSTABLE__Pagination/__tests__/Pagination.spec.js
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import renderWithinLandmark from '../../../../config/jest/helpers/renderWithinLandmark';
 
 import { UNSTABLE__Pagination, PageSelector } from '../../..';
 
@@ -13,8 +14,7 @@ import { namespace } from '../Pagination';
 
 describe('UNSTABLE__Pagination', () => {
   test('should have no Axe or DAP violations', async () => {
-    const main = document.createElement('main');
-    render(
+    const { container } = renderWithinLandmark(
       <UNSTABLE__Pagination totalItems={40} pageSizes={[10, 20]}>
         {({ currentPage, onSetPage, totalPages }) => (
           <PageSelector
@@ -23,14 +23,10 @@ describe('UNSTABLE__Pagination', () => {
             totalPages={totalPages}
           />
         )}
-      </UNSTABLE__Pagination>,
-      {
-        // DAP requires a landmark '<main>' in the DOM:
-        container: document.body.appendChild(main),
-      }
+      </UNSTABLE__Pagination>
     );
-    await expect(document.body).toHaveNoAxeViolations();
-    await expect(document.body).toHaveNoDAPViolations('UNSTABLE_Pagination');
+    await expect(container).toHaveNoAxeViolations();
+    await expect(container).toHaveNoDAPViolations('UNSTABLE_Pagination');
   });
 
   test('should cycle pagination elements in tab order', () => {


### PR DESCRIPTION
## Affected issues

- Resolves #427 

This PR includes a helper for rendering a component in a landmark element. 

However, in the interest of keeping tests readable & avoiding abstracted test cases, the two a11y assertions are kept as-is.

## Proposed changes

- add `renderWithinLandmark` helper to wrap jsx in a `main` landmark element
- update component a11y tests to use `renderWithinLandmark`
- update testing documentation