### PR TITLE
fix(data-table-pagination): remove unused prop itemsPerPageFollowsText

### DIFF
--- a/src/components/DataTable/DataTablePagination/DataTablePagination.js
+++ b/src/components/DataTable/DataTablePagination/DataTablePagination.js
@@ -56,11 +56,6 @@ class DataTablePagination extends Component {
     itemsPerPageText: PropTypes.string,
 
     /**
-     * @type {string} A variant of `itemsPerPageText`, with a sign indicating that the number follows, e.g. ':'.
-     */
-    itemsPerPageFollowsText: PropTypes.string,
-
-    /**
      * @type {Function} A variant of `itemRangeText`, used if the total number of items is unknown.
      */
     itemText: PropTypes.func,
@@ -195,7 +190,6 @@ class DataTablePagination extends Component {
       forwardText,
       id,
       isLastPage,
-      itemsPerPageFollowsText,
       itemsPerPageText,
       itemRangeText,
       itemText,
@@ -224,7 +218,6 @@ class DataTablePagination extends Component {
           forwardText={forwardText}
           id={id}
           isLastPage={isLastPage}
-          itemsPerPageFollowsText={itemsPerPageFollowsText}
           itemsPerPageText={itemsPerPageText}
           itemRangeText={itemRangeText}
           itemText={itemText}

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -2008,9 +2008,6 @@ Map {
       "itemText": Object {
         "type": "func",
       },
-      "itemsPerPageFollowsText": Object {
-        "type": "string",
-      },
       "itemsPerPageText": Object {
         "type": "string",
       },


### PR DESCRIPTION
## Affected issues

- Part of #457 

## Proposed changes

- remove unused prop `itemsPerPageFollowsText` which doesn't do anything & also that causes console errors in test output, e.g.:

```
console.error node_modules/react-dom/cjs/react-dom-server.node.development.js:76
 
      Warning: React does not recognize the `itemsPerPageFollowsText` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `itemsperpagefollowstext` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in div
          in Pagination
          in div
 ```