### PR TITLE
Expose (Data)Decorator onContextMenu prop

### DIFF
--- a/src/components/DataDecorator/DataDecorator.js
+++ b/src/components/DataDecorator/DataDecorator.js
@@ -55,7 +55,21 @@ class DataDecorator extends Component {
       title,
       scoreThresholds,
       scoreDescription,
+      onClick: propOnClick,
+      onContextMenu: propOnContextMenu,
     } = this.props;
+    const onClick = !propOnClick
+      ? event => {
+          event.stopPropagation();
+          this.toggleOpen();
+        }
+      : propOnClick;
+    const onContextMenu = propOnContextMenu
+      ? event => {
+          event.preventDefault();
+          propOnContextMenu(event);
+        }
+      : undefined;
     const decoratorProps = {
       className,
       inline,
@@ -66,6 +80,8 @@ class DataDecorator extends Component {
       title,
       scoreThresholds,
       scoreDescription,
+      onClick,
+      onContextMenu,
     };
     const componentLabels = {
       ...defaultLabels.labels,
@@ -80,14 +96,7 @@ class DataDecorator extends Component {
     };
     return (
       <Fragment>
-        <Decorator
-          {...decoratorProps}
-          active={this.state.isOpen}
-          onClick={event => {
-            event.stopPropagation();
-            this.toggleOpen();
-          }}
-        />
+        <Decorator {...decoratorProps} active={this.state.isOpen} />
         <PanelV2
           isOpen={this.state.isOpen}
           stopPropagation={stopPropagation}
@@ -182,6 +191,10 @@ DataDecorator.propTypes = {
   /** @type {boolean} Whether the rendered Decorator includes an icon */
   noIcon: PropTypes.bool,
 
+  onClick: PropTypes.func,
+
+  onContextMenu: PropTypes.func,
+
   /** @type {Function} The function to call when the DataDecorator Panel closes. */
   onClose: PropTypes.func,
 
@@ -249,6 +262,8 @@ DataDecorator.defaultProps = {
   inline: defaultProps.inline,
   labels: {},
   noIcon: false,
+  onClick: undefined,
+  onContextMenu: undefined,
   onClose: () => {},
   onOpen: () => {},
   primaryButton: undefined,

--- a/src/components/DataDecorator/DataDecorator.js
+++ b/src/components/DataDecorator/DataDecorator.js
@@ -191,8 +191,10 @@ DataDecorator.propTypes = {
   /** @type {boolean} Whether the rendered Decorator includes an icon */
   noIcon: PropTypes.bool,
 
+  /** @type {Function} The function to call when the DataDecorator is clicked. */
   onClick: PropTypes.func,
 
+  /** @type {Function} The function to call when the DataDecorator is secondary-clicked */
   onContextMenu: PropTypes.func,
 
   /** @type {Function} The function to call when the DataDecorator Panel closes. */

--- a/src/components/DataDecorator/DataDecorator.js
+++ b/src/components/DataDecorator/DataDecorator.js
@@ -55,15 +55,8 @@ class DataDecorator extends Component {
       title,
       scoreThresholds,
       scoreDescription,
-      onClick: propOnClick,
       onContextMenu: propOnContextMenu,
     } = this.props;
-    const onClick = !propOnClick
-      ? event => {
-          event.stopPropagation();
-          this.toggleOpen();
-        }
-      : propOnClick;
     const onContextMenu = propOnContextMenu
       ? event => {
           event.preventDefault();
@@ -80,7 +73,6 @@ class DataDecorator extends Component {
       title,
       scoreThresholds,
       scoreDescription,
-      onClick,
       onContextMenu,
     };
     const componentLabels = {
@@ -96,7 +88,14 @@ class DataDecorator extends Component {
     };
     return (
       <Fragment>
-        <Decorator {...decoratorProps} active={this.state.isOpen} />
+        <Decorator
+          {...decoratorProps}
+          active={this.state.isOpen}
+          onClick={event => {
+            event.stopPropagation();
+            this.toggleOpen();
+          }}
+        />
         <PanelV2
           isOpen={this.state.isOpen}
           stopPropagation={stopPropagation}
@@ -191,9 +190,6 @@ DataDecorator.propTypes = {
   /** @type {boolean} Whether the rendered Decorator includes an icon */
   noIcon: PropTypes.bool,
 
-  /** @type {Function} The function to call when the DataDecorator is clicked. */
-  onClick: PropTypes.func,
-
   /** @type {Function} The function to call when the DataDecorator is secondary-clicked */
   onContextMenu: PropTypes.func,
 
@@ -264,7 +260,6 @@ DataDecorator.defaultProps = {
   inline: defaultProps.inline,
   labels: {},
   noIcon: false,
-  onClick: undefined,
   onContextMenu: undefined,
   onClose: () => {},
   onOpen: () => {},

--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -130,6 +130,7 @@ Decorator.propTypes = {
   /** @type {Function} Click handler of the Decorator. */
   onClick: PropTypes.func,
 
+  /** @type {Function} Secondary click handler of the Decorator. */
   onContextMenu: PropTypes.func,
 
   /** @type {boolean} Whether the Decorator includes an icon */

--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -65,7 +65,6 @@ class Decorator extends Component {
       inline,
       noIcon,
       onClick,
-      onContextMenu,
       score,
       scoreThresholds,
     } = this.props;
@@ -91,7 +90,7 @@ class Decorator extends Component {
       );
     }
 
-    if (onClick || onContextMenu) {
+    if (onClick) {
       return (
         <button
           className={decoratorClasses}
@@ -172,7 +171,7 @@ Decorator.defaultProps = {
   href: undefined,
   inline: false,
   onClick: undefined,
-  onContextMenu: undefined,
+  onContextMenu: () => {},
   noIcon: false,
   score: undefined,
   scoreThresholds: [0, 4, 7, 10],

--- a/src/components/DataDecorator/Decorator/Decorator.js
+++ b/src/components/DataDecorator/Decorator/Decorator.js
@@ -33,6 +33,10 @@ class Decorator extends Component {
     this.props.onClick(event, this.props.type, this.props.value);
   };
 
+  handleContextMenuClick = event => {
+    this.props.onContextMenu(event, this.props.type, this.props.value);
+  };
+
   renderDecorator = (noIcon, path, inline, score, scoreThresholds) => (
     <Fragment>
       {!noIcon && (
@@ -61,6 +65,7 @@ class Decorator extends Component {
       inline,
       noIcon,
       onClick,
+      onContextMenu,
       score,
       scoreThresholds,
     } = this.props;
@@ -86,9 +91,13 @@ class Decorator extends Component {
       );
     }
 
-    if (onClick) {
+    if (onClick || onContextMenu) {
       return (
-        <button className={decoratorClasses} onClick={this.handleClick}>
+        <button
+          className={decoratorClasses}
+          onClick={this.handleClick}
+          onContextMenu={this.handleContextMenuClick}
+        >
           {decorator}
         </button>
       );
@@ -120,6 +129,8 @@ Decorator.propTypes = {
 
   /** @type {Function} Click handler of the Decorator. */
   onClick: PropTypes.func,
+
+  onContextMenu: PropTypes.func,
 
   /** @type {boolean} Whether the Decorator includes an icon */
   noIcon: PropTypes.bool,
@@ -160,6 +171,7 @@ Decorator.defaultProps = {
   href: undefined,
   inline: false,
   onClick: undefined,
+  onContextMenu: undefined,
   noIcon: false,
   score: undefined,
   scoreThresholds: [0, 4, 7, 10],

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -1121,7 +1121,9 @@ Map {
       "inline": false,
       "labels": Object {},
       "noIcon": false,
+      "onClick": undefined,
       "onClose": [Function],
+      "onContextMenu": undefined,
       "onOpen": [Function],
       "primaryButton": undefined,
       "renderFooter": null,
@@ -1198,7 +1200,13 @@ Map {
       "noIcon": Object {
         "type": "bool",
       },
+      "onClick": Object {
+        "type": "func",
+      },
       "onClose": Object {
+        "type": "func",
+      },
+      "onContextMenu": Object {
         "type": "func",
       },
       "onOpen": Object {
@@ -2463,6 +2471,7 @@ Map {
       "inline": false,
       "noIcon": false,
       "onClick": undefined,
+      "onContextMenu": undefined,
       "score": undefined,
       "scoreDescription": [Function],
       "scoreThresholds": Array [
@@ -2491,6 +2500,9 @@ Map {
         "type": "bool",
       },
       "onClick": Object {
+        "type": "func",
+      },
+      "onContextMenu": Object {
         "type": "func",
       },
       "score": Object {

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -1121,7 +1121,6 @@ Map {
       "inline": false,
       "labels": Object {},
       "noIcon": false,
-      "onClick": undefined,
       "onClose": [Function],
       "onContextMenu": undefined,
       "onOpen": [Function],
@@ -1199,9 +1198,6 @@ Map {
       },
       "noIcon": Object {
         "type": "bool",
-      },
-      "onClick": Object {
-        "type": "func",
       },
       "onClose": Object {
         "type": "func",
@@ -2471,7 +2467,7 @@ Map {
       "inline": false,
       "noIcon": false,
       "onClick": undefined,
-      "onContextMenu": undefined,
+      "onContextMenu": [Function],
       "score": undefined,
       "scoreDescription": [Function],
       "scoreThresholds": Array [


### PR DESCRIPTION
@jendowns the most important aspect of this is the ability to include the `onContextMenu` prop for the `DataDecorator` and `Decorator` components. The overriding of the `DataDecorator`'s `onClick` can be removed if its not desirable.