### PR TITLE
fix(data-decorator): allow inner panel to be closed with esc key or outside click

### DIFF
--- a/src/components/DataDecorator/DataDecorator.js
+++ b/src/components/DataDecorator/DataDecorator.js
@@ -26,13 +26,13 @@ class DataDecorator extends Component {
   toggleOpen = () => (this.state.isOpen ? this.close() : this.open());
 
   open = () => {
-    this.props.onOpen();
     this.setState({ isOpen: true });
+    this.props.onOpen();
   };
 
   close = () => {
-    this.props.onClose();
     this.setState({ isOpen: false });
+    this.props.onClose();
   };
 
   render() {
@@ -90,6 +90,7 @@ class DataDecorator extends Component {
         />
         <PanelV2
           isOpen={this.state.isOpen}
+          onClose={this.close}
           stopPropagation={stopPropagation}
           stopPropagationEvents={stopPropagationEvents}
           closeButton={{


### PR DESCRIPTION
## Proposed changes

- use `onClose` prop for inner `PanelV2` so that a panel opened with the `DataDecorator` can also be closed with the escape key or clicking outside the panel.

NOTE: not providing an `onClose` prop for this because the `DataDecorator` already has an existing `onClose` prop that does something slightly different. 
