### PR TITLE
feat(tag-wall-filter): allow additions of new tags

### DIFF
--- a/src/components/TagWallFilter/Filter/Filter.js
+++ b/src/components/TagWallFilter/Filter/Filter.js
@@ -109,6 +109,19 @@ class Filter extends React.Component {
 
     const { inputValue } = this.state;
 
+    const renderInnerMenuItem = ({ itemProps, itemText }) => (
+      <div
+        className={`${namespace}__list-item__entry`}
+        aria-labelledby={itemProps.id}
+      >
+        <span className={`${carbonPrefix}text-truncate--end`} title={itemText}>
+          {itemText}
+        </span>
+        <span className={`${namespace}__add`}>
+          <Icon className={`${namespace}__add__icon`} renderIcon={Add20} />
+        </span>
+      </div>
+    );
     const menuItems = sortItems(
       filterItems(items, { itemToString, inputValue }),
       {
@@ -117,7 +130,28 @@ class Filter extends React.Component {
         compareItems,
         locale,
       }
-    ).map(item => {
+    );
+    if (menuItems.length === 0 && this.props.allowAddition) {
+      const newItem = {
+        id: inputValue,
+        label: inputValue,
+      };
+      const itemProps = getItemProps({ item: newItem });
+      const itemText = `${this.props.newItemPrefix}${itemToString(newItem)}`;
+      return (
+        <MenuItem
+          className={`${namespace}__list-item`}
+          isActive
+          onKeyDown={e => this.handleKeyDownChange(e, newItem)}
+          role="button"
+          tabIndex="0"
+          {...itemProps}
+        >
+          {renderInnerMenuItem({ itemProps, itemText })}
+        </MenuItem>
+      );
+    }
+    return menuItems.map(item => {
       const itemProps = getItemProps({ item });
       const itemText = itemToString(item);
 
@@ -131,25 +165,10 @@ class Filter extends React.Component {
           tabIndex="0"
           {...itemProps}
         >
-          <div
-            className={`${namespace}__list-item__entry`}
-            aria-labelledby={itemProps.id}
-          >
-            <span
-              className={`${carbonPrefix}text-truncate--end`}
-              title={itemText}
-            >
-              {itemText}
-            </span>
-            <span className={`${namespace}__add`}>
-              <Icon className={`${namespace}__add__icon`} renderIcon={Add20} />
-            </span>
-          </div>
+          {renderInnerMenuItem({ itemProps, itemText })}
         </MenuItem>
       );
     });
-
-    return menuItems;
   };
 
   render() {
@@ -235,6 +254,8 @@ Filter.defaultProps = {
   filterItems: defaultFilterItems,
   initialSelectedItems: [],
   selectedItems: [],
+  newItemPrefix: 'Add: ',
+  allowAddition: false,
   itemToString: defaultItemToString,
   locale: 'en',
   sortItems: defaultSortItems,
@@ -265,6 +286,11 @@ Filter.propTypes = {
     })
   ),
 
+  /**
+   * @type {string} The prefix string to add when no item has been found, e.g "Add: yourtag", the default prefix is "Add: "
+   */
+  newItemPrefix: PropTypes.string,
+  allowAddition: PropTypes.bool,
   /** @type {func} Render a given item to a string label */
   itemToString: PropTypes.func,
 

--- a/src/components/TagWallFilter/TagWallFilter.js
+++ b/src/components/TagWallFilter/TagWallFilter.js
@@ -108,6 +108,8 @@ export const FilterTagFragmentRender = ({
   itemToString,
   onChange,
   tagWallLabel,
+  allowAddition,
+  newItemPrefix,
   tearsheetProps,
   ...otherProps
 }) => (
@@ -131,6 +133,8 @@ export const FilterTagFragmentRender = ({
       id={id}
       items={availableItems}
       itemToString={itemToString}
+      newItemPrefix={newItemPrefix}
+      allowAddition={allowAddition}
       onChange={change => dispatchItemChange(change, onChange)}
       {...otherProps}
     />
@@ -192,6 +196,8 @@ export const TagWallFilter = ({
   allItems,
   filterFieldClearSelectionTooltip,
   filterFieldClearAllTooltip,
+  newItemPrefix,
+  allowAddition,
 }) => {
   const tearsheetProps = {
     className: namespace,
@@ -219,6 +225,8 @@ export const TagWallFilter = ({
       tearsheetProps={tearsheetProps}
       filterFieldClearSelectionTooltip={filterFieldClearSelectionTooltip}
       filterFieldClearAllTooltip={filterFieldClearAllTooltip}
+      newItemPrefix={newItemPrefix}
+      allowAddition={allowAddition}
     />
   );
 };
@@ -276,6 +284,13 @@ TagWallFilter.propTypes = {
     })
   ),
 
+  /**
+   * @type {string} The prefix string to add when no item has been found, e.g "Add: yourtag", the default prefix is "Add: "
+   */
+  newItemPrefix: PropTypes.string,
+
+  allowAddition: PropTypes.bool,
+
   /** @type {func} Called whenever a something changed. Is called with the latest state */
   onChange: PropTypes.func,
 
@@ -293,6 +308,8 @@ TagWallFilter.defaultProps = {
   selectedItems: [],
   allItems: undefined,
   onChange: noop,
+  newItemPrefix: 'Add: ',
+  allowAddition: false,
   inputFieldPlaceholder: '',
   tagWallLabel: null,
   filterFieldClearSelectionTooltip: 'Clear selected item',

--- a/src/components/TagWallFilter/TagWallFilter.stories.js
+++ b/src/components/TagWallFilter/TagWallFilter.stories.js
@@ -5,10 +5,8 @@
 /* eslint-disable no-param-reassign */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, object } from '@storybook/addon-knobs';
+import { boolean, object, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-
-import { compose } from 'recompose';
 
 import { patterns } from '../../../.storybook';
 
@@ -33,58 +31,12 @@ const buttons = {
   },
 };
 
-const itemsReducer = (items, item) => {
-  items[item.id] = item;
-  return [items, item];
-};
-const filterItems = selectedItemsMap => ([items, item]) => {
-  if (item.id in selectedItemsMap) {
-    delete items[item.id];
-  }
-  return [items, item];
-};
-const selectFirst = ([items]) => items;
-
-storiesOf(patterns('TagWallFilter'), module).add(
-  `TagWall with Filter list for multiselect`,
-  () => {
-    const selectedItems = object('selectedItems', [
-      {
-        id: 'item-0',
-        label:
-          'Tag that is a very long string and will need to be truncated with an ellipsis',
-      },
-    ]);
-    const selectedItemsMap = selectedItems.reduce(
-      compose(
-        selectFirst,
-        itemsReducer
-      ),
-      {}
-    );
-    const availableItems = Object.values(
-      object(
-        'availableItems',
-        Object.values(
-          items.reduce(
-            compose(
-              selectFirst,
-              filterItems(selectedItemsMap),
-              itemsReducer
-            ),
-            {}
-          )
-        )
-      ).reduce(
-        compose(
-          selectFirst,
-          filterItems(selectedItemsMap),
-          itemsReducer
-        ),
-        {}
-      )
-    );
+storiesOf(patterns('TagWallFilter'), module)
+  .add(`TagWall with Filter list for multiselect`, () => {
+    const selectedItems = object('selectedItems', [items[0]]);
+    const availableItems = object('availableItems', items.slice(1));
     const visible = boolean('visible (toggle to apply changes to items)', true);
+
     return (
       visible && (
         <TagWallFilter
@@ -100,5 +52,28 @@ storiesOf(patterns('TagWallFilter'), module).add(
         />
       )
     );
-  }
-);
+  })
+  .add('with addition', () => {
+    const selectedItems = object('selectedItems', [items[0]]);
+    const availableItems = object('availableItems', items.slice(1));
+    const newItemPrefix = text('newItemPrefix', 'Add: ');
+    const visible = boolean('visible (toggle to apply changes to items)', true);
+
+    return (
+      visible && (
+        <TagWallFilter
+          focusTrap={boolean('focusTrap', false)}
+          heading="Cities"
+          description="Filter and select city names."
+          selectedItems={selectedItems}
+          availableItems={availableItems}
+          onChange={action('onChange')}
+          inputFieldPlaceholder="Search cities"
+          tagWallLabel="Cities"
+          newItemPrefix={newItemPrefix}
+          allowAddition
+          {...buttons}
+        />
+      )
+    );
+  });

--- a/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
+++ b/src/components/TagWallFilter/__tests__/__snapshots__/TagWallFilter.spec.js.snap
@@ -1400,6 +1400,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                     className="security--tearsheet--small__scroll-gradient__content"
                                   >
                                     <Filter
+                                      allowAddition={false}
                                       className=""
                                       compareItems={[Function]}
                                       disabled={false}
@@ -1418,6 +1419,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 1`] = 
                                         ]
                                       }
                                       locale="en"
+                                      newItemPrefix="Add: "
                                       onChange={[Function]}
                                       placeholder="placeholder"
                                       selectedItems={Array []}
@@ -2006,6 +2008,7 @@ exports[`TagWallFilter tests FilterTagFragment should render the fragment 2`] = 
 
 exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter component 1`] = `
 <TagWallFilter
+  allowAddition={false}
   availableItems={
     Array [
       Object {
@@ -2026,6 +2029,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
   heading="TagWallFilter Heading"
   id="test-id"
   inputFieldPlaceholder=""
+  newItemPrefix="Add: "
   onChange={[Function]}
   primaryButton={
     Object {
@@ -2048,6 +2052,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
   tagWallLabel={null}
 >
   <FilterTagFragment
+    allowAddition={false}
     availableItems={
       Array [
         Object {
@@ -2060,6 +2065,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
     filterFieldClearSelectionTooltip="Clear selected item"
     id="test-id"
     itemToString={[Function]}
+    newItemPrefix="Add: "
     onChange={[Function]}
     placeholder=""
     selectedItems={
@@ -2093,6 +2099,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
     }
   >
     <mapProps(FilterTagFragmentRender)
+      allowAddition={false}
       availableItems={
         Array [
           Object {
@@ -2136,6 +2143,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
         }
       }
       itemToString={[Function]}
+      newItemPrefix="Add: "
       onChange={[Function]}
       placeholder=""
       selectedItems={
@@ -2169,6 +2177,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
       }
     >
       <FilterTagFragmentRender
+        allowAddition={false}
         availableItems={
           Array [
             Object {
@@ -2182,6 +2191,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
         filterFieldClearSelectionTooltip="Clear selected item"
         id="test-id"
         itemToString={[Function]}
+        newItemPrefix="Add: "
         onChange={[Function]}
         placeholder=""
         selectedItems={
@@ -3849,6 +3859,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                       className=""
                                     >
                                       <Filter
+                                        allowAddition={false}
                                         className=""
                                         compareItems={[Function]}
                                         disabled={false}
@@ -3867,6 +3878,7 @@ exports[`TagWallFilter tests TagWallFilter should mount the TagWallFilter compon
                                           ]
                                         }
                                         locale="en"
+                                        newItemPrefix="Add: "
                                         onChange={[Function]}
                                         placeholder=""
                                         selectedItems={Array []}

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -9961,12 +9961,14 @@ Map {
   "TagWallFilter" => Object {
     "defaultProps": Object {
       "allItems": undefined,
+      "allowAddition": false,
       "description": "",
       "filterFieldClearAllTooltip": "Clear all selected items",
       "filterFieldClearSelectionTooltip": "Clear selected item",
       "focusTrap": true,
       "id": "security--tag-wall-filter",
       "inputFieldPlaceholder": "",
+      "newItemPrefix": "Add: ",
       "onChange": [Function],
       "selectedItems": Array [],
       "tagWallLabel": null,
@@ -9992,6 +9994,9 @@ Map {
           },
         ],
         "type": "arrayOf",
+      },
+      "allowAddition": Object {
+        "type": "bool",
       },
       "availableItems": Object {
         "args": Array [
@@ -10068,6 +10073,9 @@ Map {
         "type": "string",
       },
       "inputFieldPlaceholder": Object {
+        "type": "string",
+      },
+      "newItemPrefix": Object {
         "type": "string",
       },
       "onChange": Object {


### PR DESCRIPTION

![ezgif com-video-to-gif (12)](https://user-images.githubusercontent.com/22816887/86515589-ef7eaf80-be11-11ea-99a5-27e27b3c265a.gif)


- This PR allows users to add their own tags not specified in the initial props

## Affected issues

- Resolves https://github.com/carbon-design-system/ibm-security/issues/651

## Proposed changes

- New prop `allowAdditions` added to `TagWallFilter` and passed through to `Filter` .
    - When this prop is `true` and the user has entered a string that is not found in the available items, a new option will be available to allow the user to add this tag to the list of tags.

- New prop `newItemPrefix` - configurable prefix for when a new item is added

## Testing instructions

- Check out the new story for `TagWallFilter` - with additions

1. Type in a random string
2. Click the "Add: <string>"
3. Note the actions
