### PR TITLE
fix(data-table): proxy `defaultProps` and `propTypes`

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -15,6 +15,11 @@ import TableOverflowCell from './TableOverflowCell';
 import TableToolbarDownload from './TableToolbarDownload';
 
 const {
+  defaultProps: carbonDefaultProps,
+  propTypes: carbonPropTypes,
+} = CarbonDataTable;
+
+const {
   TableActionList,
   TableBatchAction,
   TableBatchActions,
@@ -122,70 +127,20 @@ const DataTable = ({
 );
 
 DataTable.defaultProps = {
-  isSortable: true,
+  ...carbonDefaultProps,
   isSelectable: true,
+  isSortable: true,
   missingDataCharacter: '–',
-  render: undefined,
-  sortRow: undefined,
-  filterRows: undefined,
-  useZebraStyles: false,
 };
 
 DataTable.propTypes = {
-  /**
-   * @type {Object.<Object, *>}
-   * The `rows` prop is where you provide us with a list of all the rows that
-   * you want to render in the table. The only hard requirement is that this
-   * is an array of objects, and that each object has a unique `id` field
-   * available on it.
-   */
-  rows: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-    })
-  ).isRequired,
-
-  /**
-   * @type {Object.<Object, *>}
-   * The `headers` prop represents the order in which the headers should
-   * appear in the table. We expect an array of objects to be passed in, where
-   * `key` is the name of the key in a row object, and `header` is the name of
-   * the header.
-   */
-  headers: PropTypes.arrayOf(
-    PropTypes.shape({
-      key: PropTypes.string.isRequired,
-      header: PropTypes.string.isRequired,
-    })
-  ).isRequired,
-
-  /** @type {function(rows: Array, headers: Array, ...props)}
-   * render function for the contents of the table.
-   */
-  render: PropTypes.func,
-
-  /** @type {bool} Defines whether the table is sortable. */
-  isSortable: PropTypes.bool,
-
-  /**
-   * @type {func} Optional hook to manually control sorting of the rows.
-   */
-  sortRow: PropTypes.func,
-
-  /**
-   * @type {func} Optional hook to manually control filtering of the rows from the
-   * TableToolbarSearch component
-   */
-  filterRows: PropTypes.func,
+  ...carbonPropTypes,
 
   /** @type {bool} Defines whether the table is selectable. */
   isSelectable: PropTypes.bool,
 
   /** @type {string} Defines missing data in a cell replaced with a character. */
   missingDataCharacter: PropTypes.string,
-
-  /** @type {bool} Defines whether the table uses zebra styles. */
-  useZebraStyles: PropTypes.bool,
 };
 
 export const { defaultProps, propTypes } = DataTable;

--- a/src/components/DataTable/DataTable.stories.js
+++ b/src/components/DataTable/DataTable.stories.js
@@ -8,10 +8,14 @@ import { storiesOf } from '@storybook/react';
 
 import { components } from '../../../.storybook';
 
-const sizes = [null, 'compact', 'short', 'tall'];
+import { DataTable } from '../..';
+
+const {
+  defaultProps: { size },
+} = DataTable;
 
 const props = () => ({
-  size: select('Row height (size)', sizes, sizes[0]),
+  size: select('Row height (size)', [size, 'compact', 'short', 'tall'], size),
   stickyHeader: boolean('Sticky header (stickyHeader)', false),
   useZebraStyles: boolean('Zebra row styles (useZebraStyles)', false),
 });

--- a/src/components/DataTable/DataTable.stories.js
+++ b/src/components/DataTable/DataTable.stories.js
@@ -3,14 +3,17 @@
  * @copyright IBM Security 2019 - 2020
  */
 
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import { components } from '../../../.storybook';
 
+const sizes = [null, 'compact', 'short', 'tall'];
+
 const props = () => ({
-  useZebraStyles: boolean('Zebra row styles (useZebraStyles)', false),
+  size: select('Row height (size)', sizes, sizes[0]),
   stickyHeader: boolean('Sticky header (stickyHeader)', false),
+  useZebraStyles: boolean('Zebra row styles (useZebraStyles)', false),
 });
 
 const readmeURL = 'https://bit.ly/2Z9PGsC';

--- a/src/components/DataTable/DataTablePagination/__tests__/__snapshots__/DataTablePagination.spec.js.snap
+++ b/src/components/DataTable/DataTablePagination/__tests__/__snapshots__/DataTablePagination.spec.js.snap
@@ -5,6 +5,7 @@ exports[`DataTablePagination Rendering renders correctly 1`] = `
   className="security--data-table-pagination"
 >
   <DataTable
+    filterRows={[Function]}
     headers={
       Array [
         Object {
@@ -35,7 +36,9 @@ exports[`DataTablePagination Rendering renders correctly 1`] = `
     }
     isSelectable={false}
     isSortable={false}
+    locale="en"
     missingDataCharacter="–"
+    overflowMenuOnHover={true}
     rows={
       Array [
         Object {
@@ -80,7 +83,9 @@ exports[`DataTablePagination Rendering renders correctly 1`] = `
         },
       ]
     }
-    useZebraStyles={false}
+    size="normal"
+    sortRow={[Function]}
+    translateWithId={[Function]}
   />
   <Pagination
     backwardText="Backward"

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable.spec.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable.spec.js.snap
@@ -10,6 +10,7 @@ Object {
 
 exports[`DataTable Rendering renders 1`] = `
 <DataTable
+  filterRows={[Function]}
   headers={
     Array [
       Object {
@@ -40,7 +41,9 @@ exports[`DataTable Rendering renders 1`] = `
   }
   isSelectable={false}
   isSortable={false}
+  locale="en"
   missingDataCharacter="–"
+  overflowMenuOnHover={true}
   render={[Function]}
   rows={
     Array [
@@ -134,7 +137,9 @@ exports[`DataTable Rendering renders 1`] = `
       },
     ]
   }
-  useZebraStyles={false}
+  size="normal"
+  sortRow={[Function]}
+  translateWithId={[Function]}
 >
   <div
     className="security--data-table"
@@ -268,7 +273,6 @@ exports[`DataTable Rendering renders 1`] = `
       size="normal"
       sortRow={[Function]}
       translateWithId={[Function]}
-      useZebraStyles={false}
     >
       <TableContainer>
         <div
@@ -278,7 +282,6 @@ exports[`DataTable Rendering renders 1`] = `
             isSortable={false}
             overflowMenuOnHover={true}
             size="normal"
-            useZebraStyles={false}
           >
             <ScrollGradient
               className="security--data-table__table-wrapper"
@@ -310,7 +313,6 @@ exports[`DataTable Rendering renders 1`] = `
                     isSortable={false}
                     overflowMenuOnHover={true}
                     size="normal"
-                    useZebraStyles={false}
                   >
                     <table
                       className="bx--data-table bx--data-table--no-border"
@@ -1662,6 +1664,7 @@ exports[`DataTable Rendering renders 1`] = `
 
 exports[`DataTable Rendering renders a custom table 1`] = `
 <DataTable
+  filterRows={[Function]}
   headers={
     Array [
       Object {
@@ -1692,7 +1695,9 @@ exports[`DataTable Rendering renders a custom table 1`] = `
   }
   isSelectable={false}
   isSortable={false}
+  locale="en"
   missingDataCharacter="–"
+  overflowMenuOnHover={true}
   render={[Function]}
   rows={
     Array [
@@ -1786,7 +1791,9 @@ exports[`DataTable Rendering renders a custom table 1`] = `
       },
     ]
   }
-  useZebraStyles={false}
+  size="normal"
+  sortRow={[Function]}
+  translateWithId={[Function]}
 >
   <div
     className="security--data-table"
@@ -1920,7 +1927,6 @@ exports[`DataTable Rendering renders a custom table 1`] = `
       size="normal"
       sortRow={[Function]}
       translateWithId={[Function]}
-      useZebraStyles={false}
     >
       <TableContainer>
         <div
@@ -1930,7 +1936,6 @@ exports[`DataTable Rendering renders a custom table 1`] = `
             isSortable={false}
             overflowMenuOnHover={true}
             size="normal"
-            useZebraStyles={false}
           >
             <ScrollGradient
               className="security--data-table__table-wrapper"
@@ -1962,7 +1967,6 @@ exports[`DataTable Rendering renders a custom table 1`] = `
                     isSortable={false}
                     overflowMenuOnHover={true}
                     size="normal"
-                    useZebraStyles={false}
                   >
                     <table
                       className="bx--data-table bx--data-table--no-border"
@@ -3314,6 +3318,7 @@ exports[`DataTable Rendering renders a custom table 1`] = `
 
 exports[`DataTable Rendering renders a selectable table 1`] = `
 <DataTable
+  filterRows={[Function]}
   headers={
     Array [
       Object {
@@ -3344,7 +3349,9 @@ exports[`DataTable Rendering renders a selectable table 1`] = `
   }
   isSelectable={true}
   isSortable={false}
+  locale="en"
   missingDataCharacter="–"
+  overflowMenuOnHover={true}
   render={[Function]}
   rows={
     Array [
@@ -3438,7 +3445,9 @@ exports[`DataTable Rendering renders a selectable table 1`] = `
       },
     ]
   }
-  useZebraStyles={false}
+  size="normal"
+  sortRow={[Function]}
+  translateWithId={[Function]}
 >
   <div
     className="security--data-table"
@@ -3572,7 +3581,6 @@ exports[`DataTable Rendering renders a selectable table 1`] = `
       size="normal"
       sortRow={[Function]}
       translateWithId={[Function]}
-      useZebraStyles={false}
     >
       <TableContainer>
         <div
@@ -3582,7 +3590,6 @@ exports[`DataTable Rendering renders a selectable table 1`] = `
             isSortable={false}
             overflowMenuOnHover={true}
             size="normal"
-            useZebraStyles={false}
           >
             <ScrollGradient
               className="security--data-table__table-wrapper"
@@ -3614,7 +3621,6 @@ exports[`DataTable Rendering renders a selectable table 1`] = `
                     isSortable={false}
                     overflowMenuOnHover={true}
                     size="normal"
-                    useZebraStyles={false}
                   >
                     <table
                       className="bx--data-table bx--data-table--no-border"
@@ -4966,6 +4972,7 @@ exports[`DataTable Rendering renders a selectable table 1`] = `
 
 exports[`DataTable Rendering renders a sortable table 1`] = `
 <DataTable
+  filterRows={[Function]}
   headers={
     Array [
       Object {
@@ -4996,7 +5003,9 @@ exports[`DataTable Rendering renders a sortable table 1`] = `
   }
   isSelectable={false}
   isSortable={true}
+  locale="en"
   missingDataCharacter="–"
+  overflowMenuOnHover={true}
   render={[Function]}
   rows={
     Array [
@@ -5090,7 +5099,9 @@ exports[`DataTable Rendering renders a sortable table 1`] = `
       },
     ]
   }
-  useZebraStyles={false}
+  size="normal"
+  sortRow={[Function]}
+  translateWithId={[Function]}
 >
   <div
     className="security--data-table"
@@ -5224,7 +5235,6 @@ exports[`DataTable Rendering renders a sortable table 1`] = `
       size="normal"
       sortRow={[Function]}
       translateWithId={[Function]}
-      useZebraStyles={false}
     >
       <TableContainer>
         <div
@@ -5234,7 +5244,6 @@ exports[`DataTable Rendering renders a sortable table 1`] = `
             isSortable={true}
             overflowMenuOnHover={true}
             size="normal"
-            useZebraStyles={false}
           >
             <ScrollGradient
               className="security--data-table__table-wrapper"
@@ -5266,7 +5275,6 @@ exports[`DataTable Rendering renders a sortable table 1`] = `
                     isSortable={true}
                     overflowMenuOnHover={true}
                     size="normal"
-                    useZebraStyles={false}
                   >
                     <table
                       className="bx--data-table bx--data-table--sort bx--data-table--no-border"

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -1852,13 +1852,15 @@ Map {
       },
     },
     "defaultProps": Object {
-      "filterRows": undefined,
+      "filterRows": [Function],
       "isSelectable": true,
       "isSortable": true,
+      "locale": "en",
       "missingDataCharacter": "–",
-      "render": undefined,
-      "sortRow": undefined,
-      "useZebraStyles": false,
+      "overflowMenuOnHover": true,
+      "size": "normal",
+      "sortRow": [Function],
+      "translateWithId": [Function],
     },
     "propTypes": Object {
       "filterRows": Object {
@@ -1871,7 +1873,7 @@ Map {
               Object {
                 "header": Object {
                   "isRequired": true,
-                  "type": "string",
+                  "type": "node",
                 },
                 "key": Object {
                   "isRequired": true,
@@ -1891,20 +1893,35 @@ Map {
       "isSortable": Object {
         "type": "bool",
       },
+      "locale": Object {
+        "type": "string",
+      },
       "missingDataCharacter": Object {
         "type": "string",
       },
-      "render": Object {
-        "type": "func",
+      "overflowMenuOnHover": Object {
+        "type": "bool",
+      },
+      "radio": Object {
+        "type": "bool",
       },
       "rows": Object {
         "args": Array [
           Object {
             "args": Array [
               Object {
+                "disabled": Object {
+                  "type": "bool",
+                },
                 "id": Object {
                   "isRequired": true,
                   "type": "string",
+                },
+                "isExpanded": Object {
+                  "type": "bool",
+                },
+                "isSelected": Object {
+                  "type": "bool",
                 },
               },
             ],
@@ -1914,11 +1931,25 @@ Map {
         "isRequired": true,
         "type": "arrayOf",
       },
+      "size": Object {
+        "args": Array [
+          Array [
+            "compact",
+            "short",
+            "normal",
+            "tall",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "sortRow": Object {
         "type": "func",
       },
-      "useZebraStyles": Object {
+      "stickyHeader": Object {
         "type": "bool",
+      },
+      "translateWithId": Object {
+        "type": "func",
       },
     },
   },
@@ -1927,7 +1958,7 @@ Map {
       "backwardText": "Backward",
       "className": "",
       "disabled": false,
-      "filterRows": undefined,
+      "filterRows": [Function],
       "forwardText": "Forward",
       "isLastPage": false,
       "isSelectable": true,
@@ -1935,17 +1966,19 @@ Map {
       "itemRangeText": [Function],
       "itemText": [Function],
       "itemsPerPageText": "Items per page",
+      "locale": "en",
       "missingDataCharacter": "–",
+      "overflowMenuOnHover": true,
       "page": 1,
       "pageInputDisabled": false,
       "pageNumberText": "Page Number",
       "pageRangeText": [Function],
       "pageText": [Function],
       "pagesUnknown": false,
-      "render": undefined,
-      "sortRow": undefined,
+      "size": "normal",
+      "sortRow": [Function],
+      "translateWithId": [Function],
       "useBackendPagination": false,
-      "useZebraStyles": false,
     },
     "propTypes": Object {
       "backwardText": Object {
@@ -1970,7 +2003,7 @@ Map {
               Object {
                 "header": Object {
                   "isRequired": true,
-                  "type": "string",
+                  "type": "node",
                 },
                 "key": Object {
                   "isRequired": true,
@@ -2015,11 +2048,17 @@ Map {
       "itemsPerPageText": Object {
         "type": "string",
       },
+      "locale": Object {
+        "type": "string",
+      },
       "missingDataCharacter": Object {
         "type": "string",
       },
       "onChange": Object {
         "type": "func",
+      },
+      "overflowMenuOnHover": Object {
+        "type": "bool",
       },
       "page": Object {
         "type": "number",
@@ -2051,17 +2090,26 @@ Map {
       "pagesUnknown": Object {
         "type": "bool",
       },
-      "render": Object {
-        "type": "func",
+      "radio": Object {
+        "type": "bool",
       },
       "rows": Object {
         "args": Array [
           Object {
             "args": Array [
               Object {
+                "disabled": Object {
+                  "type": "bool",
+                },
                 "id": Object {
                   "isRequired": true,
                   "type": "string",
+                },
+                "isExpanded": Object {
+                  "type": "bool",
+                },
+                "isSelected": Object {
+                  "type": "bool",
                 },
               },
             ],
@@ -2071,16 +2119,30 @@ Map {
         "isRequired": true,
         "type": "arrayOf",
       },
+      "size": Object {
+        "args": Array [
+          Array [
+            "compact",
+            "short",
+            "normal",
+            "tall",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "sortRow": Object {
         "type": "func",
+      },
+      "stickyHeader": Object {
+        "type": "bool",
       },
       "totalItems": Object {
         "type": "number",
       },
-      "useBackendPagination": Object {
-        "type": "bool",
+      "translateWithId": Object {
+        "type": "func",
       },
-      "useZebraStyles": Object {
+      "useBackendPagination": Object {
         "type": "bool",
       },
     },


### PR DESCRIPTION
## Affected issue

Related to #664

## Proposed changes

- Proxy Carbon's `DataTable` `defaultProps` and `propTypes` - any changes upstream were not being reflected and would cause disparities between both implementations and consumer expectation
- Update snapshots to reflect changes
- Add `size` knob to `DataTable` stories