### PR TITLE
fix(searchbar): remove unused Search prop showIcon

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -198,7 +198,6 @@ export default class SearchBar extends React.Component {
           value={value}
           onChange={this.handleInputChange}
           closeButtonLabelText={clearButtonLabelText}
-          showIcon={false}
         />
         <Button
           name="search-submit"

--- a/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
@@ -47,7 +47,6 @@ exports[`SearchBar Rendering disables the submit button with no selected scopes 
     name="search-input"
     onChange={[Function]}
     placeHolderText="Placeholder"
-    showIcon={false}
     type="text"
     value=""
   />
@@ -78,7 +77,6 @@ exports[`SearchBar Rendering disables the submit button with no value 1`] = `
     name="search-input"
     onChange={[Function]}
     placeHolderText="Placeholder"
-    showIcon={false}
     type="text"
     value={null}
   />
@@ -109,7 +107,6 @@ exports[`SearchBar Rendering renders 1`] = `
     name="search-input"
     onChange={[Function]}
     placeHolderText="Placeholder"
-    showIcon={false}
     type="text"
     value=""
   />
@@ -140,7 +137,6 @@ exports[`SearchBar Rendering renders an initial value 1`] = `
     name="search-input"
     onChange={[Function]}
     placeHolderText="Placeholder"
-    showIcon={false}
     type="text"
     value="Initial value"
   />
@@ -206,7 +202,6 @@ exports[`SearchBar Rendering renders scopes 1`] = `
     name="search-input"
     onChange={[Function]}
     placeHolderText="Placeholder"
-    showIcon={false}
     type="text"
     value=""
   />
@@ -279,7 +274,6 @@ exports[`SearchBar Rendering renders selected scopes 1`] = `
     name="search-input"
     onChange={[Function]}
     placeHolderText="Placeholder"
-    showIcon={false}
     type="text"
     value=""
   />


### PR DESCRIPTION
The `showIcon` prop passed to inner `Search` component is not a valid `Search` prop:
https://github.com/carbon-design-system/carbon/blob/f592f2d2540042befa0cc8e97cb31a0d9c52f748/packages/react/src/components/Search/Search.js#L18

## Proposed changes

- remove `showIcon` prop from `Search` component and update snapshots

