### PR TITLE
feat(tearsheet-small): update use of body prop and isLoading render prop, deprecate children prop

### DIFF
--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.js
@@ -8,6 +8,7 @@ import Close20 from '@carbon/icons-react/lib/close/20';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import deprecate from 'carbon-components-react/lib/prop-types/deprecate';
 
 import { getComponentNamespace } from '../../../globals/namespace';
 import * as defaultLabels from '../../../globals/nls';
@@ -49,14 +50,16 @@ class TearsheetSmall extends PureComponent {
     return null;
   }
 
-  renderProp = prop => (typeof prop === 'function' ? prop() : prop);
+  renderProp = (prop, ...args) =>
+    typeof prop === 'function' ? prop(...args) : prop;
 
   renderBody = () => {
-    if (React.Children.count(this.props.children) > 0) {
-      return this.props.children;
-    }
+    const { body, children } = this.props;
+    const { loading } = this.state;
 
-    return this.renderProp(this.props.body);
+    const elementToRender = body || children;
+
+    return this.renderProp(elementToRender, { isLoading: loading });
   };
 
   render() {
@@ -121,7 +124,7 @@ class TearsheetSmall extends PureComponent {
                       [`${namespace}__scroll-gradient__content`]: !flush,
                     })}
                   >
-                    {this.renderBody({ isLoading: this.state.loading })}
+                    {this.renderBody()}
                   </div>
                 </ScrollGradient>
               </section>
@@ -205,7 +208,11 @@ TearsheetSmall.propTypes = {
     PropTypes.element,
   ]),
 
-  children: PropTypes.element,
+  /** @deprecated Deprecated. Please use `body` prop. */
+  children: deprecate(
+    PropTypes.element,
+    `\nThe prop \`children\` for TearsheetSmall has been deprecated in favor of \`body\`.`
+  ),
 
   /** @type {Object<Object>} An object list of primary button props. */
   primaryButton: buttonType.isRequired,

--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.stories.js
@@ -193,7 +193,7 @@ storiesOf(patterns('TearsheetSmall'), module)
           isOpen
           loading={loading}
           labels={labels}
-          body={isLoading => (
+          body={({ isLoading }) => (
             <>
               <p>
                 Whenever the TearsheetSmall is loading, please use{' '}

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -10414,7 +10414,6 @@ Map {
   "TearsheetSmall" => Object {
     "defaultProps": Object {
       "body": "",
-      "children": undefined,
       "className": "",
       "description": "",
       "flush": false,
@@ -10444,9 +10443,6 @@ Map {
           ],
         ],
         "type": "oneOfType",
-      },
-      "children": Object {
-        "type": "element",
       },
       "className": Object {
         "type": "string",

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -10414,6 +10414,7 @@ Map {
   "TearsheetSmall" => Object {
     "defaultProps": Object {
       "body": "",
+      "children": undefined,
       "className": "",
       "description": "",
       "flush": false,
@@ -10444,6 +10445,7 @@ Map {
         ],
         "type": "oneOfType",
       },
+      "children": [Function],
       "className": Object {
         "type": "string",
       },


### PR DESCRIPTION
## Affected issues

- Resolves #601

## Proposed changes

- update uses of `body` and `isLoading` render prop so that you can't tab through `TearsheetSmall` content while it is loading.
- deprecate the `children` prop for `TearsheetSmall`, which is a "hidden" prop because it isn't documented in the storybook and isn't shown as part of that recommended API (alternatively I can be convinced to deprecate `body` instead -- it's just that `body` has been part of the API for some time, and it's demonstrated in the storybook... whereas `children` is only utilized, as far as I can tell, by the `TagWallFilter`. It's just that we shouldn't have both existing to do the same thing.)

## Testing instructions

- make sure you can't tab through `TearsheetSmall` content while it is loading
