### PR TITLE
fix(card): remove text-transform capitalization from header

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -2626,10 +2626,6 @@ body {
   outline-offset: -2px;
 }
 
-.security--card__header {
-  text-transform: capitalize;
-}
-
 .security--card__header__image {
   width: 2rem;
   height: 2rem;

--- a/src/components/Card/_mixins.scss
+++ b/src/components/Card/_mixins.scss
@@ -57,8 +57,6 @@ $card__name: card;
   }
 
   &__header {
-    text-transform: capitalize;
-
     &__image {
       width: $card__image__sizing__dimensions;
       height: $card__image__sizing__dimensions;


### PR DESCRIPTION
## Affected issues

- Resolves #677

## Proposed changes

- remove `text-transform: capitalize` style from `Card` header text
