### PR TITLE
feat(combo-button): deprecate primaryFocus prop, replace with selectorPrimaryFocus

### DIFF
--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -21,7 +21,12 @@ import { namespace as buttonNamespace } from '../Button/Button';
 
 export const namespace = getComponentNamespace('combo-button');
 
-const ComboButton = ({ children, className, direction }) => {
+const ComboButton = ({
+  children,
+  className,
+  direction,
+  selectorPrimaryFocus,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapper = useRef(null);
 
@@ -69,7 +74,7 @@ const ComboButton = ({ children, className, direction }) => {
     overflowItems = childrenArray.slice(1);
 
     // Create `OverflowMenuItem` components:
-    overflowMenuItemWithProps = overflowItems.map((item, index) => {
+    overflowMenuItemWithProps = overflowItems.map(item => {
       // Need to explicitly define props, versus using `...rest`,
       // because otherwise unused `Button`-related props from
       // may trigger invalid DOM warnings.
@@ -79,9 +84,9 @@ const ComboButton = ({ children, className, direction }) => {
         disabled,
         href,
         onClick,
-        selectorPrimaryFocus,
         id,
         renderIcon: Icon,
+        ...other
       } = item.props;
 
       return (
@@ -103,9 +108,7 @@ const ComboButton = ({ children, className, direction }) => {
           id={id}
           key={id || `item-${href}`}
           onClick={onClick}
-          selectorPrimaryFocus={
-            !selectorPrimaryFocus && index === 0 ? true : selectorPrimaryFocus
-          }
+          {...other}
         />
       );
     });
@@ -146,6 +149,7 @@ const ComboButton = ({ children, className, direction }) => {
             renderIcon={() =>
               isOpen ? overflowIcon(ChevronUp16) : overflowIcon(ChevronDown16)
             }
+            selectorPrimaryFocus={selectorPrimaryFocus}
           >
             {overflowMenuItemWithProps}
           </OverflowMenu>
@@ -164,11 +168,18 @@ ComboButton.propTypes = {
 
   /** @type {string} Overflow menu direction. */
   direction: PropTypes.oneOf([TooltipDirection.TOP, TooltipDirection.BOTTOM]),
+
+  /**
+   * Specify a CSS selector that matches the DOM element that should
+   * be focused when the OverflowMenu opens
+   */
+  selectorPrimaryFocus: PropTypes.string,
 };
 
 ComboButton.defaultProps = {
   className: '',
   direction: TooltipDirection.TOP,
+  selectorPrimaryFocus: '[data-overflow-menu-primary-focus]',
 };
 
 export default ComboButton;

--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -79,7 +79,7 @@ const ComboButton = ({ children, className, direction }) => {
         disabled,
         href,
         onClick,
-        primaryFocus,
+        selectorPrimaryFocus,
         id,
         renderIcon: Icon,
       } = item.props;
@@ -103,7 +103,9 @@ const ComboButton = ({ children, className, direction }) => {
           id={id}
           key={id || `item-${href}`}
           onClick={onClick}
-          primaryFocus={!primaryFocus && index === 0 ? true : primaryFocus}
+          selectorPrimaryFocus={
+            !selectorPrimaryFocus && index === 0 ? true : selectorPrimaryFocus
+          }
         />
       );
     });

--- a/src/components/ComboButton/ComboButton.stories.js
+++ b/src/components/ComboButton/ComboButton.stories.js
@@ -32,28 +32,28 @@ storiesOf(patterns('ComboButton'), module).add(
   () => (
     <div style={{ width: 300 }}>
       <ComboButton {...props()}>
-        <ComboButtonItem href="#" renderIcon={ArrowRight20}>
-          Item 1 (becomes primary button and text will be truncated)
+        <ComboButtonItem
+          href="#"
+          onClick={action(`onClick (Item 1)`)}
+          renderIcon={ArrowRight20}
+        >
+          Item 1 -- becomes primary button and text will be truncated
         </ComboButtonItem>
-        {Array(5)
-          .fill(0)
-          .map((item, index) => {
-            const text = `Item ${index +
-              2} - text may be long and will be truncated`;
-            return (
-              <ComboButtonItem
-                className="some-class"
-                key={text}
-                href={`#${index}`}
-                index={index}
-                id={index}
-                onClick={action(`onClick (${text})`)}
-                renderIcon={index % 2 === 0 ? Filter20 : null} // Show icon at even indexes.
-              >
-                {text}
-              </ComboButtonItem>
-            );
-          })}
+        <ComboButtonItem
+          href="#"
+          onClick={action(`onClick (Item 2)`)}
+          renderIcon={Filter20}
+        >
+          Item 2
+        </ComboButtonItem>
+        <ComboButtonItem
+          href="#"
+          renderIcon={Filter20}
+          onClick={action(`onClick (Item 3)`)}
+          data-overflow-menu-primary-focus
+        >
+          Item 3 -- will be selected when menu opens
+        </ComboButtonItem>
       </ComboButton>
     </div>
   ),

--- a/src/components/ComboButton/ComboButtonItem/ComboButtonItem.js
+++ b/src/components/ComboButton/ComboButtonItem/ComboButtonItem.js
@@ -5,6 +5,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import deprecate from 'carbon-components-react/lib/prop-types/deprecate';
+
 import { namespace } from '../ComboButton';
 
 const ComboButtonItem = props => {
@@ -31,8 +34,15 @@ ComboButtonItem.propTypes = {
   /** @type {func} Click handler. */
   onClick: PropTypes.func,
 
+  /** @deprecated This prop has been deprecated in favor of `selectorPrimaryFocus` */
+  // eslint-disable-next-line react/require-default-props
+  primaryFocus: deprecate(
+    PropTypes.bool,
+    `\nThe prop \`primaryFocus\` for ComboButtonItem has been deprecated in favor of \`selectorPrimaryFocus\`.`
+  ),
+
   /** @type {boolean} Assign primary focus to a combo button item rendered inside an overflow menu. */
-  primaryFocus: PropTypes.bool,
+  selectorPrimaryFocus: PropTypes.bool,
 
   /** @type {function|object} Icon to render. */
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -44,7 +54,7 @@ ComboButtonItem.defaultProps = {
   href: undefined,
   iconDescription: '',
   onClick: () => {},
-  primaryFocus: false,
+  selectorPrimaryFocus: false,
   renderIcon: null,
 };
 

--- a/src/components/ComboButton/ComboButtonItem/ComboButtonItem.js
+++ b/src/components/ComboButton/ComboButtonItem/ComboButtonItem.js
@@ -34,15 +34,15 @@ ComboButtonItem.propTypes = {
   /** @type {func} Click handler. */
   onClick: PropTypes.func,
 
-  /** @deprecated This prop has been deprecated in favor of `selectorPrimaryFocus` */
+  /**
+   * @deprecated This prop has been deprecated.
+   * Please use `selectorPrimaryFocus` in ComboButton instead.
+   */
   // eslint-disable-next-line react/require-default-props
   primaryFocus: deprecate(
     PropTypes.bool,
-    `\nThe prop \`primaryFocus\` for ComboButtonItem has been deprecated in favor of \`selectorPrimaryFocus\`.`
+    `\nThe prop \`primaryFocus\` for ComboButtonItem has been deprecated. Please use the \`selectorPrimaryFocus\` in ComboButton instead.`
   ),
-
-  /** @type {boolean} Assign primary focus to a combo button item rendered inside an overflow menu. */
-  selectorPrimaryFocus: PropTypes.bool,
 
   /** @type {function|object} Icon to render. */
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -54,7 +54,6 @@ ComboButtonItem.defaultProps = {
   href: undefined,
   iconDescription: '',
   onClick: () => {},
-  selectorPrimaryFocus: false,
   renderIcon: null,
 };
 

--- a/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
+++ b/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
@@ -4,6 +4,7 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
 <ComboButton
   className=""
   direction="top"
+  selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
 >
   <div
     className="security--combo-button"
@@ -106,6 +107,7 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
         onClose={[Function]}
         onOpen={[Function]}
         renderIcon={[Function]}
+        selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
       >
         <OverflowMenu
           ariaLabel="Menu"
@@ -191,6 +193,7 @@ exports[`ComboButton renders a combo button without an overflow menu 1`] = `
 <ComboButton
   className=""
   direction="top"
+  selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
 >
   <div
     className="security--combo-button"

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -951,7 +951,6 @@ Map {
       "href": undefined,
       "iconDescription": "",
       "onClick": [Function],
-      "primaryFocus": false,
       "renderIcon": null,
       "selectorPrimaryFocus": false,
     },

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -953,6 +953,7 @@ Map {
       "onClick": [Function],
       "primaryFocus": false,
       "renderIcon": null,
+      "selectorPrimaryFocus": false,
     },
     "propTypes": Object {
       "children": Object {
@@ -974,9 +975,7 @@ Map {
       "onClick": Object {
         "type": "func",
       },
-      "primaryFocus": Object {
-        "type": "bool",
-      },
+      "primaryFocus": [Function],
       "renderIcon": Object {
         "args": Array [
           Array [
@@ -989,6 +988,9 @@ Map {
           ],
         ],
         "type": "oneOfType",
+      },
+      "selectorPrimaryFocus": Object {
+        "type": "bool",
       },
     },
   },

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -924,6 +924,7 @@ Map {
     "defaultProps": Object {
       "className": "",
       "direction": "top",
+      "selectorPrimaryFocus": "[data-overflow-menu-primary-focus]",
     },
     "propTypes": Object {
       "children": Object {
@@ -942,6 +943,9 @@ Map {
         ],
         "type": "oneOf",
       },
+      "selectorPrimaryFocus": Object {
+        "type": "string",
+      },
     },
   },
   "ComboButtonItem" => Object {
@@ -952,7 +956,6 @@ Map {
       "iconDescription": "",
       "onClick": [Function],
       "renderIcon": null,
-      "selectorPrimaryFocus": false,
     },
     "propTypes": Object {
       "children": Object {
@@ -987,9 +990,6 @@ Map {
           ],
         ],
         "type": "oneOfType",
-      },
-      "selectorPrimaryFocus": Object {
-        "type": "bool",
       },
     },
   },


### PR DESCRIPTION
## Affected issues

- partially addresses #683 

## Proposed changes

- deprecate `primaryFocus` prop
- replace with `selectorPrimaryFocus`

