### PR TITLE
fix(icon-button-bar): use selectorPrimaryFocus in OverflowMenu

### DIFF
--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -25,6 +25,7 @@ const IconButtonBar = ({
   overflowMenuDirection,
   size,
   tooltip,
+  selectorPrimaryFocus,
 }) => {
   const isMaxLength = actions.length > length;
   const iconButtonBarClasses = classnames(namespace, className, {
@@ -73,6 +74,7 @@ const IconButtonBar = ({
         key={action.label}
         onClick={action.onClick}
         disabled={action.disabled}
+        {...action.otherProps}
       />
     ));
   };
@@ -103,6 +105,7 @@ const IconButtonBar = ({
             flipped
             menuOptionsClass={iconButtonBarMenuOptionsClasses}
             renderIcon={getOverflowMenuIcon()}
+            selectorPrimaryFocus={selectorPrimaryFocus}
           >
             {renderMenuItems()}
           </OverflowMenu>
@@ -151,6 +154,12 @@ IconButtonBar.propTypes = {
 
   /** @type {boolean} Specify tooltip. */
   tooltip: PropTypes.bool,
+
+  /**
+   * Specify a CSS selector that matches the DOM element that should
+   * be focused when the OverflowMenu opens
+   */
+  selectorPrimaryFocus: PropTypes.string,
 };
 
 IconButtonBar.defaultProps = {
@@ -161,6 +170,7 @@ IconButtonBar.defaultProps = {
   overflowMenuDirection: IconButton.TooltipDirection.TOP,
   size: 'lg',
   tooltip: true,
+  selectorPrimaryFocus: '[data-overflow-menu-primary-focus]',
 };
 
 export default IconButtonBar;

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -25,9 +25,9 @@ const IconButtonBar = ({
   overflowMenuDirection,
   size,
   tooltip,
-  selectorPrimaryFocus,
 }) => {
   const isMaxLength = actions.length > length;
+  const iconButtonPrimaryFocus = `${namespace}--primary-focus`;
   const iconButtonBarClasses = classnames(namespace, className, {
     [`${namespace}--${size}`]: size,
   });
@@ -74,7 +74,9 @@ const IconButtonBar = ({
         key={action.label}
         onClick={action.onClick}
         disabled={action.disabled}
-        {...action.otherProps}
+        className={classnames(action.className, {
+          [`${iconButtonPrimaryFocus}`]: action.setFocus,
+        })}
       />
     ));
   };
@@ -105,7 +107,7 @@ const IconButtonBar = ({
             flipped
             menuOptionsClass={iconButtonBarMenuOptionsClasses}
             renderIcon={getOverflowMenuIcon()}
-            selectorPrimaryFocus={selectorPrimaryFocus}
+            selectorPrimaryFocus={`.${iconButtonPrimaryFocus}`}
           >
             {renderMenuItems()}
           </OverflowMenu>
@@ -121,6 +123,12 @@ IconButtonBar.propTypes = {
     PropTypes.shape({
       ...propTypes,
       divider: PropTypes.oneOf(['left', 'right', 'sides']),
+
+      /**
+       * Whether or not the icon button should receive focus when the menu is first opened.
+       * By default, the first button in the menu will receive focus.
+       */
+      setFocus: PropTypes.bool,
     })
   ),
 
@@ -154,12 +162,6 @@ IconButtonBar.propTypes = {
 
   /** @type {boolean} Specify tooltip. */
   tooltip: PropTypes.bool,
-
-  /**
-   * Specify a CSS selector that matches the DOM element that should
-   * be focused when the OverflowMenu opens
-   */
-  selectorPrimaryFocus: PropTypes.string,
 };
 
 IconButtonBar.defaultProps = {
@@ -170,7 +172,6 @@ IconButtonBar.defaultProps = {
   overflowMenuDirection: IconButton.TooltipDirection.TOP,
   size: 'lg',
   tooltip: true,
-  selectorPrimaryFocus: '[data-overflow-menu-primary-focus]',
 };
 
 export default IconButtonBar;

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -72,7 +72,7 @@ const IconButtonBar = ({
         itemText={action.label}
         key={action.label}
         onClick={action.onClick}
-        primaryFocus={index === 0}
+        selectorPrimaryFocus={index === 0}
         disabled={action.disabled}
       />
     ));

--- a/src/components/IconButtonBar/IconButtonBar.js
+++ b/src/components/IconButtonBar/IconButtonBar.js
@@ -67,12 +67,11 @@ const IconButtonBar = ({
     if (overflowMenuDirection === IconButton.TooltipDirection.TOP) {
       items.reverse();
     }
-    return items.map((action, index) => (
+    return items.map(action => (
       <OverflowMenuItem
         itemText={action.label}
         key={action.label}
         onClick={action.onClick}
-        selectorPrimaryFocus={index === 0}
         disabled={action.disabled}
       />
     ));

--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -80,11 +80,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
         iconClassName,
         label: 'Label 3',
         onClick: action('onClick'),
-        otherProps: {
-          // This data attribute means that "Label 3" is selected
-          // by default when the overflow menu is opened.
-          [`data-overflow-menu-primary-focus`]: true,
-        },
+        setFocus: true,
         renderIcon:
           size === 'sm'
             ? Locked16

--- a/src/components/IconButtonBar/IconButtonBar.stories.js
+++ b/src/components/IconButtonBar/IconButtonBar.stories.js
@@ -29,7 +29,7 @@ import { patterns } from '../../../.storybook';
 
 import { IconButton, IconButtonBar } from '../..';
 
-import { className, iconClassName, label, sizes } from '../IconButton/_mocks_';
+import { className, iconClassName, sizes } from '../IconButton/_mocks_';
 import { TooltipDirection } from '../IconButton/IconButton';
 
 storiesOf(patterns('IconButtonBar'), module).add(
@@ -47,7 +47,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
         ),
         disabled: false,
         iconClassName,
-        label: `${label} 1`,
+        label: 'Label 1',
         onClick: action('onClick'),
         renderIcon:
           size === 'sm'
@@ -63,7 +63,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
         divider: undefined,
         disabled: false,
         iconClassName,
-        label: `${label} 2`,
+        label: 'Label 2',
         onClick: action('onClick'),
         renderIcon:
           size === 'sm'
@@ -78,8 +78,13 @@ storiesOf(patterns('IconButtonBar'), module).add(
         className,
         disabled: false,
         iconClassName,
-        label: `${label} 3`,
+        label: 'Label 3',
         onClick: action('onClick'),
+        otherProps: {
+          // This data attribute means that "Label 3" is selected
+          // by default when the overflow menu is opened.
+          [`data-overflow-menu-primary-focus`]: true,
+        },
         renderIcon:
           size === 'sm'
             ? Locked16
@@ -93,7 +98,7 @@ storiesOf(patterns('IconButtonBar'), module).add(
         className,
         disabled: false,
         iconClassName,
-        label: `${label} 4`,
+        label: 'Label 4',
         onClick: action('onClick'),
         renderIcon:
           size === 'sm'

--- a/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
+++ b/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
@@ -71,8 +71,10 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -82,6 +84,7 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -165,8 +168,10 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -176,6 +181,7 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -259,8 +265,10 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -270,6 +278,7 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -353,8 +362,10 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -364,6 +375,7 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -391,8 +403,10 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -402,6 +416,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -411,6 +426,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -420,6 +436,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -475,8 +492,10 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -486,6 +505,7 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -495,6 +515,7 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -578,8 +599,10 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
         "render": [Function],
       }
     }
+    selectorPrimaryFocus=".security--icon-button-bar--primary-focus"
   >
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}
@@ -589,6 +612,7 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
       onKeyDown={[Function]}
     />
     <OverflowMenuItem
+      className="class"
       disabled={false}
       hasDivider={false}
       isDelete={false}

--- a/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
+++ b/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
@@ -80,7 +80,7 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -90,7 +90,7 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -176,7 +176,7 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -186,7 +186,7 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -272,7 +272,7 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -282,7 +282,7 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -368,7 +368,7 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -378,7 +378,7 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -408,7 +408,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -418,7 +418,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
     <OverflowMenuItem
       disabled={false}
@@ -428,7 +428,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 2"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
     <OverflowMenuItem
       disabled={false}
@@ -438,7 +438,7 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 1"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -496,7 +496,7 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -506,7 +506,7 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
     <OverflowMenuItem
       disabled={false}
@@ -516,7 +516,7 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       key="Label 2"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -602,7 +602,7 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={true}
+      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -612,7 +612,7 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      primaryFocus={false}
+      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>

--- a/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
+++ b/src/components/IconButtonBar/__tests__/__snapshots__/IconButtonBar.spec.js.snap
@@ -80,7 +80,6 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -90,7 +89,6 @@ exports[`IconButtonBar renders the 'lg' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -176,7 +174,6 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -186,7 +183,6 @@ exports[`IconButtonBar renders the 'md' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -272,7 +268,6 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -282,7 +277,6 @@ exports[`IconButtonBar renders the 'sm' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -368,7 +362,6 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -378,7 +371,6 @@ exports[`IconButtonBar renders the 'xl' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -408,7 +400,6 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -418,7 +409,6 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
     <OverflowMenuItem
       disabled={false}
@@ -428,7 +418,6 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 2"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
     <OverflowMenuItem
       disabled={false}
@@ -438,7 +427,6 @@ exports[`IconButtonBar renders the length of '1' variation 1`] = `
       key="Label 1"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -496,7 +484,6 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -506,7 +493,6 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
     <OverflowMenuItem
       disabled={false}
@@ -516,7 +502,6 @@ exports[`IconButtonBar renders the length of '2' variation 1`] = `
       key="Label 2"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>
@@ -602,7 +587,6 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
       key="Label 4"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={true}
     />
     <OverflowMenuItem
       disabled={false}
@@ -612,7 +596,6 @@ exports[`IconButtonBar renders the length of '3' variation 1`] = `
       key="Label 3"
       onClick={[Function]}
       onKeyDown={[Function]}
-      selectorPrimaryFocus={false}
     />
   </ForwardRef(OverflowMenu)>
 </div>

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -4402,6 +4402,9 @@ Map {
                   ],
                   "type": "oneOfType",
                 },
+                "setFocus": Object {
+                  "type": "bool",
+                },
                 "size": Object {
                   "args": Array [
                     Array [


### PR DESCRIPTION
## Affected issues

partially addresses #683 

## Proposed changes

- use `selectorPrimaryFocus` in `OverflowMenu` (set it to a known class name for icon buttons)
- add `setFocus` prop to individual actions (assign it a class name if true)

## Testing instructions

- ensure that `IconButtonBar` functions as expected
