### PR TITLE
fix(wizard): fix className, allow 3 lines for steps before truncation

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -17039,7 +17039,6 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
 
 .security--wizard .bx--progress--vertical .bx--progress-line {
   display: none;
-  visibility: hidden;
 }
 
 @keyframes collapse-accordion {

--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -17007,6 +17007,31 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
   margin-left: -1.5rem;
 }
 
+.security--wizard .bx--progress--vertical .bx--progress-step,
+.security--wizard .bx--progress--vertical .bx--progress-step-button {
+  flex-wrap: nowrap;
+  margin-bottom: 0.5rem;
+}
+
+.security--wizard .bx--progress--vertical .bx--progress-step svg,
+.security--wizard .bx--progress--vertical .bx--progress-step-button svg {
+  margin-left: 0;
+}
+
+.security--wizard .bx--progress--vertical .bx--progress-label {
+  display: inline-block;
+  max-width: 80ch;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.security--wizard .bx--progress--vertical .bx--progress-line {
+  display: none;
+  visibility: hidden;
+}
+
 @keyframes collapse-accordion {
   0% {
     height: 100%;

--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -17030,7 +17030,6 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
 }
 
 .security--wizard .bx--progress--vertical .bx--progress-label {
-  display: inline-block;
   max-width: 80ch;
   overflow: hidden;
   display: -webkit-box;

--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -241,7 +241,14 @@ class Wizard extends Component {
    * Renders the component.
    */
   render() {
-    const { labels, focusTrap, title, subTitle, ...other } = this.props;
+    const {
+      labels,
+      focusTrap,
+      title,
+      subTitle,
+      className,
+      ...other
+    } = this.props;
     const componentLabels = {
       ...defaultLabels.labels,
       ...labels,
@@ -335,7 +342,7 @@ class Wizard extends Component {
         }}
         loading={this.state.loading}
         loadingMessage={this.props.loadingMessage}
-        className={classnames(namespace, this.props.className)}
+        className={classnames(namespace, className)}
         {...other}
       />
     );

--- a/src/components/Wizard/Wizard.stories.js
+++ b/src/components/Wizard/Wizard.stories.js
@@ -50,7 +50,8 @@ const labels = {
 
 const steps = [
   {
-    title: 'First Step',
+    title:
+      'First Step that is very long will be truncated at 3 lines if the viewport size is small enough.',
     renderMain: (state, setState) => (
       <div>
         <p style={{ fontSize: 'normal' }}>Please fill out the form.</p>

--- a/src/components/Wizard/_index.scss
+++ b/src/components/Wizard/_index.scss
@@ -41,7 +41,6 @@
 
     .#{$prefix}--progress-line {
       display: none;
-      visibility: hidden;
     }
   }
 }

--- a/src/components/Wizard/_index.scss
+++ b/src/components/Wizard/_index.scss
@@ -6,6 +6,8 @@
 
 @import '@carbon/layout/scss/spacing';
 
+@import '../../globals/namespace/index';
+
 @import '../Nav/index';
 @import '../ProgressIndicator/index';
 @import '../Tearsheet/index';
@@ -15,5 +17,31 @@
 @include security--component($name: wizard) {
   &__navItem {
     margin-left: -$carbon--spacing-06;
+  }
+
+  .#{$prefix}--progress--vertical {
+    .#{$prefix}--progress-step,
+    .#{$prefix}--progress-step-button {
+      flex-wrap: nowrap;
+      margin-bottom: $carbon--spacing-03;
+    }
+
+    .#{$prefix}--progress-step svg,
+    .#{$prefix}--progress-step-button svg {
+      margin-left: 0;
+    }
+
+    .#{$prefix}--progress-label {
+      max-width: 80ch;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+    }
+
+    .#{$prefix}--progress-line {
+      display: none;
+      visibility: hidden;
+    }
   }
 }


### PR DESCRIPTION
## Affected issues

- Resolves #617

## Proposed changes

- fix issue where `.security--wizard` className was being dropped
- update styles for vertical `ProgressIndicator` in `Wizard` to hide the line and remove some margins
- allow `Wizard` steps to be 3 lines long / 40 characters before truncating them (this can be updated to whatever)

## Testing instructions

- review the `Wizard` story
