### PR TITLE
docs(overflow-menu): remove usage of primaryFocus in stories

### DIFF
--- a/src/components/DataTable/stories/with-overflow-menu.js
+++ b/src/components/DataTable/stories/with-overflow-menu.js
@@ -63,7 +63,6 @@ const overflowStory = props => (
                         <OverflowMenuItem
                           key={key}
                           itemText={`${itemText} ${index + 1}`}
-                          primaryFocus={index === 0}
                         />
                       );
                     })}

--- a/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -45,11 +45,7 @@ const props = {
 const OverflowMenuExample = ({ overflowMenuProps, overflowMenuItemProps }) => (
   <>
     <OverflowMenu {...overflowMenuProps}>
-      <OverflowMenuItem
-        {...overflowMenuItemProps}
-        itemText="Option 1"
-        primaryFocus
-      />
+      <OverflowMenuItem {...overflowMenuItemProps} itemText="Option 1" />
       <OverflowMenuItem
         {...overflowMenuItemProps}
         itemText="Option 2 is an example of a really long string and how we recommend handling this"
@@ -65,11 +61,7 @@ const OverflowMenuExample = ({ overflowMenuProps, overflowMenuItemProps }) => (
       />
     </OverflowMenu>
     <OverflowMenu {...overflowMenuProps}>
-      <OverflowMenuItem
-        {...overflowMenuItemProps}
-        itemText="Option 1"
-        primaryFocus
-      />
+      <OverflowMenuItem {...overflowMenuItemProps} itemText="Option 1" />
       <OverflowMenuItem
         {...overflowMenuItemProps}
         itemText="Option 2 is an example of a really long string and how we recommend handling this"


### PR DESCRIPTION
## Affected issues

- Resolves #683 

## Proposed changes

- remove usage of old prop `primaryFocus` from `OverflowMenu` story
- remove usage of old prop `primaryFocus` from `DataTable` with overflow menu story
