### PR TITLE
fix(time-picker): add padding style override to input

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -22663,6 +22663,10 @@ bx--text-area.bx--skeleton::placeholder {
   color: var(--disabled-02, #525252);
 }
 
+input.bx--time-picker__input-field {
+  padding: 0 1rem;
+}
+
 .bx--toggle {
   position: absolute;
   width: 1px;

--- a/src/components/TimePicker/_index.scss
+++ b/src/components/TimePicker/_index.scss
@@ -1,7 +1,18 @@
 ////
 /// Time picker component.
 /// @group time-picker
-/// @copyright IBM Security 2018
+/// @copyright IBM Security 2018-2020
 ////
 
+@import '@carbon/layout/scss/spacing';
+@import 'carbon-components/scss/globals/scss/vars';
 @import 'carbon-components/scss/components/time-picker/time-picker';
+
+@import '../../globals/namespace/index';
+
+@include export-namespace($name: time-picker) {
+  // TODO: Waiting for fix from Carbon via https://github.com/carbon-design-system/carbon/pull/6483
+  input.#{$prefix}--time-picker__input-field {
+    padding: 0 $carbon--spacing-05;
+  }
+}


### PR DESCRIPTION
## Affected issues

- Resolves #671 

## Proposed changes

- add 1rem left and right padding to `TimePicker`
