### PR TITLE
feat(header): add profile.description prop to the popover

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -17821,6 +17821,12 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
   word-break: break-all;
 }
 
+.security--header__popover__profile__description {
+  padding-right: 1.5rem;
+  padding-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
 .security--header__popover__profile__body--account {
   padding-right: 1.5rem;
   padding-bottom: 1rem;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -230,6 +230,11 @@ export default class Header extends Component {
             </div>
           </Fragment>
         </HeaderPopoverHeader>
+        {profile.description && (
+          <section className={`${namespace}__popover__profile__description`}>
+            {profile.description}
+          </section>
+        )}
         {hasAccount && (
           <section
             className={classnames(`${namespace}__popover__profile__body`, {

--- a/src/components/Header/_mixins.scss
+++ b/src/components/Header/_mixins.scss
@@ -321,6 +321,12 @@ $header__transition__timing-function: $timing-function;
         }
       }
 
+      &__description {
+        padding-right: $header__popover__spacing__padding;
+        padding-bottom: $header__profile__spacing__margin;
+        padding-left: $header__popover__spacing__padding;
+      }
+
       &__body {
         &--account {
           padding-right: $header__popover__spacing__padding;

--- a/src/components/Header/_mocks_/index.js
+++ b/src/components/Header/_mocks_/index.js
@@ -3,6 +3,7 @@
  * @copyright IBM Security 2018
  */
 
+import React from 'react';
 import { url } from '../../_mocks_';
 import labels from '../locales/en/Header.json';
 
@@ -100,6 +101,12 @@ const profile = {
     first_name: 'Sample',
     surname: 'User',
   },
+  description: (
+    <span>
+      Example description node with extra information and{' '}
+      <a href="#example">example link.</a>
+    </span>
+  ),
 };
 
 const profileWithAccount = Object.assign({}, profile, {

--- a/src/components/Header/constants.js
+++ b/src/components/Header/constants.js
@@ -183,6 +183,9 @@ const propTypes = {
       /** @type {string} The profile surname. */
       surname: PropTypes.string.isRequired,
     }).isRequired,
+
+    /** Optional description for a profile. */
+    description: PropTypes.node,
   }),
 
   /** @type {boolean} Whether or not to show the Edit Profile link. */

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -3926,6 +3926,9 @@ Map {
               ],
               "type": "shape",
             },
+            "description": Object {
+              "type": "node",
+            },
             "email": Object {
               "type": "string",
             },
@@ -7622,6 +7625,9 @@ Map {
                     ],
                     "type": "shape",
                   },
+                  "description": Object {
+                    "type": "node",
+                  },
                   "email": Object {
                     "type": "string",
                   },
@@ -7682,6 +7688,9 @@ Map {
                 },
               ],
               "type": "shape",
+            },
+            "description": Object {
+              "type": "node",
             },
             "email": Object {
               "type": "string",


### PR DESCRIPTION
## Affected issues

- Resolves #668

I have opted to add the extra section below the profile popover heading, and above the body section. But let me know if it needs to be moved.

## Proposed changes

- adds `profile.description` prop with `node` type
- update stories to include the prop in use
- update snapshots
