### PR TITLE
feat(toolbar): support supplying IDs to navigation items

### DIFF
--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -3,18 +3,20 @@
  * @copyright IBM Security 2019 - 2020
  */
 
-import Launch16 from '@carbon/icons-react/lib/launch/16';
-
+import { Launch16 } from '@carbon/icons-react';
+import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
 import classnames from 'classnames';
 import { bool, elementType, func, node, number, string } from 'prop-types';
 import React, { Component } from 'react';
-import NavItemLink from '../NavItemLink';
 
 import Icon from '../../Icon';
+import NavItemLink from '../NavItemLink';
 
 import { getComponentNamespace } from '../../../globals/namespace';
 
 export const namespace = getComponentNamespace('nav__list__item');
+
+const getInstanceId = setupGetInstanceId();
 
 /**
  * Navigation item component.
@@ -73,13 +75,19 @@ export default class NavItem extends Component {
     element: 'a',
     handleItemSelect: null,
     href: undefined,
-    id: namespace,
+    id: null,
     label: '',
     link: true,
     onClick: () => {},
     onKeyPress: () => {},
     tabIndex: 0,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.navItemId = `${namespace}__${getInstanceId()}`;
+  }
 
   state = {
     current: this.props.current,
@@ -139,7 +147,7 @@ export default class NavItem extends Component {
       >
         {link ? (
           <NavItemLink
-            id={id}
+            id={id || this.navItemId}
             className={classnames(linkClassName, {
               [`${namespace}__link--external`]: externalLink,
             })}

--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -4,7 +4,6 @@
  */
 
 import { Launch16 } from '@carbon/icons-react';
-import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
 import classnames from 'classnames';
 import { bool, elementType, func, node, number, string } from 'prop-types';
 import React, { Component } from 'react';
@@ -15,8 +14,6 @@ import NavItemLink from '../NavItemLink';
 import { getComponentNamespace } from '../../../globals/namespace';
 
 export const namespace = getComponentNamespace('nav__list__item');
-
-const getInstanceId = setupGetInstanceId();
 
 /**
  * Navigation item component.
@@ -83,12 +80,6 @@ export default class NavItem extends Component {
     tabIndex: 0,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.navItemId = `${namespace}__${getInstanceId()}`;
-  }
-
   state = {
     current: this.props.current,
   };
@@ -147,7 +138,7 @@ export default class NavItem extends Component {
       >
         {link ? (
           <NavItemLink
-            id={id || this.navItemId}
+            id={id}
             className={classnames(linkClassName, {
               [`${namespace}__link--external`]: externalLink,
             })}

--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -4,6 +4,7 @@
  */
 
 import { Launch16 } from '@carbon/icons-react';
+import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
 import classnames from 'classnames';
 import { bool, elementType, func, node, number, string } from 'prop-types';
 import React, { Component } from 'react';
@@ -13,6 +14,7 @@ import NavItemLink from '../NavItemLink';
 
 import { getComponentNamespace } from '../../../globals/namespace';
 
+const getInstanceId = setupGetInstanceId();
 export const namespace = getComponentNamespace('nav__list__item');
 
 /**
@@ -88,6 +90,8 @@ export default class NavItem extends Component {
     return props.current === state.current ? null : { current: props.current };
   }
 
+  instanceId = `${namespace}__${getInstanceId()}`;
+
   render() {
     const {
       className,
@@ -111,9 +115,11 @@ export default class NavItem extends Component {
     const externalLink =
       isAbsoluteLink.test(href) && href.indexOf(window.location.host) === -1;
 
+    const navItemId = id || this.instanceId;
+
     const classNames = classnames(namespace, className, {
       [`${namespace}--active`]:
-        (this.state.current !== null && this.state.current === id) ||
+        (this.state.current !== null && this.state.current === navItemId) ||
         (activeHref !== undefined && activeHref === href && !externalLink),
       [`${namespace}--disabled`]: disabled,
     });
@@ -138,7 +144,7 @@ export default class NavItem extends Component {
       >
         {link ? (
           <NavItemLink
-            id={id}
+            id={navItemId}
             className={classnames(linkClassName, {
               [`${namespace}__link--external`]: externalLink,
             })}
@@ -157,7 +163,7 @@ export default class NavItem extends Component {
           </NavItemLink>
         ) : (
           <div
-            id={id}
+            id={navItemId}
             className={linkClassName}
             onClick={handleDisabled(handleItemSelect)}
             onKeyPress={handleDisabled(handleItemSelect)}

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -13,7 +13,7 @@ exports[`NavItem Rendering renders correctly 1`] = `
     className="security--nav__list__item__link"
     element="a"
     href="#"
-    id={null}
+    id="security--nav__list__item__1"
   >
     Label
   </NavItemLink>
@@ -30,6 +30,7 @@ exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
   <a
     class="security--nav__list__item__link"
     href="#"
+    id="security--nav__list__item__2"
   >
     Label
   </a>

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -13,7 +13,7 @@ exports[`NavItem Rendering renders correctly 1`] = `
     className="security--nav__list__item__link"
     element="a"
     href="#"
-    id="security--nav__list__item"
+    id="security--nav__list__item__1"
   >
     Label
   </NavItemLink>
@@ -30,7 +30,7 @@ exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
   <a
     class="security--nav__list__item__link"
     href="#"
-    id="security--nav__list__item"
+    id="security--nav__list__item__2"
   >
     Label
   </a>

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -13,7 +13,7 @@ exports[`NavItem Rendering renders correctly 1`] = `
     className="security--nav__list__item__link"
     element="a"
     href="#"
-    id="security--nav__list__item__1"
+    id={null}
   >
     Label
   </NavItemLink>
@@ -30,7 +30,6 @@ exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
   <a
     class="security--nav__list__item__link"
     href="#"
-    id="security--nav__list__item__2"
   >
     Label
   </a>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -103,7 +103,7 @@ exports[`Nav Rendering renders correctly 1`] = `
         element="a"
         handleItemSelect={null}
         href="#"
-        id="security--nav__list__item"
+        id={null}
         key="security--nav__list__item--0/.0"
         label=""
         link={true}
@@ -123,12 +123,12 @@ exports[`Nav Rendering renders correctly 1`] = `
             className="security--nav__list__item__link"
             element="a"
             href="#"
-            id="security--nav__list__item"
+            id="security--nav__list__item__1"
           >
             <a
               className="security--nav__list__item__link"
               href="#"
-              id="security--nav__list__item"
+              id="security--nav__list__item__1"
             >
               Label
             </a>
@@ -184,7 +184,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       <a
         class="security--nav__list__item__link"
         href="#"
-        id="security--nav__list__item"
+        id="security--nav__list__item__2"
       >
         Label
       </a>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -123,12 +123,12 @@ exports[`Nav Rendering renders correctly 1`] = `
             className="security--nav__list__item__link"
             element="a"
             href="#"
-            id={null}
+            id="security--nav__list__item__1"
           >
             <a
               className="security--nav__list__item__link"
               href="#"
-              id={null}
+              id="security--nav__list__item__1"
             >
               Label
             </a>
@@ -184,6 +184,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       <a
         class="security--nav__list__item__link"
         href="#"
+        id="security--nav__list__item__2"
       >
         Label
       </a>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -123,12 +123,12 @@ exports[`Nav Rendering renders correctly 1`] = `
             className="security--nav__list__item__link"
             element="a"
             href="#"
-            id="security--nav__list__item__1"
+            id={null}
           >
             <a
               className="security--nav__list__item__link"
               href="#"
-              id="security--nav__list__item__1"
+              id={null}
             >
               Label
             </a>
@@ -184,7 +184,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       <a
         class="security--nav__list__item__link"
         href="#"
-        id="security--nav__list__item__2"
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -122,7 +122,7 @@ exports[`Nav Rendering renders correctly 1`] = `
               element="a"
               handleItemSelect={null}
               href="#0"
-              id="security--nav__list__item"
+              id={null}
               key="security--nav__list__item--0/.0"
               label=""
               link={true}
@@ -142,12 +142,12 @@ exports[`Nav Rendering renders correctly 1`] = `
                   className="security--nav__list__item__link"
                   element="a"
                   href="#0"
-                  id="security--nav__list__item"
+                  id="security--nav__list__item__1"
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#0"
-                    id="security--nav__list__item"
+                    id="security--nav__list__item__1"
                   >
                     Label
                   </a>
@@ -260,7 +260,7 @@ exports[`Nav Rendering renders correctly 1`] = `
               element="a"
               handleItemSelect={null}
               href="#1"
-              id="security--nav__list__item"
+              id={null}
               key="security--nav__list__item--0/.0"
               label=""
               link={true}
@@ -280,12 +280,12 @@ exports[`Nav Rendering renders correctly 1`] = `
                   className="security--nav__list__item__link"
                   element="a"
                   href="#1"
-                  id="security--nav__list__item"
+                  id="security--nav__list__item__2"
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#1"
-                    id="security--nav__list__item"
+                    id="security--nav__list__item__2"
                   >
                     Label
                   </a>
@@ -303,7 +303,7 @@ exports[`Nav Rendering renders correctly 1`] = `
         element="a"
         handleItemSelect={null}
         href="#2"
-        id="security--nav__list__item"
+        id={null}
         key="security--nav__list__item--2/.2"
         label=""
         link={true}
@@ -323,12 +323,12 @@ exports[`Nav Rendering renders correctly 1`] = `
             className="security--nav__list__item__link"
             element="a"
             href="#2"
-            id="security--nav__list__item"
+            id="security--nav__list__item__3"
           >
             <a
               className="security--nav__list__item__link"
               href="#2"
-              id="security--nav__list__item"
+              id="security--nav__list__item__3"
             >
               Label
             </a>
@@ -397,7 +397,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           <a
             class="security--nav__list__item__link"
             href="#0"
-            id="security--nav__list__item"
+            id="security--nav__list__item__1"
           >
             Label
           </a>
@@ -447,7 +447,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           <a
             class="security--nav__list__item__link"
             href="#1"
-            id="security--nav__list__item"
+            id="security--nav__list__item__2"
           >
             Label
           </a>
@@ -463,7 +463,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       <a
         class="security--nav__list__item__link"
         href="#2"
-        id="security--nav__list__item"
+        id="security--nav__list__item__3"
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -142,12 +142,12 @@ exports[`Nav Rendering renders correctly 1`] = `
                   className="security--nav__list__item__link"
                   element="a"
                   href="#0"
-                  id={null}
+                  id="security--nav__list__item__1"
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#0"
-                    id={null}
+                    id="security--nav__list__item__1"
                   >
                     Label
                   </a>
@@ -280,12 +280,12 @@ exports[`Nav Rendering renders correctly 1`] = `
                   className="security--nav__list__item__link"
                   element="a"
                   href="#1"
-                  id={null}
+                  id="security--nav__list__item__2"
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#1"
-                    id={null}
+                    id="security--nav__list__item__2"
                   >
                     Label
                   </a>
@@ -323,12 +323,12 @@ exports[`Nav Rendering renders correctly 1`] = `
             className="security--nav__list__item__link"
             element="a"
             href="#2"
-            id={null}
+            id="security--nav__list__item__3"
           >
             <a
               className="security--nav__list__item__link"
               href="#2"
-              id={null}
+              id="security--nav__list__item__3"
             >
               Label
             </a>
@@ -397,6 +397,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           <a
             class="security--nav__list__item__link"
             href="#0"
+            id="security--nav__list__item__1"
           >
             Label
           </a>
@@ -446,6 +447,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           <a
             class="security--nav__list__item__link"
             href="#1"
+            id="security--nav__list__item__2"
           >
             Label
           </a>
@@ -461,6 +463,7 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       <a
         class="security--nav__list__item__link"
         href="#2"
+        id="security--nav__list__item__3"
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -142,12 +142,12 @@ exports[`Nav Rendering renders correctly 1`] = `
                   className="security--nav__list__item__link"
                   element="a"
                   href="#0"
-                  id="security--nav__list__item__1"
+                  id={null}
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#0"
-                    id="security--nav__list__item__1"
+                    id={null}
                   >
                     Label
                   </a>
@@ -280,12 +280,12 @@ exports[`Nav Rendering renders correctly 1`] = `
                   className="security--nav__list__item__link"
                   element="a"
                   href="#1"
-                  id="security--nav__list__item__2"
+                  id={null}
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#1"
-                    id="security--nav__list__item__2"
+                    id={null}
                   >
                     Label
                   </a>
@@ -323,12 +323,12 @@ exports[`Nav Rendering renders correctly 1`] = `
             className="security--nav__list__item__link"
             element="a"
             href="#2"
-            id="security--nav__list__item__3"
+            id={null}
           >
             <a
               className="security--nav__list__item__link"
               href="#2"
-              id="security--nav__list__item__3"
+              id={null}
             >
               Label
             </a>
@@ -397,7 +397,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           <a
             class="security--nav__list__item__link"
             href="#0"
-            id="security--nav__list__item__1"
           >
             Label
           </a>
@@ -447,7 +446,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           <a
             class="security--nav__list__item__link"
             href="#1"
-            id="security--nav__list__item__2"
           >
             Label
           </a>
@@ -463,7 +461,6 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       <a
         class="security--nav__list__item__link"
         href="#2"
-        id="security--nav__list__item__3"
       >
         Label
       </a>

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,17 +1,20 @@
 /**
  * @file Toolbar.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
-import ArrowLeft20 from '@carbon/icons-react/lib/arrow--left/20';
-import Close20 from '@carbon/icons-react/lib/close/20';
-import Help20 from '@carbon/icons-react/lib/help/20';
-import Menu20 from '@carbon/icons-react/lib/menu/20';
-import Settings20 from '@carbon/icons-react/lib/settings/20';
+import {
+  ArrowLeft20,
+  Close20,
+  Help20,
+  Menu20,
+  Settings20,
+} from '@carbon/icons-react';
 
 import classnames from 'classnames';
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
 import { isClient } from '../../globals/utils/capabilities';
 import root from '../../globals/utils/globalRoot';
 
@@ -173,6 +176,7 @@ export default class Toolbar extends Component {
                       }) => (
                         <NavItem
                           key={navigationListItemId}
+                          id={navigationListItemId}
                           href={navigationListItemHref}
                           link={content === undefined}
                           handleItemSelect={() => this.toggleContent(content)}
@@ -192,6 +196,7 @@ export default class Toolbar extends Component {
                 ) : (
                   <NavItem
                     key={navigationItemId}
+                    id={navigationItemId}
                     href={href}
                     link={content === undefined}
                     handleItemSelect={() => this.toggleContent(content)}

--- a/src/components/Toolbar/_mocks_/index.js
+++ b/src/components/Toolbar/_mocks_/index.js
@@ -70,7 +70,6 @@ const applicationsToGenerate = [
   {
     title: 'Section 2',
     icon,
-    id: 'section2Id',
   },
   {
     title: 'Section 3',

--- a/src/components/Toolbar/_mocks_/index.js
+++ b/src/components/Toolbar/_mocks_/index.js
@@ -6,24 +6,16 @@
 import { icon, url, random } from '../../_mocks_';
 import labels from '../locales/en/Toolbar.json';
 
-const externalURL = 'https://www.ibm.com';
-
 /**
  * Generates the initial navigation model.
  */
 const generateNavigationModel = ({
-  content,
-  href,
-  icon,
-  id,
-  title,
+  href = window.location.host + url(random(30)),
+  id = `${random(30)}`,
   ...props
 }) => ({
-  content,
-  href: href || window.location.host + url(random(30)),
-  icon,
-  id: id || `${random(30)}`,
-  title,
+  href,
+  id,
   ...props,
 });
 
@@ -39,22 +31,14 @@ const generateNavigationListModel = (title, navigation) => ({
 /**
  * Generates data for the navigation.
  */
-const generateNavigation = array =>
-  array.map(item =>
-    generateNavigationModel({
-      title: item.title,
-      content: item.content,
-      icon: item.icon,
-      href: item.href,
-    })
-  );
+const generateNavigation = array => array.map(generateNavigationModel);
 
 /**
  * Generates application data for the navigation.
  */
 const generateApplications = array =>
-  array.map(({ children, id, title, content, icon }) => ({
-    ...generateNavigationModel({ title, content, icon, id }),
+  array.map(({ children, ...props }) => ({
+    ...generateNavigationModel(props),
     children,
   }));
 
@@ -115,7 +99,7 @@ const settings = [
   generateNavigationListModel(
     'Legal',
     generateNavigation([
-      { title: 'Privacy', href: externalURL },
+      { title: 'Privacy', href: 'https://www.ibm.com' },
       { title: 'Terms' },
     ])
   ),

--- a/src/components/Toolbar/_mocks_/index.js
+++ b/src/components/Toolbar/_mocks_/index.js
@@ -1,6 +1,6 @@
 /**
  * @file Toolbar mocks.
- * @copyright IBM Security 2018
+ * @copyright IBM Security 2018 - 2020
  */
 
 import { icon, url, random } from '../../_mocks_';
@@ -11,12 +11,20 @@ const externalURL = 'https://www.ibm.com';
 /**
  * Generates the initial navigation model.
  */
-const generateNavigationModel = (title, content, icon, href) => ({
-  id: url(random(30)),
-  title,
+const generateNavigationModel = ({
   content,
+  href,
   icon,
+  id,
+  title,
+  ...props
+}) => ({
+  content,
   href: href || window.location.host + url(random(30)),
+  icon,
+  id: id || `${random(30)}`,
+  title,
+  ...props,
 });
 
 /**
@@ -33,15 +41,20 @@ const generateNavigationListModel = (title, navigation) => ({
  */
 const generateNavigation = array =>
   array.map(item =>
-    generateNavigationModel(item.title, item.content, item.icon, item.href)
+    generateNavigationModel({
+      title: item.title,
+      content: item.content,
+      icon: item.icon,
+      href: item.href,
+    })
   );
 
 /**
  * Generates application data for the navigation.
  */
 const generateApplications = array =>
-  array.map(({ children, title, content, icon }) => ({
-    ...generateNavigationModel(title, content, icon),
+  array.map(({ children, id, title, content, icon }) => ({
+    ...generateNavigationModel({ title, content, icon, id }),
     children,
   }));
 
@@ -57,6 +70,7 @@ const applicationsToGenerate = [
   {
     title: 'Section 2',
     icon,
+    id: 'section2Id',
   },
   {
     title: 'Section 3',

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -5672,7 +5672,7 @@ Map {
       "element": "a",
       "handleItemSelect": null,
       "href": undefined,
-      "id": "security--nav__list__item",
+      "id": null,
       "label": "",
       "link": true,
       "onClick": [Function],


### PR DESCRIPTION
## Affected issues

Resolves #710

## Proposed changes

- Add support for supplying IDs to toolbar navigation items
- Generate `NavItem` instance ID if none is supplied
- Refactor `Toolbar` mocks to be more flexible with props
- Update snapshot tests