### PR TITLE
fix(overflow-menu): add `visually-hidden` dependency

### DIFF
--- a/src/components/OverflowMenu/_index.scss
+++ b/src/components/OverflowMenu/_index.scss
@@ -1,7 +1,8 @@
 ////
 /// Overflow menu component.
 /// @group overflow-menu
-/// @copyright IBM Security 2019
+/// @copyright IBM Security 2019 - 2020
 ////
 
+@import 'carbon-components/scss/globals/scss/css--helpers';
 @import 'carbon-components/scss/components/overflow-menu/overflow-menu';


### PR DESCRIPTION
## Proposed change

Add CSS helpers to `OverflowMenu` styles to accommodate `visually-hidden` dependency when importing the component in isolation (see https://deploy-preview-47--ibm-cloud-paks.netlify.app/?path=/story/security-iconbuttonbar--default and select `OverflowMenu`)