### PR TITLE
feat(search-bar): apply titleText prop for inner multiselect

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -12558,14 +12558,31 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
 }
 
 .security--search-bar__scopes.bx--list-box {
-  flex: 0 0 14rem;
   border: 0;
 }
 
 .security--search-bar__scopes.bx--list-box,
 .security--search-bar__scopes.bx--list-box .bx--list-box__field {
-  height: 100%;
+  height: 3rem;
   max-height: unset;
+}
+
+.security--search-bar .bx--multi-select__wrapper,
+.security--search-bar .bx--search, .security--search-bar__submit {
+  align-self: flex-end;
+}
+
+.security--search-bar--hide-scopes-label .bx--label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
 }
 
 .security--stacked-notification {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -96,7 +96,7 @@ export default class SearchBar extends React.Component {
     titleText: PropTypes.string,
 
     /**
-     * Whether or not the scopes MultiSelecto label is visually hidden.
+     * Whether or not the scopes MultiSelect label is visually hidden.
      */
     hideScopesLabel: PropTypes.bool,
   };

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import Button from '../Button';
 import Search from '../Search';
 import MultiSelect from '../MultiSelect';
@@ -89,6 +89,16 @@ export default class SearchBar extends React.Component {
      * with "selected" items moved to the start of the scope items array.
      */
     sortItems: PropTypes.func, // eslint-disable-line react/require-default-props
+
+    /**
+     * Provide accessible label text for the scopes MultiSelect.
+     */
+    titleText: PropTypes.string,
+
+    /**
+     * Whether or not the scopes MultiSelecto label is visually hidden.
+     */
+    hideScopesLabel: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -99,6 +109,8 @@ export default class SearchBar extends React.Component {
     scopeToString: () => {},
     scopes: [],
     selectedScopes: [],
+    titleText: 'Scopes multiselect',
+    hideScopesLabel: true,
   };
 
   /**
@@ -154,6 +166,7 @@ export default class SearchBar extends React.Component {
       selectedScopes,
       translateWithId,
       sortItems,
+      titleText,
     } = this.props;
 
     if (scopes.length === 0) return null;
@@ -170,6 +183,7 @@ export default class SearchBar extends React.Component {
         itemToString={scopeToString}
         translateWithId={translateWithId}
         sortItems={sortItems}
+        titleText={titleText}
       />
     );
   }
@@ -184,11 +198,16 @@ export default class SearchBar extends React.Component {
       scopes,
       selectedScopes,
       clearButtonLabelText,
+      hideScopesLabel,
     } = this.props;
 
-    const formClassNames = classNames(namespace, className);
     return (
-      <form className={formClassNames} onSubmit={this.handleSubmit}>
+      <form
+        className={classnames(namespace, className, {
+          [`${namespace}--hide-scopes-label`]: hideScopesLabel,
+        })}
+        onSubmit={this.handleSubmit}
+      >
         {this.renderScopeSelector()}
         <Search
           name="search-input"

--- a/src/components/SearchBar/SearchBar.stories.js
+++ b/src/components/SearchBar/SearchBar.stories.js
@@ -4,7 +4,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import React from 'react';
@@ -72,6 +72,7 @@ const storyProps = {
       allSelectedScopesLabel
     ),
     scopeToString: ({ name }) => name,
+    hideScopesLabel: boolean('Hide scopes label (hideScopesLabel)', true),
   }),
   translationIds: {
     'close.menu': 'Close the menu',

--- a/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/SearchBar/__tests__/__snapshots__/SearchBar.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchBar Rendering disables the submit button with no selected scopes 1`] = `
 <form
-  className="security--search-bar"
+  className="security--search-bar security--search-bar--hide-scopes-label"
   onSubmit={[Function]}
 >
   <MultiSelect
@@ -38,6 +38,7 @@ exports[`SearchBar Rendering disables the submit button with no selected scopes 
     selectionFeedback="top-after-reopen"
     sortItems={[Function]}
     title={false}
+    titleText="Scopes multiselect"
     type="default"
   />
   <Search
@@ -67,7 +68,7 @@ exports[`SearchBar Rendering disables the submit button with no selected scopes 
 
 exports[`SearchBar Rendering disables the submit button with no value 1`] = `
 <form
-  className="security--search-bar"
+  className="security--search-bar security--search-bar--hide-scopes-label"
   onSubmit={[Function]}
 >
   <Search
@@ -97,7 +98,7 @@ exports[`SearchBar Rendering disables the submit button with no value 1`] = `
 
 exports[`SearchBar Rendering renders 1`] = `
 <form
-  className="security--search-bar"
+  className="security--search-bar security--search-bar--hide-scopes-label"
   onSubmit={[Function]}
 >
   <Search
@@ -127,7 +128,7 @@ exports[`SearchBar Rendering renders 1`] = `
 
 exports[`SearchBar Rendering renders an initial value 1`] = `
 <form
-  className="security--search-bar"
+  className="security--search-bar security--search-bar--hide-scopes-label"
   onSubmit={[Function]}
 >
   <Search
@@ -157,7 +158,7 @@ exports[`SearchBar Rendering renders an initial value 1`] = `
 
 exports[`SearchBar Rendering renders scopes 1`] = `
 <form
-  className="security--search-bar"
+  className="security--search-bar security--search-bar--hide-scopes-label"
   onSubmit={[Function]}
 >
   <MultiSelect
@@ -193,6 +194,7 @@ exports[`SearchBar Rendering renders scopes 1`] = `
     selectionFeedback="top-after-reopen"
     sortItems={[Function]}
     title={false}
+    titleText="Scopes multiselect"
     type="default"
   />
   <Search
@@ -222,7 +224,7 @@ exports[`SearchBar Rendering renders scopes 1`] = `
 
 exports[`SearchBar Rendering renders selected scopes 1`] = `
 <form
-  className="security--search-bar"
+  className="security--search-bar security--search-bar--hide-scopes-label"
   onSubmit={[Function]}
 >
   <MultiSelect
@@ -265,6 +267,7 @@ exports[`SearchBar Rendering renders selected scopes 1`] = `
     selectionFeedback="top-after-reopen"
     sortItems={[Function]}
     title={false}
+    titleText="Scopes multiselect"
     type="default"
   />
   <Search

--- a/src/components/SearchBar/_index.scss
+++ b/src/components/SearchBar/_index.scss
@@ -4,7 +4,7 @@
 /// @copyright IBM Security 2019
 ////
 
-@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/spacing';
 @import '@carbon/themes/scss/tokens';
 
 @import 'carbon-components/scss/globals/scss/vars';
@@ -19,13 +19,31 @@
   display: flex;
 
   &__scopes.#{$prefix}--list-box {
-    flex: 0 0 carbon--mini-units(28);
     border: 0;
 
     &,
     .#{$prefix}--list-box__field {
-      height: 100%;
+      height: $carbon--layout-04;
       max-height: unset;
     }
+  }
+
+  .#{$prefix}--multi-select__wrapper,
+  .#{$prefix}--search,
+  &__submit {
+    align-self: flex-end;
+  }
+
+  &--hide-scopes-label .#{$prefix}--label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    border: 0;
+    visibility: inherit;
+    clip: rect(0, 0, 0, 0);
   }
 }

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -7165,11 +7165,13 @@ Map {
   "SearchBar" => Object {
     "defaultProps": Object {
       "className": "",
+      "hideScopesLabel": true,
       "onChange": [Function],
       "onSubmit": [Function],
       "scopeToString": [Function],
       "scopes": Array [],
       "selectedScopes": Array [],
+      "titleText": "Scopes multiselect",
       "value": "",
     },
     "propTypes": Object {
@@ -7179,6 +7181,9 @@ Map {
       "clearButtonLabelText": Object {
         "isRequired": true,
         "type": "string",
+      },
+      "hideScopesLabel": Object {
+        "type": "bool",
       },
       "labelText": Object {
         "isRequired": true,
@@ -7239,6 +7244,9 @@ Map {
       },
       "submitLabel": Object {
         "isRequired": true,
+        "type": "string",
+      },
+      "titleText": Object {
         "type": "string",
       },
       "translateWithId": Object {


### PR DESCRIPTION
## Affected issues

- Resolves #722 

## Proposed changes

- add `titleText` prop to provide label for inner `MultiSelect` (the generated `<label>` element is then tied to ARIA attributes in generated markup)
- add `hideScopesLabel` boolean prop to allow you to visually hide the generated `MultiSelect` label while still maintaining the ARIA attributes. NOTE: set to `true` by default for compatibility with existing implementations in product.

## Testing instructions

- pull down branch and experiment with turning `hideScopesLabel` on/off, inspect the ARIA attributes, etc.
