### PR TITLE
fix(header): remove footer element from popover

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -373,7 +373,7 @@ export default class Header extends Component {
           </span>
         )}
 
-        <footer className={`${namespace}__popover__footer`}>
+        <div className={`${namespace}__popover__footer`}>
           {links.notifications_view_all && (
             <HeaderPopoverLinkSecondary href={links.notifications_view_all}>
               {labels.notifications.link}{' '}
@@ -387,7 +387,7 @@ export default class Header extends Component {
               title={labels.notifications.preferences || ''}
             />
           )}
-        </footer>
+        </div>
       </div>,
       isActive.notifications
     );

--- a/src/components/Panel/PanelContainer.js
+++ b/src/components/Panel/PanelContainer.js
@@ -218,7 +218,7 @@ export default class PanelContainer extends Component {
           {children}
         </section>
         {hasFooter && (
-          <footer ref={this.footer} className={`${namespace}__footer`}>
+          <div ref={this.footer} className={`${namespace}__footer`}>
             {renderFooter ? (
               renderFooter()
             ) : (
@@ -248,7 +248,7 @@ export default class PanelContainer extends Component {
                 </Button>
               </Fragment>
             )}
-          </footer>
+          </div>
         )}
       </div>
     );


### PR DESCRIPTION
## Affected issues

- Resolves #717

## Proposed changes

- Removes `footer` element from `Header` component notifications popover, since the content there is not contained within a specific sectioning element + the content is not particularly ["footer-like" according to the spec](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-footer-element.html).

## Testing instructions

- double-check that the `Header` component's notification popover still looks good 👍 
