### PR TITLE
fix(nav-item): add `tabindex` to link

### DIFF
--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -3,16 +3,16 @@
  * @copyright IBM Security 2019 - 2020
  */
 
-import Launch16 from '@carbon/icons-react/lib/launch/16';
+import { Launch16 } from '@carbon/icons-react';
 
 import classnames from 'classnames';
 import { bool, elementType, func, node, number, string } from 'prop-types';
 import React, { Component } from 'react';
-import NavItemLink from '../NavItemLink';
-
-import Icon from '../../Icon';
 
 import { getComponentNamespace } from '../../../globals/namespace';
+
+import Icon from '../../Icon';
+import NavItemLink from '../NavItemLink';
 
 export const namespace = getComponentNamespace('nav__list__item');
 
@@ -124,9 +124,12 @@ export default class NavItem extends Component {
       target: '_blank',
     };
 
-    const handleDisabled = action => (!disabled ? action : null);
+    const handleDisabled = (action, defaultValue = null) =>
+      !disabled ? action : defaultValue;
 
     const linkClassName = `${namespace}__link`;
+
+    const navItemTabIndex = handleDisabled(tabIndex, -1);
 
     return (
       <li
@@ -135,7 +138,6 @@ export default class NavItem extends Component {
         onClick={event => handleDisabled(onClick(event, href))}
         onKeyPress={event => handleDisabled(onClick(event, href))}
         role="menuitem"
-        tabIndex={handleDisabled(children ? -1 : tabIndex)}
       >
         {link ? (
           <NavItemLink
@@ -145,6 +147,7 @@ export default class NavItem extends Component {
             })}
             element={element}
             href={href}
+            tabIndex={navItemTabIndex}
             {...other}
             {...externalLinkProps}
           >
@@ -163,7 +166,7 @@ export default class NavItem extends Component {
             onClick={handleDisabled(handleItemSelect)}
             onKeyPress={handleDisabled(handleItemSelect)}
             role="menuitem"
-            tabIndex={handleDisabled(tabIndex)}
+            tabIndex={navItemTabIndex}
           >
             {children}
           </div>

--- a/src/components/Nav/NavItem/__tests__/NavItem.spec.js
+++ b/src/components/Nav/NavItem/__tests__/NavItem.spec.js
@@ -1,6 +1,6 @@
 /**
  * @file Navigation item tests.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import { shallow } from 'enzyme';
@@ -37,11 +37,6 @@ describe('NavItem', () => {
 
     it("renders the HTML of the node's subtree", () => {
       expect(navigationItem.render()).toMatchSnapshot();
-    });
-
-    it('renders with correct `tabIndex` when there are no children', () => {
-      navigationItem.setProps({ children: null });
-      expect(navigationItem.prop('tabIndex')).toEqual(0);
     });
   });
 

--- a/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Nav/NavItem/__tests__/__snapshots__/NavItem.spec.js.snap
@@ -7,13 +7,13 @@ exports[`NavItem Rendering renders correctly 1`] = `
   onClick={[Function]}
   onKeyPress={[Function]}
   role="menuitem"
-  tabIndex={-1}
 >
   <NavItemLink
     className="security--nav__list__item__link"
     element="a"
     href="#"
     id="security--nav__list__item"
+    tabIndex={0}
   >
     Label
   </NavItemLink>
@@ -25,12 +25,12 @@ exports[`NavItem Rendering renders the HTML of the node's subtree 1`] = `
   class="security--nav__list__item class security--nav__list__item--active"
   label=""
   role="menuitem"
-  tabindex="-1"
 >
   <a
     class="security--nav__list__item__link"
     href="#"
     id="security--nav__list__item"
+    tabindex="0"
   >
     Label
   </a>

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList.spec.js.snap
@@ -117,18 +117,19 @@ exports[`Nav Rendering renders correctly 1`] = `
           onClick={[Function]}
           onKeyPress={[Function]}
           role="menuitem"
-          tabIndex={-1}
         >
           <NavItemLink
             className="security--nav__list__item__link"
             element="a"
             href="#"
             id="security--nav__list__item"
+            tabIndex={0}
           >
             <a
               className="security--nav__list__item__link"
               href="#"
               id="security--nav__list__item"
+              tabIndex={0}
             >
               Label
             </a>
@@ -179,12 +180,12 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       class="security--nav__list__item security--nav__list__item--active"
       label=""
       role="menuitem"
-      tabindex="-1"
     >
       <a
         class="security--nav__list__item__link"
         href="#"
         id="security--nav__list__item"
+        tabindex="0"
       >
         Label
       </a>

--- a/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav.spec.js.snap
@@ -136,18 +136,19 @@ exports[`Nav Rendering renders correctly 1`] = `
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="menuitem"
-                tabIndex={-1}
               >
                 <NavItemLink
                   className="security--nav__list__item__link"
                   element="a"
                   href="#0"
                   id="security--nav__list__item"
+                  tabIndex={-1}
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#0"
                     id="security--nav__list__item"
+                    tabIndex={-1}
                   >
                     Label
                   </a>
@@ -274,18 +275,19 @@ exports[`Nav Rendering renders correctly 1`] = `
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="menuitem"
-                tabIndex={-1}
               >
                 <NavItemLink
                   className="security--nav__list__item__link"
                   element="a"
                   href="#1"
                   id="security--nav__list__item"
+                  tabIndex={-1}
                 >
                   <a
                     className="security--nav__list__item__link"
                     href="#1"
                     id="security--nav__list__item"
+                    tabIndex={-1}
                   >
                     Label
                   </a>
@@ -317,18 +319,19 @@ exports[`Nav Rendering renders correctly 1`] = `
           onClick={[Function]}
           onKeyPress={[Function]}
           role="menuitem"
-          tabIndex={-1}
         >
           <NavItemLink
             className="security--nav__list__item__link"
             element="a"
             href="#2"
             id="security--nav__list__item"
+            tabIndex={0}
           >
             <a
               className="security--nav__list__item__link"
               href="#2"
               id="security--nav__list__item"
+              tabIndex={0}
             >
               Label
             </a>
@@ -392,12 +395,12 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           class="security--nav__list__item"
           label=""
           role="menuitem"
-          tabindex="-1"
         >
           <a
             class="security--nav__list__item__link"
             href="#0"
             id="security--nav__list__item"
+            tabindex="-1"
           >
             Label
           </a>
@@ -442,12 +445,12 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
           class="security--nav__list__item"
           label=""
           role="menuitem"
-          tabindex="-1"
         >
           <a
             class="security--nav__list__item__link"
             href="#1"
             id="security--nav__list__item"
+            tabindex="-1"
           >
             Label
           </a>
@@ -458,12 +461,12 @@ exports[`Nav Rendering renders the HTML of the node's subtree 1`] = `
       class="security--nav__list__item"
       label=""
       role="menuitem"
-      tabindex="-1"
     >
       <a
         class="security--nav__list__item__link"
         href="#2"
         id="security--nav__list__item"
+        tabindex="0"
       >
         Label
       </a>


### PR DESCRIPTION
## Proposed change

- Add `tabindex` to link `NavItemLink` to prevent tabbing while `NavList` is open
- Remove `tabindex` unit test as the `NavItem` should always have `children`
- Update snapshot tests