### PR TITLE
fix(resize-observer): allow library handle ponyfill

### DIFF
--- a/src/components/ScrollGradient/ScrollGradient.js
+++ b/src/components/ScrollGradient/ScrollGradient.js
@@ -7,6 +7,8 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+// https://www.npmjs.com/package/resize-observer-polyfill
+import ResizeObserver from 'resize-observer-polyfill';
 import { throttle } from 'throttle-debounce';
 
 import { getComponentNamespace } from '../../globals/namespace';
@@ -15,10 +17,6 @@ import { isClient } from '../../globals/utils/capabilities';
 export const namespace = getComponentNamespace('scroll-gradient');
 
 const scrollDirection = { X: 'X', Y: 'Y' };
-
-// Checks if the native version is available and switch between this and the polyfill to improve performance on browsers with native support - https://www.npmjs.com/package/resize-observer-polyfill
-const ResizeObserver =
-  (isClient() && window.ResizeObserver) || require('resize-observer-polyfill');
 
 class ScrollGradient extends Component {
   static propTypes = {


### PR DESCRIPTION
## Proposed change

`resize-observer-polyfill` already checks for the native implementation of `ResizeObserver`, so this change enables it to handle that for us instead