### PR TITLE
feat(wizard): add prop to provide accessible label to nav

### DIFF
--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -247,6 +247,7 @@ class Wizard extends Component {
       title,
       subTitle,
       className,
+      navLabel, // avoid spreading with rest of props.
       ...other
     } = this.props;
     const componentLabels = {

--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -209,7 +209,7 @@ class Wizard extends Component {
     const { currentStep, valid } = this.state;
 
     return !this.sequentialMode ? (
-      <Nav label="">
+      <Nav label={this.props.navLabel}>
         {this.steps.map(({ title }, index) => (
           <NavItem
             key={title}
@@ -395,6 +395,9 @@ Wizard.propTypes = {
 
   /** Optional class name for the wrapper node. */
   className: PropTypes.string,
+
+  /** Provide an accessible label that describes the Wizard sidebar navigation. */
+  navLabel: PropTypes.string,
 };
 
 Wizard.defaultProps = {
@@ -410,6 +413,7 @@ Wizard.defaultProps = {
   onDelete: () => Promise.resolve(),
   isSequential: undefined,
   labels: {},
+  navLabel: 'Steps navigation',
 };
 
 export default Wizard;

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -12556,6 +12556,7 @@ Map {
       "isOpen": undefined,
       "isSequential": undefined,
       "labels": Object {},
+      "navLabel": "Steps navigation",
       "onClose": [Function],
       "onDelete": [Function],
       "rootNode": <body />,
@@ -12604,6 +12605,9 @@ Map {
           },
         ],
         "type": "objectOf",
+      },
+      "navLabel": Object {
+        "type": "string",
       },
       "onClose": Object {
         "type": "func",


### PR DESCRIPTION
## Affected issues

- Resolves #737

## Proposed changes

- adds `navLabel` prop with a default value "Steps navigation", to provide an accessible label to the inner `Nav` component. "Steps navigation" versus "Wizard navigation" because "Wizard" is more of a UI dev/design term, and this label is meant to be understood by users.

## Testing instructions

- verify the nav markup has a valid `aria-label` attribute in the "Editable Wizard" variation: https://deploy-preview-738--ibm-security.netlify.app/?path=/story/patterns-wizard--with-editable-wizard
