### PR TITLE
fix(scroll-gradient): add immediate child combinator to prevent overw…

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -7649,33 +7649,33 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
   z-index: 1;
 }
 
-.security--scroll-gradient--x .security--scroll-gradient__before,
-.security--scroll-gradient--x .security--scroll-gradient__after {
+.security--scroll-gradient--x > .security--scroll-gradient__before,
+.security--scroll-gradient--x > .security--scroll-gradient__after {
   top: 0;
   width: 3rem;
   height: 100%;
 }
 
-.security--scroll-gradient--x .security--scroll-gradient__before {
+.security--scroll-gradient--x > .security--scroll-gradient__before {
   left: 0;
 }
 
-.security--scroll-gradient--x .security--scroll-gradient__after {
+.security--scroll-gradient--x > .security--scroll-gradient__after {
   right: 0;
 }
 
-.security--scroll-gradient--y .security--scroll-gradient__before,
-.security--scroll-gradient--y .security--scroll-gradient__after {
+.security--scroll-gradient--y > .security--scroll-gradient__before,
+.security--scroll-gradient--y > .security--scroll-gradient__after {
   left: 0;
   height: 3rem;
   width: 100%;
 }
 
-.security--scroll-gradient--y .security--scroll-gradient__before {
+.security--scroll-gradient--y > .security--scroll-gradient__before {
   top: 0;
 }
 
-.security--scroll-gradient--y .security--scroll-gradient__after {
+.security--scroll-gradient--y > .security--scroll-gradient__after {
   bottom: 0;
 }
 

--- a/src/components/ScrollGradient/_index.scss
+++ b/src/components/ScrollGradient/_index.scss
@@ -42,7 +42,7 @@
     z-index: 1;
   }
 
-  &--x {
+  &--x > {
     #{$block}__before,
     #{$block}__after {
       top: 0;
@@ -59,7 +59,7 @@
     }
   }
 
-  &--y {
+  &--y > {
     #{$block}__before,
     #{$block}__after {
       left: 0;


### PR DESCRIPTION
## Affected issues

- Resolves #756 

## Proposed changes

- Add the immediate child combinator (`>`) so that `.security--scroll-gradient--y` and `.security--scroll-gradient--x` only target the direct `.security--scroll-gradient__before` and `.security--scroll-gradient__after` children elements and not those further down the DOM 

## Testing instructions

- I've just tested the css output (built using `yarn build`) on my [sandbox](https://codesandbox.io/s/nervous-pare-09he9?file=/src/index.js) and it works but perhaps there's a better way of validating these kinds of changes?
