### PR TITLE
feat(summary-card-skeleton): add `className`, spread props

### DIFF
--- a/src/components/SummaryCard/SummaryCardSkeleton/SummaryCardSkeleton.js
+++ b/src/components/SummaryCard/SummaryCardSkeleton/SummaryCardSkeleton.js
@@ -1,14 +1,16 @@
 /**
  * @file Summary card skeleton.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
+import classnames from 'classnames';
+import { string } from 'prop-types';
 import React from 'react';
 
 import { getComponentNamespace } from '../../../globals/namespace/index';
 
-import Card from '..';
 import SkeletonText from '../../SkeletonText';
+import Card from '..';
 
 const namespace = getComponentNamespace('summary-card--skeleton');
 
@@ -20,8 +22,8 @@ const WIDTHS = {
 
 const { sm, md, lg } = WIDTHS;
 
-const SummaryCardSkeleton = () => (
-  <Card className={namespace}>
+const SummaryCardSkeleton = ({ className, ...other }) => (
+  <Card className={classnames(namespace, className)} {...other}>
     <SkeletonText width={sm} />
     <SkeletonText width={sm} heading />
     <SkeletonText width={md} />
@@ -34,5 +36,13 @@ const SummaryCardSkeleton = () => (
     </div>
   </Card>
 );
+
+SummaryCardSkeleton.propTypes = {
+  className: string,
+};
+
+SummaryCardSkeleton.defaultProps = {
+  className: null,
+};
 
 export default SummaryCardSkeleton;

--- a/src/components/SummaryCard/SummaryCardSkeleton/SummaryCardSkeleton.js
+++ b/src/components/SummaryCard/SummaryCardSkeleton/SummaryCardSkeleton.js
@@ -38,6 +38,7 @@ const SummaryCardSkeleton = ({ className, ...other }) => (
 );
 
 SummaryCardSkeleton.propTypes = {
+  /** Provide an optional class to be applied to the containing node */
   className: string,
 };
 

--- a/src/components/SummaryCard/SummaryCardSkeleton/__tests__/SummaryCardSkeleton.spec.js
+++ b/src/components/SummaryCard/SummaryCardSkeleton/__tests__/SummaryCardSkeleton.spec.js
@@ -3,6 +3,7 @@
  * @copyright IBM Security 2020
  */
 
+import { render } from '@testing-library/react';
 import React from 'react';
 import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
 
@@ -11,7 +12,28 @@ import { SummaryCardSkeleton } from '../../../..';
 describe('SummaryCardSkeleton', () => {
   test('should have no Axe or DAP violations', async () => {
     const { container } = renderWithinLandmark(<SummaryCardSkeleton />);
+
     await expect(container).toHaveNoAxeViolations();
     await expect(container).toHaveNoDAPViolations('SummaryCardSkeleton');
+  });
+
+  test('adds a class to the containing node', () => {
+    const className = 'className';
+
+    expect(
+      render(
+        <SummaryCardSkeleton className={className} />
+      ).container.querySelector(`.${className}`)
+    ).toBeInTheDocument();
+  });
+
+  test('adds additional props to the containing node', () => {
+    const dataTestId = 'dataTestId';
+
+    expect(
+      render(<SummaryCardSkeleton data-testid={dataTestId} />).getByTestId(
+        dataTestId
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -9186,7 +9186,16 @@ Map {
       },
     },
   },
-  "SummaryCardSkeleton" => Object {},
+  "SummaryCardSkeleton" => Object {
+    "defaultProps": Object {
+      "className": null,
+    },
+    "propTypes": Object {
+      "className": Object {
+        "type": "string",
+      },
+    },
+  },
   "Switch" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {


### PR DESCRIPTION
## Affected issue

Resolves #760 

## Proposed change

Add `className` and optional props to `SummaryCardSkeleton`