### PR TITLE
fix(StatusIcon): add aria label to icons

### DIFF
--- a/src/components/StatusIcon/StatusIcon.js
+++ b/src/components/StatusIcon/StatusIcon.js
@@ -37,6 +37,9 @@ export default class StatusIcon extends Component {
 
     /** @type {string} Status. */
     status: oneOf(STATUS),
+
+    /** @type {string} icon aria label. */
+    iconLabel: string,
   };
 
   static defaultProps = {
@@ -44,6 +47,7 @@ export default class StatusIcon extends Component {
     message: null,
     size: defaultSize,
     status: undefined,
+    iconLabel: null,
   };
 
   static getDerivedStateFromProps({ status }, state) {
@@ -59,7 +63,7 @@ export default class StatusIcon extends Component {
   };
 
   render() {
-    const { className, message, size } = this.props;
+    const { className, message, size, iconLabel } = this.props;
     const { status } = this.state;
 
     let statusIcon;
@@ -68,6 +72,7 @@ export default class StatusIcon extends Component {
       case STATUS[0]:
         statusIcon = (
           <Icon
+            aria-label={iconLabel && iconLabel.length ? iconLabel : null}
             className={`${namespace}__icon ${namespace}__icon--success`}
             renderIcon={Checkmark20}
           />
@@ -76,13 +81,18 @@ export default class StatusIcon extends Component {
 
       case undefined:
         statusIcon = (
-          <Loading className={`${namespace}__icon`} withOverlay={false} />
+          <Loading
+            aria-label={iconLabel && iconLabel.length ? iconLabel : null}
+            className={`${namespace}__icon`}
+            withOverlay={false}
+          />
         );
         break;
 
       default:
         statusIcon = (
           <span
+            aria-label={iconLabel && iconLabel.length ? iconLabel : null}
             className={`${namespace}__icon--color ${namespace}__icon--color--${status}`}
           />
         );

--- a/src/components/StatusIcon/StatusIcon.js
+++ b/src/components/StatusIcon/StatusIcon.js
@@ -39,7 +39,7 @@ export default class StatusIcon extends Component {
     status: oneOf(STATUS),
 
     /** @type {string} icon aria label. */
-    iconLabel: string,
+    iconDescription: string,
   };
 
   static defaultProps = {
@@ -47,7 +47,7 @@ export default class StatusIcon extends Component {
     message: null,
     size: defaultSize,
     status: undefined,
-    iconLabel: null,
+    iconDescription: null,
   };
 
   static getDerivedStateFromProps({ status }, state) {
@@ -63,7 +63,7 @@ export default class StatusIcon extends Component {
   };
 
   render() {
-    const { className, message, size, iconLabel } = this.props;
+    const { className, message, size, iconDescription } = this.props;
     const { status } = this.state;
 
     let statusIcon;
@@ -72,7 +72,9 @@ export default class StatusIcon extends Component {
       case STATUS[0]:
         statusIcon = (
           <Icon
-            aria-label={iconLabel && iconLabel.length ? iconLabel : null}
+            aria-label={
+              iconDescription && iconDescription.length ? iconDescription : null
+            }
             className={`${namespace}__icon ${namespace}__icon--success`}
             renderIcon={Checkmark20}
           />
@@ -82,7 +84,9 @@ export default class StatusIcon extends Component {
       case undefined:
         statusIcon = (
           <Loading
-            aria-label={iconLabel && iconLabel.length ? iconLabel : null}
+            aria-label={
+              iconDescription && iconDescription.length ? iconDescription : null
+            }
             className={`${namespace}__icon`}
             withOverlay={false}
           />
@@ -92,7 +96,9 @@ export default class StatusIcon extends Component {
       default:
         statusIcon = (
           <span
-            aria-label={iconLabel && iconLabel.length ? iconLabel : null}
+            aria-label={
+              iconDescription && iconDescription.length ? iconDescription : null
+            }
             className={`${namespace}__icon--color ${namespace}__icon--color--${status}`}
           />
         );

--- a/src/components/StatusIcon/StatusIcon.stories.js
+++ b/src/components/StatusIcon/StatusIcon.stories.js
@@ -17,6 +17,7 @@ import { SIZE, STATUS } from './StatusIcon';
 const storyProps = () => ({
   message: text('Label (message)', 'Label'),
   size: select('Size (size)', SIZE, StatusIcon.defaultProps.size),
+  iconLabel: text('Icon ARIA label', 'Icon description.. '),
 });
 
 const status = STATUS[0];

--- a/src/components/StatusIcon/StatusIcon.stories.js
+++ b/src/components/StatusIcon/StatusIcon.stories.js
@@ -17,7 +17,7 @@ import { SIZE, STATUS } from './StatusIcon';
 const storyProps = () => ({
   message: text('Label (message)', 'Label'),
   size: select('Size (size)', SIZE, StatusIcon.defaultProps.size),
-  iconLabel: text('Icon ARIA label', 'Icon description.. '),
+  iconDescription: text('Icon ARIA label', 'Icon description.. '),
 });
 
 const status = STATUS[0];

--- a/src/components/StatusIcon/__tests__/StatusIcon.spec.js
+++ b/src/components/StatusIcon/__tests__/StatusIcon.spec.js
@@ -75,4 +75,11 @@ describe('StatusIcon', () => {
     const { queryByText } = render(<StatusIcon message="test message" />);
     expect(queryByText(/test message/i)).toBeVisible();
   });
+
+  test('should add an aria label', () => {
+    const { queryByLabelText } = render(
+      <StatusIcon iconLabel="has aria" message="test message" />
+    );
+    expect(queryByLabelText(/has aria/i)).toBeVisible();
+  });
 });

--- a/src/components/StatusIcon/__tests__/StatusIcon.spec.js
+++ b/src/components/StatusIcon/__tests__/StatusIcon.spec.js
@@ -78,7 +78,7 @@ describe('StatusIcon', () => {
 
   test('should add an aria label', () => {
     const { queryByLabelText } = render(
-      <StatusIcon iconLabel="has aria" message="test message" />
+      <StatusIcon iconDescription="has aria" message="test message" />
     );
     expect(queryByLabelText(/has aria/i)).toBeVisible();
   });

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -8686,6 +8686,9 @@ Map {
       "className": Object {
         "type": "string",
       },
+      "iconLabel": Object {
+        "type": "string",
+      },
       "message": Object {
         "type": "string",
       },

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -8678,6 +8678,7 @@ Map {
   "StatusIcon" => Object {
     "defaultProps": Object {
       "className": null,
+      "iconLabel": null,
       "message": null,
       "size": "md",
       "status": undefined,

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -8678,7 +8678,7 @@ Map {
   "StatusIcon" => Object {
     "defaultProps": Object {
       "className": null,
-      "iconLabel": null,
+      "iconDescription": null,
       "message": null,
       "size": "md",
       "status": undefined,
@@ -8687,7 +8687,7 @@ Map {
       "className": Object {
         "type": "string",
       },
-      "iconLabel": Object {
+      "iconDescription": Object {
         "type": "string",
       },
       "message": Object {


### PR DESCRIPTION
## Affected issues

- Resolves #764 

## Proposed changes

- adds an aria label to the icon to allow for status accessibility 
https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html

## Testing instructions

- check preview knob and inspect the element
