### PR TITLE
fix(toolbar): add default values for compatibility

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -218,8 +218,17 @@ export default class Toolbar extends Component {
   }
 
   render() {
-    const { className, labels, renderAddons = [] } = this.props;
-    const { menu, settings, support, mainNavigation } = labels;
+    const {
+      className,
+      labels: {
+        mainNavigation: { ariaLabel = null } = {},
+        menu,
+        settings,
+        support,
+      },
+      renderAddons = [],
+    } = this.props;
+
     const classes = classnames(namespace, className);
     const { isActive } = this.state;
     const activeItems = Object.entries(isActive)
@@ -233,14 +242,7 @@ export default class Toolbar extends Component {
 
     return (
       <div ref={this.wrapper}>
-        <nav
-          aria-label={
-            mainNavigation.ariaLabel && mainNavigation.ariaLabel.length
-              ? mainNavigation.ariaLabel
-              : null
-          }
-          className={classes}
-        >
+        <nav aria-label={ariaLabel} className={classes}>
           <ul className={`${namespace}__group`}>
             <li>{this.toggleIcon(menu.button, Menu20, 'menu')}</li>
             <li>{this.toggleIcon(settings.button, Settings20, 'settings')}</li>
@@ -346,6 +348,12 @@ Toolbar.propTypes = {
 
   /** @type {Object<Object.Object>} An object list of labels. */
   labels: PropTypes.shape({
+    /** @type {Object.<string, string>} An object list of navigation labels for the top level navigation item. */
+    mainNavigation: PropTypes.shape({
+      /** Specify the `aria-label` for the primary navigation */
+      ariaLabel: PropTypes.string.isRequired,
+    }).isRequired,
+
     /** @type {Object.<string, string>} An object list of menu labels. */
     menu: PropTypes.shape({
       /** @type {string} The button label. */
@@ -371,12 +379,6 @@ Toolbar.propTypes = {
 
       /** @type {string} The tooltip label. */
       tooltip: PropTypes.string,
-    }).isRequired,
-
-    /** @type {Object.<string, string>} An object list of navigation labels for the top level navigation item. */
-    mainNavigation: PropTypes.shape({
-      /** @type {string} Adds an aria label to the primary navigation */
-      ariaLabel: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
 


### PR DESCRIPTION
## Proposed change

Add default value for `Toolbar` `mainNavigation` and `ariaLabel` as otherwise causes rendering to crash

![Toolbar](https://user-images.githubusercontent.com/3846874/95442395-3b7e4a80-0953-11eb-86ed-2bdc1e72b360.png)