### PR TITLE
fix(nav): correctly apply `onClick` handlers, spread `Toolbar` props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ibm-security",
-  "version": "1.34.0-prerelease.10",
+  "version": "1.34.0-prerelease.11",
   "description": "Carbon for IBM Security",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -3,15 +3,14 @@
  * @copyright IBM Security 2019 - 2020
  */
 
-import React, { Children, Component } from 'react';
-import { node, string } from 'prop-types';
 import classnames from 'classnames';
+import { node, string } from 'prop-types';
+import React, { Children, Component } from 'react';
 
-import NavList from './NavList';
 import NavItem, { namespace as navItemNamespace } from './NavItem/NavItem';
+import NavList from './NavList';
 
 import window from '../../globals/utils/globalRoot';
-
 import { getComponentNamespace } from '../../globals/namespace';
 
 export const navNamespace = getComponentNamespace('nav');
@@ -61,7 +60,9 @@ export default class Nav extends Component {
         {...props}
         activeHref={this.state.activeHref}
         key={key}
-        onClick={this.handleItemClick}
+        onClick={(event, href) => {
+          this.handleItemClick(event, href, props.onClick);
+        }}
       />
     );
   }
@@ -95,7 +96,7 @@ export default class Nav extends Component {
    * @param {SyntheticEvent} event The event fired when the list item is toggled.
    * @param {string} activeHref The URL of the list item.
    */
-  handleItemClick(event, activeHref) {
+  handleItemClick(event, activeHref, onClick) {
     event.stopPropagation();
 
     const { type, which } = event;
@@ -106,6 +107,10 @@ export default class Nav extends Component {
     const diffHref = activeHref !== this.state.activeHref;
     if (acceptableEvent && diffHref) {
       this.setState({ activeHref });
+    }
+
+    if (onClick) {
+      onClick(event);
     }
   }
 

--- a/src/components/Nav/Nav.stories.js
+++ b/src/components/Nav/Nav.stories.js
@@ -16,7 +16,7 @@ storiesOf(components(name), module).add(
   'Default',
   () => (
     <div style={{ width: '300px' }}>
-      <Nav heading="Nav example" label="Nav">
+      <Nav heading="Nav example" label={Nav}>
         <NavList title="Nav list 1">
           <NavItem key="navitem_1-1" element="span" customprop="uniqueValue">
             Nav item 1-1 (with a custom element)

--- a/src/components/Nav/Nav.stories.js
+++ b/src/components/Nav/Nav.stories.js
@@ -1,16 +1,19 @@
 /**
  * @file Navigation stories.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
-import React from 'react';
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 
 import { components } from '../../../.storybook';
 import { Nav, NavItem, NavList } from '../..';
 
-storiesOf(components('Nav'), module).add(
-  'default',
+const { name } = Nav;
+
+storiesOf(components(name), module).add(
+  'Default',
   () => (
     <div style={{ width: '300px' }}>
       <Nav heading="Nav example" label="Nav">
@@ -18,7 +21,7 @@ storiesOf(components('Nav'), module).add(
           <NavItem key="navitem_1-1" element="span" customprop="uniqueValue">
             Nav item 1-1 (with a custom element)
           </NavItem>
-          <NavItem key="navitem_1-2" href="#navitem_1-2">
+          <NavItem key="navitem_1-2" onClick={action('onClick')}>
             Nav item 1-2
           </NavItem>
         </NavList>
@@ -43,9 +46,7 @@ storiesOf(components('Nav'), module).add(
   ),
   {
     info: {
-      text: `
-          Basic implementation of a Nav component.
-        `,
+      text: `Basic implementation of the '${name}' component.`,
     },
   }
 );

--- a/src/components/Nav/NavList/NavList.js
+++ b/src/components/Nav/NavList/NavList.js
@@ -1,17 +1,17 @@
 /**
  * @file Navigation list class.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import ChevronDown16 from '@carbon/icons-react/lib/chevron--down/16';
 
-import React, { Component } from 'react';
-import { bool, func, node, number, string } from 'prop-types';
 import classnames from 'classnames';
-
-import Icon from '../../Icon';
+import { bool, func, node, number, string } from 'prop-types';
+import React, { Component } from 'react';
 
 import { getComponentNamespace } from '../../../globals/namespace';
+
+import Icon from '../../Icon';
 import NavItem, { namespace as navItemNamespace } from '../NavItem/NavItem';
 
 export const navListNamespace = getComponentNamespace('nav__list');
@@ -50,11 +50,19 @@ export default class NavList extends Component {
   buildNewItemChild({ props }, index) {
     const { onItemClick, activeHref } = this.props;
 
+    const { onClick } = props;
+
     return (
       <NavItem
         {...props}
         key={`${navItemNamespace}--${index}`}
-        onClick={onItemClick}
+        onClick={(event, href) => {
+          onItemClick(event, href);
+
+          if (onClick) {
+            onClick(event, href);
+          }
+        }}
         activeHref={activeHref}
         tabIndex={this.state.open ? 0 : -1}
       />

--- a/src/components/Nav/NavList/NavList.js
+++ b/src/components/Nav/NavList/NavList.js
@@ -60,7 +60,7 @@ export default class NavList extends Component {
           onItemClick(event, href);
 
           if (onClick) {
-            onClick(event, href);
+            onClick(event);
           }
         }}
         activeHref={activeHref}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -163,6 +163,7 @@ export default class Toolbar extends Component {
                 icon,
                 id: navigationItemId,
                 title: navigationItemTitle,
+                ...props
               }) =>
                 children ? (
                   <NavList key={navigationItemId} title={navigationItemTitle}>
@@ -173,6 +174,7 @@ export default class Toolbar extends Component {
                         icon,
                         id: navigationListItemId,
                         title: navigationListItemTitle,
+                        ...props
                       }) => (
                         <NavItem
                           key={navigationListItemId}
@@ -180,6 +182,7 @@ export default class Toolbar extends Component {
                           href={navigationListItemHref}
                           link={content === undefined}
                           handleItemSelect={() => this.toggleContent(content)}
+                          {...props}
                         >
                           {navigationListItemTitle}
                           {icon !== undefined && (
@@ -200,6 +203,7 @@ export default class Toolbar extends Component {
                     href={href}
                     link={content === undefined}
                     handleItemSelect={() => this.toggleContent(content)}
+                    {...props}
                   >
                     {navigationItemTitle}
                     {icon !== undefined && (

--- a/src/components/Toolbar/_mocks_/index.js
+++ b/src/components/Toolbar/_mocks_/index.js
@@ -3,6 +3,8 @@
  * @copyright IBM Security 2018 - 2020
  */
 
+import { action } from '@storybook/addon-actions';
+
 import { icon, url, random } from '../../_mocks_';
 import labels from '../locales/en/Toolbar.json';
 
@@ -52,7 +54,7 @@ const applicationsToGenerate = [
     ]),
   },
   {
-    onClick: console.log,
+    onClick: action('Toolbar NavItem onClick'),
     title: 'Section 2',
     icon,
   },

--- a/src/components/Toolbar/_mocks_/index.js
+++ b/src/components/Toolbar/_mocks_/index.js
@@ -52,6 +52,7 @@ const applicationsToGenerate = [
     ]),
   },
   {
+    onClick: console.log,
     title: 'Section 2',
     icon,
   },


### PR DESCRIPTION
## Affected issue

Resolves #784

## Proposed change

- Call `onClick` handlers for `NavItem`s generated in `Nav` and `NavList`
- Pass-through props for `Toolbar` to support `onClick` handlers
- Update stories to reflect changes