### PR TITLE
feat(data-decorator): pass through `focusTrapOptions`

### DIFF
--- a/src/components/DataDecorator/DataDecorator.js
+++ b/src/components/DataDecorator/DataDecorator.js
@@ -1,18 +1,18 @@
 /**
- * @file DataDecorator
- * @copyright IBM Security 2019
+ * @file Data decorator
+ * @copyright IBM Security 2019 - 2020
  */
 
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-
 import deprecate from 'carbon-components-react/lib/prop-types/deprecate';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+import * as defaultLabels from '../../globals/nls';
+import { isNode } from '../../globals/utils/capabilities';
 
 import Decorator from './Decorator';
 import PanelV2 from '../PanelV2';
-import { PORTAL_EVENTS } from '../Portal';
-import * as defaultLabels from '../../globals/nls';
-import { isNode } from '../../globals/utils/capabilities';
+import Portal, { PORTAL_EVENTS } from '../Portal';
 
 const { defaultProps, propTypes } = Decorator;
 
@@ -42,6 +42,7 @@ class DataDecorator extends Component {
       className,
       closeButton,
       focusTrap,
+      focusTrapOptions,
       inline,
       labels,
       noIcon,
@@ -61,12 +62,14 @@ class DataDecorator extends Component {
       onContextMenu: propOnContextMenu,
       midLineTruncation,
     } = this.props;
+
     const onContextMenu = propOnContextMenu
       ? event => {
           event.preventDefault();
           propOnContextMenu(event);
         }
       : undefined;
+
     const decoratorProps = {
       className,
       inline,
@@ -80,6 +83,7 @@ class DataDecorator extends Component {
       onContextMenu,
       midLineTruncation,
     };
+
     const componentLabels = {
       ...defaultLabels.labels,
       ...labels,
@@ -91,8 +95,9 @@ class DataDecorator extends Component {
         DATA_DECORATOR_CLOSE_BUTTON: (closeButton && closeButton.label) || '',
       }),
     };
+
     return (
-      <Fragment>
+      <>
         <Decorator
           {...decoratorProps}
           active={this.state.isOpen}
@@ -101,13 +106,8 @@ class DataDecorator extends Component {
             this.toggleOpen();
           }}
         />
+
         <PanelV2
-          isOpen={this.state.isOpen}
-          onClose={this.close}
-          stopPropagation={stopPropagation}
-          stopPropagationEvents={stopPropagationEvents}
-          rootNode={rootNode}
-          focusTrap={focusTrap}
           closeButton={{
             onClick: event => {
               this.close(event, type, value);
@@ -116,6 +116,21 @@ class DataDecorator extends Component {
               }
             },
           }}
+          focusTrap={focusTrap}
+          focusTrapOptions={focusTrapOptions}
+          isOpen={this.state.isOpen}
+          labels={{
+            ...componentLabels,
+            ...defaultLabels.filterFalsey({
+              PANEL_CONTAINER_PRIMARY_BUTTON:
+                componentLabels.DATA_DECORATOR_PRIMARY_BUTTON,
+              PANEL_CONTAINER_SECONDARY_BUTTON:
+                componentLabels.DATA_DECORATOR_SECONDARY_BUTTON,
+              PANEL_CONTAINER_CLOSE_BUTTON:
+                componentLabels.DATA_DECORATOR_CLOSE_BUTTON,
+            }),
+          }}
+          onClose={this.close}
           primaryButton={
             primaryButton && {
               ...primaryButton,
@@ -133,6 +148,7 @@ class DataDecorator extends Component {
             }
           }
           renderFooter={renderFooter}
+          rootNode={rootNode}
           secondaryButton={
             secondaryButton && {
               ...secondaryButton,
@@ -149,23 +165,14 @@ class DataDecorator extends Component {
               },
             }
           }
+          stopPropagation={stopPropagation}
+          stopPropagationEvents={stopPropagationEvents}
           subtitle={subtitle}
           title={value}
-          labels={{
-            ...componentLabels,
-            ...defaultLabels.filterFalsey({
-              PANEL_CONTAINER_PRIMARY_BUTTON:
-                componentLabels.DATA_DECORATOR_PRIMARY_BUTTON,
-              PANEL_CONTAINER_SECONDARY_BUTTON:
-                componentLabels.DATA_DECORATOR_SECONDARY_BUTTON,
-              PANEL_CONTAINER_CLOSE_BUTTON:
-                componentLabels.DATA_DECORATOR_CLOSE_BUTTON,
-            }),
-          }}
         >
           {children}
         </PanelV2>
-      </Fragment>
+      </>
     );
   }
 }
@@ -191,6 +198,8 @@ DataDecorator.propTypes = {
 
   /** @type {boolean} Focus trap. */
   focusTrap: PropTypes.bool,
+
+  focusTrapOptions: Portal.propTypes.focusTrapOptions,
 
   /** @type {boolean} Determines if this is inline or not. */
   inline: propTypes.inline,
@@ -280,6 +289,7 @@ DataDecorator.defaultProps = {
   className: undefined,
   closeButton: undefined,
   focusTrap: true,
+  focusTrapOptions: Portal.defaultProps.focusTrapOptions,
   inline: defaultProps.inline,
   labels: {},
   noIcon: false,

--- a/src/components/DataDecorator/Decorator/Decorator.stories.js
+++ b/src/components/DataDecorator/Decorator/Decorator.stories.js
@@ -1,6 +1,6 @@
 /**
  * @file Decorator stories.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
 import { action } from '@storybook/addon-actions';
@@ -10,9 +10,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 
 import { components } from '../../../../.storybook';
-
-import { Button, Decorator } from '../../..';
-
+import { Decorator } from '../../..';
 import { props, midLine } from '../_mocks_';
 
 const { type, value, score, href } = props;

--- a/src/components/DataDecorator/Decorator/__tests__/Decorator.spec.js
+++ b/src/components/DataDecorator/Decorator/__tests__/Decorator.spec.js
@@ -1,14 +1,15 @@
 /**
  * @file Decorator tests.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2020
  */
 
-import { render } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
-import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
+import { render } from '@testing-library/react';
 
-import { DataDecorator, Decorator } from '../../../..';
+import React from 'react';
+
+import renderWithinLandmark from '../../../../../config/jest/helpers/renderWithinLandmark';
+import { Decorator } from '../../../..';
 
 import { namespace, icons } from '../constants';
 

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -1319,6 +1319,7 @@ Map {
       "className": undefined,
       "closeButton": undefined,
       "focusTrap": true,
+      "focusTrapOptions": Object {},
       "inline": false,
       "labels": Object {},
       "midLineTruncation": Object {
@@ -1382,6 +1383,91 @@ Map {
       },
       "focusTrap": Object {
         "type": "bool",
+      },
+      "focusTrapOptions": Object {
+        "args": Array [
+          Object {
+            "allowOutsideClick": Object {
+              "type": "func",
+            },
+            "clickOutsideDeactivates": Object {
+              "type": "bool",
+            },
+            "escapeDeactivates": Object {
+              "type": "bool",
+            },
+            "fallbackFocus": Object {
+              "args": Array [
+                Array [
+                  Object {
+                    "args": Array [
+                      [Function],
+                    ],
+                    "type": "instanceOf",
+                  },
+                  Object {
+                    "type": "string",
+                  },
+                  Object {
+                    "type": "func",
+                  },
+                ],
+              ],
+              "type": "oneOfType",
+            },
+            "initialFocus": Object {
+              "args": Array [
+                Array [
+                  Object {
+                    "args": Array [
+                      [Function],
+                    ],
+                    "type": "instanceOf",
+                  },
+                  Object {
+                    "type": "string",
+                  },
+                  Object {
+                    "type": "func",
+                  },
+                ],
+              ],
+              "type": "oneOfType",
+            },
+            "onActivate": Object {
+              "type": "func",
+            },
+            "onDeactivate": Object {
+              "type": "func",
+            },
+            "preventScroll": Object {
+              "type": "bool",
+            },
+            "returnFocusOnDeactivate": Object {
+              "type": "bool",
+            },
+            "setReturnFocus": Object {
+              "args": Array [
+                Array [
+                  Object {
+                    "args": Array [
+                      [Function],
+                    ],
+                    "type": "instanceOf",
+                  },
+                  Object {
+                    "type": "string",
+                  },
+                  Object {
+                    "type": "func",
+                  },
+                ],
+              ],
+              "type": "oneOfType",
+            },
+          },
+        ],
+        "type": "shape",
       },
       "inline": Object {
         "type": "bool",


### PR DESCRIPTION
## Affected issue

Resolves #800 

## Proposed changes

- Expose `focusTrapOptions` prop to `DataDecorator` to pass-through to `PanelV2` and subsequently `Portal`
- Reorder `DataDecorator` imports and props