### PR TITLE
Add onClick handler to navItems so the toolbar closes when item is clicked

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -178,6 +178,7 @@ export default class Toolbar extends Component {
                       }) => (
                         <NavItem
                           key={navigationListItemId}
+                          onClick={() => this.togglePanel(type)}
                           id={navigationListItemId}
                           href={navigationListItemHref}
                           link={content === undefined}
@@ -200,6 +201,7 @@ export default class Toolbar extends Component {
                   <NavItem
                     key={navigationItemId}
                     id={navigationItemId}
+                    onClick={() => this.togglePanel(type)}
                     href={href}
                     link={content === undefined}
                     handleItemSelect={() => this.toggleContent(content)}


### PR DESCRIPTION
https://jsw.ibm.com/browse/SECCON-4160

## Affected issues

- Resolves https://jsw.ibm.com/browse/SECCON-4160

## Proposed changes

Add onClick handler to navItems so the toolbar closes when item is cl

## Testing instructions

Click on a navItem and make sure toolbar closes
