### PR TITLE
docs(layout-modules): reorder documentation contents

### DIFF
--- a/src/components/UNSTABLE__LayoutModules/ActionBarModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/ActionBarModule/index.mdx
@@ -9,11 +9,11 @@ import anatomy from './images/anatomy.png';
 
 Action bars allow users to take multiple actions on the subsequent section.
 
-[↳ Overview](#overview)  
-[↳ Variants](#variants)  
+[↳ Overview](#overview)   
 [↳ Component API](#component-api)  
+[↳ Anatomy](#anatomy)      
+[↳ Variants](#variants)  
 [↳ Grid placement](#grid-placement)  
-[↳ Anatomy](#anatomy)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -31,6 +31,23 @@ The action bar module can be built using a combination of the `ActionBarModule` 
   />
 </Canvas>
 
+### Component API
+
+<ArgsTable />
+
+_**\***Required property_
+
+Additional props passed into `ActionBarModule` and `ActionBarModuleItems` will be forwarded along to their underlying containers.
+
+### Anatomy
+
+1. **Ghost button:** The predominant action for the bar should be placed here as a ghost button, alternatively a title can be supplemented, see [variants](#variants). Both the ghost button text and the title variant text should align with the text above and below.
+2. **Icon button bar:** The icon buttons are contained inside the [icon button bar](#) and are 16px in height.
+3. **Top spacer:** There is a 2px spacer `$spacing-01` included at the top of the actionBarModule
+4. **Bottom spacer:** The 8px spacer `$spacing-03`, included inside the action bar, means that the module can be placed flush to edge of the components below.
+
+<img alt="`ActionBarModule` anatomy" src={anatomy} />
+
 ### Variants
 
 If necessary, supplementary details can be placed inline with the actions instead of the ghost button.
@@ -41,14 +58,6 @@ If necessary, supplementary details can be placed inline with the actions instea
     parameters={parameters}
   />
 </Canvas>
-
-### Component API
-
-<ArgsTable />
-
-_**\***Required property_
-
-Additional props passed into `ActionBarModule` and `ActionBarModuleItems` will be forwarded along to their underlying containers.
 
 ### Grid placement
 
@@ -69,15 +78,6 @@ Action bar modules can span between 4 and 16 columns, following the [narrow grid
   <ActionBarModule />
 </Column>
 ```
-
-### Anatomy
-
-1. **Ghost button:** The predominant action for the bar should be placed here as a ghost button, alternatively a title can be supplemented, see [variants](#variants). Both the ghost button text and the title variant text should align with the text above and below.
-2. **Icon button bar:** The icon buttons are contained inside the [icon button bar](#) and are 16px in height.
-3. **Top spacer:** There is a 2px spacer `$spacing-01` included at the top of the actionBarModule
-4. **Bottom spacer:** The 8px spacer `$spacing-03`, included inside the action bar, means that the module can be placed flush to edge of the components below.
-
-<img alt="`ActionBarModule` anatomy" src={anatomy} />
 
 ### Examples
 

--- a/src/components/UNSTABLE__LayoutModules/ButtonClusterModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/ButtonClusterModule/index.mdx
@@ -13,9 +13,9 @@ The button cluster module group secondary actions that can be taken on a whole p
 
 [↳ Overview](#overview)  
 [↳ Component API](#component-api)  
+[↳ Anatomy](#anatomy)  
 [↳ Grid placement](#grid-placement)  
 [↳ Layout considerations](#layout-considerations)  
-[↳ Anatomy](#anatomy)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -38,6 +38,14 @@ The button cluster module can be built using a combination of the `ButtonCluster
 _**\***Required property_
 
 Additional props passed into `ButtonClusterModule` will be forwarded along to the underlying button cluster module container.
+
+### Anatomy
+
+1. **Ghost buttons:** Ghost buttons stack directly below each other.
+2. **Divider lines:** Divider lines create structure and provide separation between the ghost buttons.
+3. **Bottom spacer:** The 16-pixel spacer `$layout-01` below the last button provides the starting point for the layout module positioned directly underneath it.
+
+<img alt="`ButtonClusterModule` anatomy" src={anatomy} />
 
 ### Grid placement
 
@@ -67,14 +75,6 @@ Occassionally a [spacing token](#references) will need to be included to offset 
   alt="`ButtonClusterModule` layout considerations"
   src={layoutConsiderations}
 />
-
-### Anatomy
-
-1. **Ghost buttons:** Ghost buttons stack directly below each other.
-2. **Divider lines:** Divider lines create structure and provide separation between the ghost buttons.
-3. **Bottom spacer:** The 16-pixel spacer `$layout-01` below the last button provides the starting point for the layout module positioned directly underneath it.
-
-<img alt="`ButtonClusterModule` anatomy" src={anatomy} />
 
 ### Examples
 

--- a/src/components/UNSTABLE__LayoutModules/CardModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/CardModule/index.mdx
@@ -12,10 +12,10 @@ import anatomy from './images/anatomy.png';
 The card module provides a means to orderly present related content and information using summary, navigational, or widget cards as the basis.
 
 [↳ Overview](#overview)  
-[↳ Variants](#variants)  
 [↳ Component API](#component-api)  
-[↳ Grid placement](#grid-placement)  
 [↳ Anatomy](#anatomy)  
+[↳ Variants](#variants)  
+[↳ Grid placement](#grid-placement)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -33,19 +33,6 @@ Everything passed in as a [render prop](#references) child of `CardModule` will 
   />
 </Canvas>
 
-### Variants
-
-The card module can contain a number of complimentary layout modules within the parent to create a section of related modules. The following options can be used for this purpose.
-The cards within the module can also be arranged in a number of different ways.
-
-1. **[`TitleBarModule`](#references) using section title:** Section titles provide identification for the content
-2. **`TitleBarModule` using subsection title:** Subsection titles provide identification for the sub-content
-3. **[`ActionBarModule`](#references):** Provides a zone for actions related to the cards and content below it
-
-<img alt="`CardModule` variants" src={variants} />
-
-<Source id="patterns-unstable-layout-modules-cardmodule--variant" />
-
 ### Component API
 
 <ArgsTable />
@@ -61,6 +48,27 @@ In order to make sure that everything works as intended, it's important to pass 
 ```jsx
 <SummaryCard {...getLayoutProps({ className: 'className' })} />
 ```
+
+### Anatomy
+
+1. **Cards:** Cards can use `Card`, `SummaryCard`, or `Tile` components.
+2. **Card spacer (optional):** If there are multiple rows of cards, use the 16-pixel spacer `$layout-01` to separate the rows.
+3. **Bottom spacer:** The 32-pixel spacer `$layout-03` below the last card row provides the starting point for the layout module positioned directly underneath it.
+
+<img alt="`CardModule` anatomy" src={anatomy} />
+
+### Variants
+
+The card module can contain a number of complimentary layout modules within the parent to create a section of related modules. The following options can be used for this purpose.
+The cards within the module can also be arranged in a number of different ways.
+
+1. **[`TitleBarModule`](#references) using section title:** Section titles provide identification for the content
+2. **`TitleBarModule` using subsection title:** Subsection titles provide identification for the sub-content
+3. **[`ActionBarModule`](#references):** Provides a zone for actions related to the cards and content below it
+
+<img alt="`CardModule` variants" src={variants} />
+
+<Source id="patterns-unstable-layout-modules-cardmodule--variant" />
 
 ### Grid placement
 
@@ -81,14 +89,6 @@ Card modules can span between 4 and 16 columns. Following the narrow grid implem
   <CardModule />
 </Column>
 ```
-
-### Anatomy
-
-1. **Cards:** Cards can use `Card`, `SummaryCard`, or `Tile` components.
-2. **Card spacer (optional):** If there are multiple rows of cards, use the 16-pixel spacer `$layout-01` to separate the rows.
-3. **Bottom spacer:** The 32-pixel spacer `$layout-03` below the last card row provides the starting point for the layout module positioned directly underneath it.
-
-<img alt="`CardModule` anatomy" src={anatomy} />
 
 ### Examples
 

--- a/src/components/UNSTABLE__LayoutModules/DescriptionListModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/DescriptionListModule/index.mdx
@@ -16,11 +16,11 @@ import anatomy from './images/anatomy.png';
 Description list modules provide a means to orderly layout terms and definitions.
 
 [↳ Overview](#overview)  
-[↳ Variants](#variants)  
 [↳ Component API](#component-api)  
+[↳ Anatomy](#anatomy)  
+[↳ Variants](#variants)  
 [↳ Grid placement](#grid-placement)  
 [↳ Layout considerations](#layout-considerations)  
-[↳ Anatomy](#anatomy)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -38,14 +38,6 @@ Everything passed in as a child of `DescriptionListModule` will be rendered.
   />
 </Canvas>
 
-### Variants
-
-If necessary, both section and subsection titles can precede the type layout. There are two values already supplied for this so you shouldn't supplement your own type style. Learn more by reviewing the <LinkTo kind="patterns-unstable-layout-modules-titlebarmodule" story="default" > TitleBarModule. </LinkTo>
-
-<img alt="`DescriptionListModule` variants" src={variants} />
-
-<Source id="patterns-unstable-layout-modules-descriptionlistmodule--variant" />
-
 ### Component API
 
 <ArgsTable />
@@ -53,6 +45,23 @@ If necessary, both section and subsection titles can precede the type layout. Th
 _**\***Required property_
 
 Additional props passed into `DescriptionListModule` will be forwarded along to the underlying description list module container.
+
+### Anatomy
+
+1. **Term:** This is the label, it should left aligned to a grid column.
+2. **Description:** The description placement is relative to the term label, it will always fall 32px to the right of the term.
+3. **Row spacer:** The 16-pixel spacer `$layout-01` below each row provides padding between the rows.
+4. **Bottom spacer:** The 16-pixel spacer `$layout-01` below the 'Row spacer' row provides the starting point for the layout module positioned directly underneath it. At the end of the description list module both the 'Row spacer' and 'Bottom spacer' join together to create a 32px buffer.
+
+<img alt="`DescriptionListModule` anatomy" src={anatomy} />
+
+### Variants
+
+If necessary, both section and subsection titles can precede the type layout. There are two values already supplied for this so you shouldn't supplement your own type style. Learn more by reviewing the <LinkTo kind="patterns-unstable-layout-modules-titlebarmodule" story="default" > TitleBarModule. </LinkTo>
+
+<img alt="`DescriptionListModule` variants" src={variants} />
+
+<Source id="patterns-unstable-layout-modules-descriptionlistmodule--variant" />
 
 ### Grid placement
 
@@ -84,15 +93,6 @@ Occassionally a [spacing token](#references) will need to be included to offset 
   alt="`DescriptionListModule` layout considerations"
   src={layoutConsiderations}
 />
-
-### Anatomy
-
-1. **Term:** This is the label, it should left aligned to a grid column.
-2. **Description:** The description placement is relative to the term label, it will always fall 32px to the right of the term.
-3. **Row spacer:** The 16-pixel spacer `$layout-01` below each row provides padding between the rows.
-4. **Bottom spacer:** The 16-pixel spacer `$layout-01` below the 'Row spacer' row provides the starting point for the layout module positioned directly underneath it. At the end of the description list module both the 'Row spacer' and 'Bottom spacer' join together to create a 32px buffer.
-
-<img alt="`DescriptionListModule` anatomy" src={anatomy} />
 
 ### Examples
 

--- a/src/components/UNSTABLE__LayoutModules/DescriptionModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/DescriptionModule/index.mdx
@@ -14,11 +14,11 @@ import anatomy from './images/anatomy.png';
 Description modules provide a means to orderly layout short-form content.
 
 [↳ Overview](#overview)  
-[↳ Variants](#variants)  
 [↳ Component API](#component-api)  
+[↳ Anatomy](#anatomy)  
+[↳ Variants](#variants)  
 [↳ Grid placement](#grid-placement)  
 [↳ Layout considerations](#layout-considerations)  
-[↳ Anatomy](#anatomy)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -36,16 +36,6 @@ Everything passed in as a [render prop](#references) child of `DescriptionModule
   />
 </Canvas>
 
-### Variants
-
-If necessary, subsection titles can be substituted or used below section titles. There are values already supplied for the title type styles so you shouldn't supplement your own. Learn more by reviewing the <LinkTo kind="patterns-unstable-layout-modules-titlebarmodule" story="default" > TitleBarModule. </LinkTo>
-
-The description module can also be created without any title.
-
-<img alt="`DescriptionModule` variants" src={variants} />
-
-<Source id="patterns-unstable-layout-modules-descriptionmodule--variant" />
-
 ### Component API
 
 <ArgsTable />
@@ -61,6 +51,24 @@ In order to make sure that everything works as intended, it's important to pass 
 ```jsx
 <p {...getLayoutProps({ className: 'className' })} />
 ```
+
+### Anatomy
+
+1. **Title:** This is the title, achieved by using the TitleBarModule. <LinkTo kind="patterns-unstable-layout-modules-titlebarmodule" story="default" > Learn more </LinkTo> about the TitleBarModule and potential variants.
+2. **Description:** This is the description itself, the type style is defined so you shouldn't supplement your own values.
+3. **Bottom spacer:** There is a 32-pixel (`$layout-03`) spacer included below the description. Any additional modules can be placed directly underneath.
+
+<img alt="`DescriptionModule` anatomy" src={anatomy} />
+
+### Variants
+
+If necessary, subsection titles can be substituted or used below section titles. There are values already supplied for the title type styles so you shouldn't supplement your own. Learn more by reviewing the <LinkTo kind="patterns-unstable-layout-modules-titlebarmodule" story="default" > TitleBarModule. </LinkTo>
+
+The description module can also be created without any title.
+
+<img alt="`DescriptionModule` variants" src={variants} />
+
+<Source id="patterns-unstable-layout-modules-descriptionmodule--variant" />
 
 ### Grid placement
 
@@ -90,14 +98,6 @@ Occassionally a [spacing token](#references) will need to be included to offset 
   alt="`DescriptionModule` layout considerations"
   src={layoutConsiderations}
 />
-
-### Anatomy
-
-1. **Title:** This is the title, achieved by using the TitleBarModule. <LinkTo kind="patterns-unstable-layout-modules-titlebarmodule" story="default" > Learn more </LinkTo> about the TitleBarModule and potential variants.
-2. **Description:** This is the description itself, the type style is defined so you shouldn't supplement your own values.
-3. **Bottom spacer:** There is a 32-pixel (`$layout-03`) spacer included below the description. Any additional modules can be placed directly underneath.
-
-<img alt="`DescriptionModule` anatomy" src={anatomy} />
 
 ### Examples
 

--- a/src/components/UNSTABLE__LayoutModules/ICAModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/ICAModule/index.mdx
@@ -13,10 +13,10 @@ import anatomy from './images/anatomy.png';
 The ICA module provides a means to orderly layout at-a-glance statistics.
 
 [↳ Overview](#overview)  
-[↳ Interactions](#interactions)  
 [↳ Component API](#component-api)  
-[↳ Grid placement](#grid-placement)  
 [↳ Anatomy](#anatomy)  
+[↳ Interactions](#interactions)  
+[↳ Grid placement](#grid-placement)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -33,14 +33,6 @@ Everything passed in as a [render prop](#references) child of `ICAModule` will b
     parameters={parameters}
   />
 </Canvas>
-
-### Interactions
-
-If the ICA needs to be interactive, a background hover can be placed on the grid columns. This adds 16px to the height of the ICA module on hover.
-
-<img alt="`ICAModule` interactions" src={interactions} />
-
-<Source id="patterns-unstable-layout-modules-icamodule--interaction" />
 
 ### Component API
 
@@ -69,6 +61,24 @@ In order to make sure that everything works as intended, it's important to pass 
 ```jsx
 <Column {...getLayoutProps({ className: 'className' })} />
 ```
+
+### Anatomy
+
+1. **Top spacer:** There is a top spacer of 16px (\$layout-01) included inside the module so additional modules can be placed directly on top.
+2. **ICA:** This is the ICA itself, it comprises a value and a label. Spacing between the value and label, and between individual ICA's, is defined in the module.
+3. **Bottom spacer:** The is a bottom spacer of 16px (\$layout-01) included inside the module so additional modules can be placed directly on top.
+
+<img alt="`ICAModule` anatomy" src={anatomy} />
+
+
+### Interactions
+
+If the ICA needs to be interactive, a background hover can be placed on the grid columns. This adds 16px to the height of the ICA module on hover.
+
+<img alt="`ICAModule` interactions" src={interactions} />
+
+<Source id="patterns-unstable-layout-modules-icamodule--interaction" />
+
 
 ### Grid placement
 
@@ -103,14 +113,6 @@ ICAs within ICA modules can span across 2 or 3 columns, following the narrow gri
   )}
 </ICAModule>
 ```
-
-### Anatomy
-
-1. **Top spacer:** There is a top spacer of 16px (\$layout-01) included inside the module so additional modules can be placed directly on top.
-2. **ICA:** This is the ICA itself, it comprises a value and a label. Spacing between the value and label, and between individual ICA's, is defined in the module.
-3. **Bottom spacer:** The is a bottom spacer of 16px (\$layout-01) included inside the module so additional modules can be placed directly on top.
-
-<img alt="`ICAModule` anatomy" src={anatomy} />
 
 ### Examples
 

--- a/src/components/UNSTABLE__LayoutModules/TitleBarModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/TitleBarModule/index.mdx
@@ -13,10 +13,10 @@ import anatomy from './images/anatomy.png';
 Title bar modules provide interchangeable and reliable headings for establishing consistent hierarchies.
 
 [↳ Overview](#overview)  
-[↳ Variants](#variants)  
 [↳ Component API](#component-api)  
-[↳ Grid placement](#grid-placement)  
 [↳ Anatomy](#anatomy)  
+[↳ Variants](#variants)  
+[↳ Grid placement](#grid-placement)  
 [↳ Examples](#examples)  
 [↳ References](#references)  
 [↳ Troubleshooting](#troubleshooting)
@@ -31,16 +31,6 @@ Everything passed in as a child of the title bar module will be rendered.
     parameters={parameters}
   />
 </Canvas>
-
-### Variants
-
-If necessary, actions can be placed inline with the title.
-
-The title bar can also accept two type variants, sub-section title and section title, so you shouldn't supplement your own type style. [Learn more](#subsection) below.
-
-<img alt="`TitleBarModule` variants" src={variants} />
-
-<Source id="patterns-unstable-layout-modules-titlebarmodule--variant" />
 
 ### Component API
 
@@ -74,6 +64,24 @@ This prop specifies a different element to be rendered as a title.
 <TitleBarModule element="h3" title="Section 3 title" />
 ```
 
+### Anatomy
+
+1. **Title:** This the title itself, learn more about potential [variants](#variants) above.
+2. **Top spacer:** There is 16px spacer `$layout-01`, included at the top of the TitleBarModule.
+3. **Bottom spacer:** The 16px spacer `$layout-01`, included inside the bar, means that the module can be placed flush to edge of the components below.
+
+<img alt="`TitleBarModule` anatomy" src={anatomy} />
+
+### Variants
+
+If necessary, actions can be placed inline with the title.
+
+The title bar can also accept two type variants, sub-section title and section title, so you shouldn't supplement your own type style. [Learn more](#subsection) below.
+
+<img alt="`TitleBarModule` variants" src={variants} />
+
+<Source id="patterns-unstable-layout-modules-titlebarmodule--variant" />
+
 ### Grid placement
 
 Title bar modules can span between 4 and 8 columns, following the [narrow grid](#references) implementation.
@@ -93,14 +101,6 @@ Title bar modules can span between 4 and 8 columns, following the [narrow grid](
   <TitleBarModule title="Section title" />
 </Column>
 ```
-
-### Anatomy
-
-1. **Title:** This the title itself, learn more about potential [variants](#variants) above.
-2. **Top spacer:** There is 16px spacer `$layout-01`, included at the top of the TitleBarModule.
-3. **Bottom spacer:** The 16px spacer `$layout-01`, included inside the bar, means that the module can be placed flush to edge of the components below.
-
-<img alt="`TitleBarModule` anatomy" src={anatomy} />
 
 ### Examples
 


### PR DESCRIPTION
## Proposed changes

Reorder contents of documentation to:

1. Overview
2. API
3. Anatomy
4. Variants/Interactions
5. ...
