### PR TITLE
feat: add NavItem element support for Toolbar

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -170,6 +170,7 @@ export default class Toolbar extends Component {
                     {children.map(
                       ({
                         href: navigationListItemHref,
+                        element: navigationListItemElement,
                         content,
                         icon,
                         id: navigationListItemId,
@@ -181,6 +182,7 @@ export default class Toolbar extends Component {
                           onClick={() => this.togglePanel(type)}
                           id={navigationListItemId}
                           href={navigationListItemHref}
+                          element={navigationListItemElement}
                           link={content === undefined}
                           handleItemSelect={() => this.toggleContent(content)}
                           {...props}


### PR DESCRIPTION
## Affected issues

- Resolves #705 

## Proposed changes

- Pass `element` prop from `Toolbar` props down to the `NavItem` component.

## Testing instructions

- Verified by modifying `Toolbar` mock data to include an `element` prop and inspecting the rendered HTML in Storybook. Did not update mocks but can if required.
