### PR TITLE
fix(combo-button): key is not a prop warning

### DIFF
--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -33,27 +33,27 @@ const ComboButton = ({
   const childrenArray = React.Children.toArray(children).filter(Boolean);
 
   // Save first child (e.g., primary action) to use as a `Button`:
-  const button = childrenArray[0];
+  const buttonProps = childrenArray[0].props;
   // Need to explicitly define props, versus using `...rest`,
   // because otherwise unused `OverflowMenuItem`-related props from
   // may trigger invalid DOM warnings.
   const primaryActionWithProps = (
     <Button
-      className={classnames(button.props.className, `${namespace}--primary`)}
-      disabled={button.props.disabled}
-      href={button.props.href}
-      iconDescription={button.props.iconDescription}
+      className={classnames(buttonProps.className, `${namespace}--primary`)}
+      disabled={buttonProps.disabled}
+      href={buttonProps.href}
+      iconDescription={buttonProps.iconDescription}
       kind="primary"
-      id={button.props.id}
-      onClick={button.props.onClick}
-      renderIcon={button.props.renderIcon}
+      id={buttonProps.id}
+      onClick={buttonProps.onClick}
+      renderIcon={buttonProps.renderIcon}
       type="button"
     >
       <span
         className={`${carbonPrefix}text-truncate--end`}
-        title={button.props.children}
+        title={buttonProps.children}
       >
-        {button.props.children}
+        {buttonProps.children}
       </span>
     </Button>
   );

--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -33,40 +33,30 @@ const ComboButton = ({
   const childrenArray = React.Children.toArray(children).filter(Boolean);
 
   // Save first child (e.g., primary action) to use as a `Button`:
-  const primaryActionWithProps = [childrenArray[0]].map(button => {
-    // Need to explicitly define props, versus using `...rest`,
-    // because otherwise unused `OverflowMenuItem`-related props from
-    // may trigger invalid DOM warnings.
-    const {
-      children,
-      className,
-      disabled,
-      href,
-      iconDescription,
-      onClick,
-      id,
-      renderIcon: Icon,
-    } = button.props;
-
-    return (
-      <Button
-        className={classnames(className, `${namespace}--primary`)}
-        disabled={disabled}
-        href={href}
-        iconDescription={iconDescription}
-        kind="primary"
-        id={id}
-        key={id || `button-${href}`}
-        onClick={onClick}
-        renderIcon={Icon}
-        type="button"
+  const button = childrenArray[0];
+  // Need to explicitly define props, versus using `...rest`,
+  // because otherwise unused `OverflowMenuItem`-related props from
+  // may trigger invalid DOM warnings.
+  const primaryActionWithProps = (
+    <Button
+      className={classnames(button.props.className, `${namespace}--primary`)}
+      disabled={button.props.disabled}
+      href={button.props.href}
+      iconDescription={button.props.iconDescription}
+      kind="primary"
+      id={button.props.id}
+      onClick={button.props.onClick}
+      renderIcon={button.props.renderIcon}
+      type="button"
+    >
+      <span
+        className={`${carbonPrefix}text-truncate--end`}
+        title={button.props.children}
       >
-        <span className={`${carbonPrefix}text-truncate--end`} title={children}>
-          {children}
-        </span>
-      </Button>
-    );
-  });
+        {button.props.children}
+      </span>
+    </Button>
+  );
 
   // Save remaining children to be displayed in the `OverflowMenu`:
   let overflowItems;
@@ -86,7 +76,6 @@ const ComboButton = ({
         href,
         iconDescription,
         id,
-        key,
         onClick,
         renderIcon: Icon,
         ...other
@@ -109,7 +98,7 @@ const ComboButton = ({
             </>
           }
           id={id}
-          key={key || id || `${namespace}__item__${index}`}
+          key={id || index}
           onClick={onClick}
           {...other}
         />

--- a/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
+++ b/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
@@ -19,7 +19,6 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
         disabled={false}
         iconDescription=""
         id="test-1"
-        key="test-1"
         kind="primary"
         largeText={null}
         loading={false}
@@ -213,7 +212,6 @@ exports[`ComboButton renders a combo button without an overflow menu 1`] = `
         disabled={false}
         iconDescription=""
         id="test-1"
-        key="test-1"
         kind="primary"
         largeText={null}
         loading={false}


### PR DESCRIPTION
## Affected issues

```
Warning: ComboButtonItem: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
    at ComboButton
```
This might cause developers looking for errors on their side when they use the `ComboButton`.

## Proposed changes

- Don't use a loop for the single button
- Don't try to access `key` from the prop

## Testing instructions

- Run storybook in dev mode (using `yarn start`) and verify there is no more warning
- Verify `ComboButton` still works as exepected
