### PR TITLE
feat(combo-button): add prop spreading to primary action button

### DIFF
--- a/src/components/ComboButton/ComboButton.js
+++ b/src/components/ComboButton/ComboButton.js
@@ -39,6 +39,7 @@ const ComboButton = ({
   // may trigger invalid DOM warnings.
   const primaryActionWithProps = (
     <Button
+      {...buttonProps}
       className={classnames(buttonProps.className, `${namespace}--primary`)}
       disabled={buttonProps.disabled}
       href={buttonProps.href}

--- a/src/components/ComboButton/ComboButton.stories.js
+++ b/src/components/ComboButton/ComboButton.stories.js
@@ -36,6 +36,7 @@ storiesOf(patterns('ComboButton'), module).add(
           href="#"
           onClick={action(`onClick (Item 1)`)}
           renderIcon={ArrowRight20}
+          target="_blank"
         >
           Item 1 -- becomes primary button and text will be truncated
         </ComboButtonItem>
@@ -53,6 +54,14 @@ storiesOf(patterns('ComboButton'), module).add(
           data-overflow-menu-primary-focus
         >
           Item 3 -- will be selected when menu opens
+        </ComboButtonItem>
+        <ComboButtonItem
+          href="#"
+          renderIcon={Filter20}
+          onClick={action(`onClick (Item 3)`)}
+          target="_blank"
+        >
+          Item 4 -- will open link in new tab when clicked
         </ComboButtonItem>
       </ComboButton>
     </div>

--- a/src/components/ComboButton/__tests__/ComboButton.spec.js
+++ b/src/components/ComboButton/__tests__/ComboButton.spec.js
@@ -2,38 +2,85 @@
  * @file Combo button tests.
  * @copyright IBM Security 2019
  */
-
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import ArrowRight20 from '@carbon/icons-react/lib/arrow--right/20';
 
 import ComboButton, { ComboButtonItem } from '../';
 
+const COMBO_BUTTON_TESTID = 'combo-button';
+
+const renderComboButton = (overflowMenuItemCount = 0) => {
+  const primaryItem = (
+    <ComboButtonItem
+      key="test-primary-item"
+      id="test-primary-item"
+      renderIcon={ArrowRight20}
+    >
+      Primary task
+    </ComboButtonItem>
+  );
+  const overflowMenuItems = new Array(overflowMenuItemCount)
+    .fill(undefined)
+    .map((_, index) => {
+      const key = `test-menu-item-${index}`;
+      return (
+        <ComboButtonItem key={key} id={key}>
+          Other task
+        </ComboButtonItem>
+      );
+    });
+
+  const items = [primaryItem, ...overflowMenuItems];
+
+  return render(
+    <div data-testid={COMBO_BUTTON_TESTID}>
+      <ComboButton>{items}</ComboButton>
+    </div>
+  );
+};
+
+const getComboBox = () => screen.getByTestId(COMBO_BUTTON_TESTID);
+
 describe('ComboButton', () => {
   it('renders a combo button without an overflow menu', () => {
-    const comboButton = mount(
-      <ComboButton>
-        <ComboButtonItem id="test-1" renderIcon={ArrowRight20}>
-          Start a task
-        </ComboButtonItem>
-      </ComboButton>
-    );
+    renderComboButton(0);
+    const comboButton = getComboBox();
 
     expect(comboButton).toMatchSnapshot();
-    expect(comboButton.find('OverflowMenu').exists()).toEqual(false);
   });
 
   it('renders a combo button with children and an overflow menu', () => {
-    const comboButton = mount(
-      <ComboButton>
-        <ComboButtonItem id="test-1" renderIcon={ArrowRight20}>
-          Start a task
-        </ComboButtonItem>
-        <ComboButtonItem id="test-2">Filter list</ComboButtonItem>
-      </ComboButton>
-    );
+    renderComboButton(2);
+    const comboButton = getComboBox();
 
-    expect(comboButton.find('OverflowMenu').exists()).toEqual(true);
     expect(comboButton).toMatchSnapshot();
+  });
+
+  it('renders overflow menu items when overflow menu is clicked (opened) and removes overflow menu items when clicked again (closed)', () => {
+    const MENU_ITEM_COUNT = 2;
+    const getMenuItemsLength = () => screen.queryAllByRole('menuitem').length;
+    const clickComboBox = overflowMenuButton => {
+      userEvent.click(overflowMenuButton);
+    };
+
+    renderComboButton(MENU_ITEM_COUNT);
+    const overflowMenuButton = screen.getByLabelText('Menu');
+
+    expect(getMenuItemsLength()).toEqual(0); // Menu items should not be shown
+    clickComboBox(overflowMenuButton); // Open the menu
+    expect(getMenuItemsLength()).toEqual(MENU_ITEM_COUNT); // Menu items should now be shown
+    clickComboBox(overflowMenuButton); // Close the Menu
+    expect(getMenuItemsLength()).toEqual(0); // Menu items should not be shown again
+  });
+
+  it('should have no Axe or DAP violations', () => {
+    renderComboButton(3);
+
+    const comboButton = getComboBox();
+
+    expect(comboButton).toHaveNoAxeViolations();
+    expect(comboButton).toHaveNoDAPViolations('ComboButton');
   });
 });

--- a/src/components/ComboButton/__tests__/ComboButton.spec.js
+++ b/src/components/ComboButton/__tests__/ComboButton.spec.js
@@ -42,6 +42,10 @@ const renderComboButton = (overflowMenuItemCount = 0) => {
 };
 
 const getComboBox = () => screen.getByTestId(COMBO_BUTTON_TESTID);
+const getOverflowMenuButton = () => screen.getByLabelText('Menu');
+const clickComboBox = overflowMenuButton => {
+  userEvent.click(overflowMenuButton);
+};
 
 describe('ComboButton', () => {
   it('renders a combo button without an overflow menu', () => {
@@ -61,13 +65,13 @@ describe('ComboButton', () => {
   it('renders overflow menu items when overflow menu is clicked (opened) and removes overflow menu items when clicked again (closed)', () => {
     const MENU_ITEM_COUNT = 2;
     const getMenuItemsLength = () => screen.queryAllByRole('menuitem').length;
-    const clickComboBox = overflowMenuButton => {
-      userEvent.click(overflowMenuButton);
-    };
 
     renderComboButton(MENU_ITEM_COUNT);
-    const overflowMenuButton = screen.getByLabelText('Menu');
+    const overflowMenuButton = getOverflowMenuButton();
 
+    /*
+      Let's test the opening and closing of the ComboButton menu 
+    */
     expect(getMenuItemsLength()).toEqual(0); // Menu items should not be shown
     clickComboBox(overflowMenuButton); // Open the menu
     expect(getMenuItemsLength()).toEqual(MENU_ITEM_COUNT); // Menu items should now be shown
@@ -75,12 +79,21 @@ describe('ComboButton', () => {
     expect(getMenuItemsLength()).toEqual(0); // Menu items should not be shown again
   });
 
-  it('should have no Axe or DAP violations', () => {
-    renderComboButton(3);
+  it('should have no Axe or DAP violations', async () => {
+    renderComboButton(4);
 
     const comboButton = getComboBox();
+    const assertHasNoViolations = async () => {
+      await expect(comboButton).toHaveNoAxeViolations();
+      await expect(comboButton).toHaveNoDAPViolations('ComboButton');
+    };
 
-    expect(comboButton).toHaveNoAxeViolations();
-    expect(comboButton).toHaveNoDAPViolations('ComboButton');
+    await assertHasNoViolations();
+
+    // Now let's open the ComboButton menu and re-assert conditions
+    const overflowMenuButton = getOverflowMenuButton();
+    clickComboBox(overflowMenuButton);
+
+    await assertHasNoViolations();
   });
 });

--- a/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
+++ b/src/components/ComboButton/__tests__/__snapshots__/ComboButton.spec.js.snap
@@ -1,304 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ComboButton renders a combo button with children and an overflow menu 1`] = `
-<ComboButton
-  className=""
-  direction="top"
-  menuOffset={[Function]}
-  selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+<div
+  data-testid="combo-button"
 >
   <div
-    className="security--combo-button"
-    data-floating-menu-container={true}
+    class="security--combo-button"
+    data-floating-menu-container="true"
   >
     <div
-      className="security--combo-button__group"
+      class="security--combo-button__group"
     >
-      <Button
-        className="security--combo-button--primary"
-        disabled={false}
-        iconDescription=""
-        id="test-1"
-        kind="primary"
-        largeText={null}
-        loading={false}
-        onClick={[Function]}
-        renderIcon={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "render": [Function],
-          }
-        }
-        size="default"
-        tabIndex={0}
-        tooltipAlignment="center"
-        tooltipPosition="top"
+      <button
+        class="security--button security--combo-button--primary bx--btn bx--btn--primary"
+        id="test-primary-item"
+        tabindex="0"
         type="button"
       >
-        <Button
-          className="security--button security--combo-button--primary"
-          disabled={false}
-          iconDescription=""
-          id="test-1"
-          kind="primary"
-          onClick={[Function]}
-          renderIcon={
-            Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            }
-          }
-          size="default"
-          tabIndex={0}
-          tooltipAlignment="center"
-          tooltipPosition="top"
-          type="button"
+        <span
+          class="bx--text-truncate--end"
+          title="Primary task"
         >
-          <button
-            className="security--button security--combo-button--primary bx--btn bx--btn--primary"
-            disabled={false}
-            id="test-1"
-            onClick={[Function]}
-            tabIndex={0}
-            type="button"
-          >
-            <span
-              className="bx--text-truncate--end"
-              title="Start a task"
-            >
-              Start a task
-            </span>
-            <ForwardRef(ArrowRight20)
-              aria-hidden="true"
-              aria-label=""
-              className="bx--btn__icon"
-            >
-              <Icon
-                aria-hidden="true"
-                aria-label=""
-                className="bx--btn__icon"
-                fill="currentColor"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 20 20"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <svg
-                  aria-hidden={true}
-                  aria-label=""
-                  className="bx--btn__icon"
-                  fill="currentColor"
-                  focusable="false"
-                  height={20}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 20 20"
-                  width={20}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                  />
-                </svg>
-              </Icon>
-            </ForwardRef(ArrowRight20)>
-          </button>
-        </Button>
-      </Button>
-      <ForwardRef(OverflowMenu)
-        className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu"
-        direction="top"
-        menuOffset={[Function]}
-        menuOptionsClass="bx--list-box__menu"
-        onClick={[Function]}
-        onClose={[Function]}
-        renderIcon={[Function]}
-        selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+          Primary task
+        </span>
+        <svg
+          aria-hidden="true"
+          aria-label=""
+          class="bx--btn__icon"
+          fill="currentColor"
+          focusable="false"
+          height="20"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-expanded="false"
+        aria-haspopup="true"
+        aria-label="Menu"
+        class="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu bx--overflow-menu"
+        type="button"
       >
-        <OverflowMenu
-          ariaLabel="Menu"
-          className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu"
-          direction="top"
-          flipped={false}
-          iconDescription="open and close list of options"
-          innerRef={null}
-          light={false}
-          menuOffset={[Function]}
-          menuOffsetFlip={[Function]}
-          menuOptionsClass="bx--list-box__menu"
-          onClick={[Function]}
-          onClose={[Function]}
-          onKeyDown={[Function]}
-          onOpen={[Function]}
-          open={false}
-          renderIcon={[Function]}
-          selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+        <svg
+          aria-hidden="true"
+          class="security--combo-button__icon"
+          fill="currentColor"
+          focusable="false"
+          height="16"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <ClickListener
-            onClickOutside={[Function]}
-          >
-            <button
-              aria-expanded={false}
-              aria-haspopup={true}
-              aria-label="Menu"
-              className="security--button bx--btn bx--btn--primary security--combo-button__button security--combo-button__overflow-menu bx--overflow-menu"
-              onClick={[Function]}
-              onClose={[Function]}
-              onKeyDown={[Function]}
-              open={false}
-              type="button"
-            >
-              <renderOverflowMenuIcon
-                aria-label="open and close list of options"
-                className="bx--overflow-menu__icon"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-              >
-                <ForwardRef(ChevronDown16)
-                  className="security--combo-button__icon"
-                >
-                  <Icon
-                    className="security--combo-button__icon"
-                    fill="currentColor"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="security--combo-button__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                      />
-                    </svg>
-                  </Icon>
-                </ForwardRef(ChevronDown16)>
-              </renderOverflowMenuIcon>
-            </button>
-          </ClickListener>
-        </OverflowMenu>
-      </ForwardRef(OverflowMenu)>
+          <path
+            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
-</ComboButton>
+</div>
 `;
 
 exports[`ComboButton renders a combo button without an overflow menu 1`] = `
-<ComboButton
-  className=""
-  direction="top"
-  menuOffset={[Function]}
-  selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+<div
+  data-testid="combo-button"
 >
   <div
-    className="security--combo-button"
-    data-floating-menu-container={true}
+    class="security--combo-button"
+    data-floating-menu-container="true"
   >
     <div
-      className="security--combo-button__group"
+      class="security--combo-button__group"
     >
-      <Button
-        className="security--combo-button--primary"
-        disabled={false}
-        iconDescription=""
-        id="test-1"
-        kind="primary"
-        largeText={null}
-        loading={false}
-        onClick={[Function]}
-        renderIcon={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "render": [Function],
-          }
-        }
-        size="default"
-        tabIndex={0}
-        tooltipAlignment="center"
-        tooltipPosition="top"
+      <button
+        class="security--button security--combo-button--primary bx--btn bx--btn--primary"
+        id="test-primary-item"
+        tabindex="0"
         type="button"
       >
-        <Button
-          className="security--button security--combo-button--primary"
-          disabled={false}
-          iconDescription=""
-          id="test-1"
-          kind="primary"
-          onClick={[Function]}
-          renderIcon={
-            Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            }
-          }
-          size="default"
-          tabIndex={0}
-          tooltipAlignment="center"
-          tooltipPosition="top"
-          type="button"
+        <span
+          class="bx--text-truncate--end"
+          title="Primary task"
         >
-          <button
-            className="security--button security--combo-button--primary bx--btn bx--btn--primary"
-            disabled={false}
-            id="test-1"
-            onClick={[Function]}
-            tabIndex={0}
-            type="button"
-          >
-            <span
-              className="bx--text-truncate--end"
-              title="Start a task"
-            >
-              Start a task
-            </span>
-            <ForwardRef(ArrowRight20)
-              aria-hidden="true"
-              aria-label=""
-              className="bx--btn__icon"
-            >
-              <Icon
-                aria-hidden="true"
-                aria-label=""
-                className="bx--btn__icon"
-                fill="currentColor"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 20 20"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <svg
-                  aria-hidden={true}
-                  aria-label=""
-                  className="bx--btn__icon"
-                  fill="currentColor"
-                  focusable="false"
-                  height={20}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 20 20"
-                  width={20}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                  />
-                </svg>
-              </Icon>
-            </ForwardRef(ArrowRight20)>
-          </button>
-        </Button>
-      </Button>
+          Primary task
+        </span>
+        <svg
+          aria-hidden="true"
+          aria-label=""
+          class="bx--btn__icon"
+          fill="currentColor"
+          focusable="false"
+          height="20"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
-</ComboButton>
+</div>
 `;


### PR DESCRIPTION
## Pull request

### Affected issues

- Resolves #845 

### Proposed changes

- Spread `{...buttonProps}` onto the primary action button. This gives consumers the added flexibility to add props for the underlying `Button` element such as `target="_blank"` which for example provides the ability to open primary action links in a new tab.
- Migrated `ComboButton.spec.js` unit tests to using `react-testing-library` and added accessibility tests

### Testing instructions

- I have added the extra prop `target="_blank"` to the primary action item in `ComboButton.stories.js`. This link should now open in a new tab.
- I have also added an extra `ComboButtonItem` component to `ComboButton.stories.js` which exemplifies the use case of opening a link in a new tab. I think this offers greater visibility for consumers.