### PR TITLE
feat(navigation-card): add `NavigationCard` logic, story, and styles

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -10372,6 +10372,17 @@ li.bx--accordion__item--disabled:last-of-type {
   margin-bottom: 0.5rem;
 }
 
+.icon {
+  fill: var(--icon-01, #f4f4f4);
+}
+
+.label {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  letter-spacing: 0;
+}
+
 .security--ne-section {
   min-height: 12.5rem;
   background-position: center right;

--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -10372,15 +10372,13 @@ li.bx--accordion__item--disabled:last-of-type {
   margin-bottom: 0.5rem;
 }
 
-.icon {
-  fill: var(--icon-01, #f4f4f4);
-}
-
 .label {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
   letter-spacing: 0;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--ui-03, #393939);
 }
 
 .security--ne-section {

--- a/src/components/NavigationCard/NavigationCard.stories.js
+++ b/src/components/NavigationCard/NavigationCard.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import NavigationCard from '.';
+
+export default {
+  title: 'NavigationCard',
+};
+
+export const Default = () => <NavigationCard label="Card" link="Link" />;

--- a/src/components/NavigationCard/_index.scss
+++ b/src/components/NavigationCard/_index.scss
@@ -1,0 +1,10 @@
+@import '@carbon/themes/scss/tokens';
+@import '@carbon/type/scss/styles';
+
+.icon {
+  fill: $icon-01;
+}
+
+.label {
+  @include carbon--type-style($name: productive-heading-03);
+}

--- a/src/components/NavigationCard/_index.scss
+++ b/src/components/NavigationCard/_index.scss
@@ -1,10 +1,10 @@
+@import '@carbon/layout/scss/spacing';
 @import '@carbon/themes/scss/tokens';
 @import '@carbon/type/scss/styles';
 
-.icon {
-  fill: $icon-01;
-}
-
 .label {
   @include carbon--type-style($name: productive-heading-03);
+
+  padding-bottom: $carbon--spacing-05;
+  border-bottom: 1px solid $ui-03;
 }

--- a/src/components/NavigationCard/index.js
+++ b/src/components/NavigationCard/index.js
@@ -1,0 +1,27 @@
+import { ArrowRight16 } from '@carbon/icons-react';
+
+import { string } from 'prop-types';
+import React from 'react';
+
+import Card from '../Card';
+import Link from '../Link';
+
+const NavigationCard = ({ label, link }) => (
+  <Card>
+    <ArrowRight16 className="icon" />
+
+    <h3 className="label">{label}</h3>
+
+    <Link href="#">{link}</Link>
+  </Card>
+);
+
+NavigationCard.propTypes = {
+  /** Provide the label of the `NavigationCard`. */
+  label: string.isRequired,
+
+  /** Provide the contents of the `Link`. */
+  link: string.isRequired,
+};
+
+export default NavigationCard;

--- a/src/components/NavigationCard/index.js
+++ b/src/components/NavigationCard/index.js
@@ -8,7 +8,7 @@ import Link from '../Link';
 
 const NavigationCard = ({ label, link }) => (
   <Card>
-    <ArrowRight16 className="icon" />
+    <ArrowRight16 />
 
     <h3 className="label">{label}</h3>
 

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -21,6 +21,7 @@
 @import 'InteractiveTag/index';
 @import 'ListBox/index';
 @import 'Nav/index';
+@import 'NavigationCard/index';
 @import 'NonEntitledSection/index';
 @import 'Notification/index';
 @import 'Panel/index';


### PR DESCRIPTION
## Pull request - feat(big-rocks): add `NavigationCard` logic, story, and styles

### Details

| Name               | Description                                                                      |
| ------------------ | -------------------------------------------------------------------------------- |
| Title              | `NavigationCard`                                                                 |
| Description        | Inform the user of actionable navigation                                         |
| Project            | Dashboard                                                                        |
| Estimated delivery | January 19, 2021                                                                 |
| Storybook          | https://deploy-preview-857--ibm-security.netlify.app/?path=/story/navigationcard |
| Design owner       | Robyn Johnson                                                                    |
| Development owner  | Claire Kingston                                                                  |

### Design

![NavigationCard](https://user-images.githubusercontent.com/3846874/101169555-0893c280-3635-11eb-87f7-2be62b38a318.png)

### Proposed change

Add `NavigationCard` logic, story, and styles

### Testing instructions

Review `navigationcard--default` story
