### PR TITLE
docs(layout-modules): add missing `narrow grid` links

### DIFF
--- a/src/components/UNSTABLE__LayoutModules/CardModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/CardModule/index.mdx
@@ -72,7 +72,7 @@ The cards within the module can also be arranged in a number of different ways.
 
 ### Grid placement
 
-Card modules can span between 4 and 16 columns. Following the narrow grid implementation, the layout module container hangs 16 pixels in the left margin. The narrow grid position allows headings and copy outside of containers to align with the labels within the card module.
+Card modules can span between 4 and 16 columns. Following the [narrow grid](https://react.carbondesignsystem.com/?path=/docs/grid--narrow) implementation, the layout module container hangs 16 pixels in the left margin. The narrow grid position allows headings and copy outside of containers to align with the labels within the card module.
 
 <Row>
   <Column>

--- a/src/components/UNSTABLE__LayoutModules/ICAModule/index.mdx
+++ b/src/components/UNSTABLE__LayoutModules/ICAModule/index.mdx
@@ -80,7 +80,7 @@ If the ICA needs to be interactive, a background hover can be placed on the grid
 
 ### Grid placement
 
-ICAs within ICA modules can span across 2 or 3 columns, following the narrow grid implementation.
+ICAs within ICA modules can span across 2 or 3 columns, following the [narrow grid](https://react.carbondesignsystem.com/?path=/docs/grid--narrow) implementation.
 
 <Row>
   <Column>


### PR DESCRIPTION
## Pull request - docs(layout-modules): add missing `narrow grid` links

### Affected issue

Resolves #858

### Proposed change

Add missing 'narrow grid' links to `CardModule` and `ICAModule`