### PR TITLE
feat(toolbar): enable nodes in titles

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -317,7 +317,7 @@ const navigation = {
   id: PropTypes.string.isRequired,
 
   /** @type {string} The title of the navigation. */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
 
   /** @type {node} Content. */
   content: PropTypes.node,

--- a/src/components/Toolbar/_mocks_/index.js
+++ b/src/components/Toolbar/_mocks_/index.js
@@ -4,9 +4,10 @@
  */
 
 import { action } from '@storybook/addon-actions';
-
+import React from 'react';
 import { icon, url, random } from '../../_mocks_';
 import labels from '../locales/en/Toolbar.json';
+import Tag from '../../Tag';
 
 /**
  * Generates the initial navigation model.
@@ -50,7 +51,13 @@ const applicationsToGenerate = [
     children: generateApplications([
       { title: 'Applications' },
       { title: 'Plugins' },
-      { title: 'Users' },
+      {
+        title: (
+          <div>
+            Applications<Tag>Beta</Tag>
+          </div>
+        ),
+      },
     ]),
   },
   {

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -8813,7 +8813,7 @@ Map {
                                           "isRequired": true,
                                           "title": Object {
                                             "isRequired": true,
-                                            "type": "string",
+                                            "type": "node",
                                           },
                                           "type": "string",
                                         },
@@ -8839,7 +8839,7 @@ Map {
                                 },
                                 "title": Object {
                                   "isRequired": true,
-                                  "type": "string",
+                                  "type": "node",
                                 },
                               },
                             ],
@@ -8851,7 +8851,7 @@ Map {
                       },
                       "title": Object {
                         "isRequired": true,
-                        "type": "string",
+                        "type": "node",
                       },
                     },
                   ],
@@ -8925,7 +8925,7 @@ Map {
                                           "isRequired": true,
                                           "title": Object {
                                             "isRequired": true,
-                                            "type": "string",
+                                            "type": "node",
                                           },
                                           "type": "string",
                                         },
@@ -8951,7 +8951,7 @@ Map {
                                 },
                                 "title": Object {
                                   "isRequired": true,
-                                  "type": "string",
+                                  "type": "node",
                                 },
                               },
                             ],
@@ -8963,7 +8963,7 @@ Map {
                       },
                       "title": Object {
                         "isRequired": true,
-                        "type": "string",
+                        "type": "node",
                       },
                     },
                   ],
@@ -9011,7 +9011,7 @@ Map {
                                           "isRequired": true,
                                           "title": Object {
                                             "isRequired": true,
-                                            "type": "string",
+                                            "type": "node",
                                           },
                                           "type": "string",
                                         },
@@ -9037,7 +9037,7 @@ Map {
                                 },
                                 "title": Object {
                                   "isRequired": true,
-                                  "type": "string",
+                                  "type": "node",
                                 },
                               },
                             ],
@@ -9049,7 +9049,7 @@ Map {
                       },
                       "title": Object {
                         "isRequired": true,
-                        "type": "string",
+                        "type": "node",
                       },
                     },
                   ],
@@ -12619,7 +12619,7 @@ Map {
                                     "isRequired": true,
                                     "title": Object {
                                       "isRequired": true,
-                                      "type": "string",
+                                      "type": "node",
                                     },
                                     "type": "string",
                                   },
@@ -12645,7 +12645,7 @@ Map {
                           },
                           "title": Object {
                             "isRequired": true,
-                            "type": "string",
+                            "type": "node",
                           },
                         },
                       ],
@@ -12657,7 +12657,7 @@ Map {
                 },
                 "title": Object {
                   "isRequired": true,
-                  "type": "string",
+                  "type": "node",
                 },
               },
             ],
@@ -12731,7 +12731,7 @@ Map {
                                     "isRequired": true,
                                     "title": Object {
                                       "isRequired": true,
-                                      "type": "string",
+                                      "type": "node",
                                     },
                                     "type": "string",
                                   },
@@ -12757,7 +12757,7 @@ Map {
                           },
                           "title": Object {
                             "isRequired": true,
-                            "type": "string",
+                            "type": "node",
                           },
                         },
                       ],
@@ -12769,7 +12769,7 @@ Map {
                 },
                 "title": Object {
                   "isRequired": true,
-                  "type": "string",
+                  "type": "node",
                 },
               },
             ],
@@ -12817,7 +12817,7 @@ Map {
                                     "isRequired": true,
                                     "title": Object {
                                       "isRequired": true,
-                                      "type": "string",
+                                      "type": "node",
                                     },
                                     "type": "string",
                                   },
@@ -12843,7 +12843,7 @@ Map {
                           },
                           "title": Object {
                             "isRequired": true,
-                            "type": "string",
+                            "type": "node",
                           },
                         },
                       ],
@@ -12855,7 +12855,7 @@ Map {
                 },
                 "title": Object {
                   "isRequired": true,
-                  "type": "string",
+                  "type": "node",
                 },
               },
             ],


### PR DESCRIPTION
## Pull request -
Changed toolbar title from prop type string to node so we can have a title as well as a component.

### Affected issues

- Resolves  SECCON-9522

### Proposed changes
- Change title string to node
- Updated storybook mocks also

