### PR TITLE
fix(summary-card): fix high contrast issue

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -16788,10 +16788,6 @@ li.bx--accordion__item--disabled:last-of-type {
   color: var(--text-01, #f4f4f4);
 }
 
-.security--summary-card__action-overlay__close-button .bx--btn__icon path, .security--summary-card__action-overlay__close-button:hover .bx--btn__icon path, .security--summary-card__action-overlay__close-button:focus .bx--btn__icon path, .security--summary-card__action-overlay__close-button:active .bx--btn__icon path {
-  fill: var(--icon-01, #f4f4f4);
-}
-
 .security--summary-card__action-overlay__close-button .bx--btn__icon {
   margin-left: 0;
   height: 1.25rem;

--- a/src/components/SummaryCard/_mixins.scss
+++ b/src/components/SummaryCard/_mixins.scss
@@ -1,7 +1,7 @@
 ////
 /// Summary card mixins.
 /// @group summary-card
-/// @copyright IBM Security 2019 - 2020
+/// @copyright IBM Security 2019 - 2021
 ////
 
 @import '@carbon/layout/scss/mini-unit';
@@ -192,10 +192,6 @@
       &:focus,
       &:active {
         color: $text-01;
-
-        .#{$prefix}--btn__icon path {
-          fill: $icon-01;
-        }
       }
 
       .#{$prefix}--btn__icon {


### PR DESCRIPTION
## Pull request - fix(summary-card): fix high contrast issue

### Proposed change

Allow Carbon manage icon color for `SummaryCard` close button