### PR TITLE
feat(list-module): add ListItemModule stories

### DIFF
--- a/docs/themes/themes.md
+++ b/docs/themes/themes.md
@@ -22,7 +22,6 @@
 | `icon-02`            | `cool-gray-70`    | `gray-30`         |
 | `icon-03`            | `white-0`         | `white-0`         |
 | `link-01`            | `blue-60`         | `blue-40`         |
-| `link-02`            | `blue-70`         | `blue-30`         |
 | `inverse-link`       | `blue-40`         | `blue-60`         |
 | `field-01`           | `white-0`         | `gray-90`         |
 | `field-02`           | `cool-gray-10`    | `gray-80`         |
@@ -67,7 +66,7 @@
 | `decorative-01`      | `cool-gray-20`    | `gray-70`         |
 | `button-separator`   | `cool-gray-20`    | `gray-100`        |
 | `skeleton-01`        | `#e0e4ea`         | `#353535`         |
-| `skeleton-02`        | `cool-gray-30`    | `gray-70`         |
+| `skeleton-02`        | `cool-gray-30`    | `gray-80`         |
 | `brand-01`           | `blue-60`         | `blue-60`         |
 | `brand-02`           | `cool-gray-80`    | `gray-60`         |
 | `brand-03`           | `blue-60`         | `white-0`         |

--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -27188,6 +27188,7 @@ a.bx--navigation-link:focus {
 
 .security--unstable--layout__module--list-item--button {
   text-align: left;
+  width: inherit;
 }
 
 .security--unstable--layout__module--list-item--a:focus, .security--unstable--layout__module--list-item--a:hover, .security--unstable--layout__module--list-item--button:focus, .security--unstable--layout__module--list-item--button:hover {

--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -27177,12 +27177,52 @@ a.bx--navigation-link:focus {
   border-width: 0;
 }
 
+.security--unstable--layout__module--list-item--a, .security--unstable--layout__module--list-item--button {
+  transition-duration: 0.2s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.security--unstable--layout__module--list-item--button {
+  text-align: left;
+}
+
+.security--unstable--layout__module--list-item--a:focus, .security--unstable--layout__module--list-item--a:hover, .security--unstable--layout__module--list-item--button:focus, .security--unstable--layout__module--list-item--button:hover {
+  background-color: var(--hover-ui, #353535);
+}
+
+.security--unstable--layout__module--list-item--a:focus, .security--unstable--layout__module--list-item--button:focus {
+  outline: 2px solid var(--focus, #ffffff);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .security--unstable--layout__module--list-item--a:focus, .security--unstable--layout__module--list-item--button:focus {
+    outline-style: dotted;
+  }
+}
+
+.security--unstable--layout__module--list-item__farside-column {
+  margin-left: auto;
+}
+
+.security--unstable--layout__module--list-item__distributed-column {
+  margin-right: auto;
+}
+
 .security--unstable--layout__module--list-item__title, .security--unstable--layout__module--list-item__description {
   margin-top: 0;
 }
 
 .security--unstable--layout__module--list-item__icon {
   margin-right: 1rem;
+}
+
+.security--unstable--layout__module--list-item__top-icon {
+  margin-bottom: 1rem;
 }
 
 .security--unstable--layout__module--list-item__avatar {
@@ -27217,6 +27257,7 @@ a.bx--navigation-link:focus {
   font-weight: 400;
   line-height: 1.34;
   letter-spacing: 0.32px;
+  display: block;
   margin-top: 0.25rem;
 }
 
@@ -27226,6 +27267,11 @@ a.bx--navigation-link:focus {
 
 .security--unstable--layout__module--list-item__title:last-child, .security--unstable--layout__module--list-item__description:last-child, .security--unstable--layout__module--list-item__label:last-child {
   margin-bottom: 0;
+}
+
+.security--unstable--layout__module--list-item .bx--tag {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
 }
 
 .security--unstable--layout__module--list-item__component {

--- a/src/components/UNSTABLE__LayoutModules/ListItemModule/ListItemModule.stories.js
+++ b/src/components/UNSTABLE__LayoutModules/ListItemModule/ListItemModule.stories.js
@@ -9,6 +9,9 @@ import {
   Locked16,
   UserAvatar20,
 } from '@carbon/icons-react';
+
+import { action } from '@storybook/addon-actions';
+
 import React from 'react';
 
 import { getDocsParameters } from '../../../../.storybook';
@@ -33,13 +36,11 @@ export default {
 export const Default = () => (
   <ListItemModule href="#">
     {({ Column, getLayoutProps }) => (
-      <>
-        <Column>
-          <h2 {...getLayoutProps({ type: 'title' })}>List title</h2>
+      <Column>
+        <h2 {...getLayoutProps({ type: 'title' })}>List title</h2>
 
-          <span {...getLayoutProps({ type: 'label' })}>Label</span>
-        </Column>
-      </>
+        <span {...getLayoutProps({ type: 'label' })}>Label</span>
+      </Column>
     )}
   </ListItemModule>
 );
@@ -47,27 +48,23 @@ export const Default = () => (
 export const NonInteractive = () => (
   <ListItemModule>
     {({ Column, getLayoutProps }) => (
-      <>
-        <Column>
-          <h2 {...getLayoutProps({ type: 'title' })}>List title</h2>
+      <Column>
+        <h2 {...getLayoutProps({ type: 'title' })}>List title</h2>
 
-          <span {...getLayoutProps({ type: 'label' })}>Label</span>
-        </Column>
-      </>
+        <span {...getLayoutProps({ type: 'label' })}>Label</span>
+      </Column>
     )}
   </ListItemModule>
 );
 
 export const AsButton = () => (
-  <ListItemModule onClick={() => console.log('hi')}>
+  <ListItemModule onClick={action('onClick')}>
     {({ Column, getLayoutProps }) => (
-      <>
-        <Column>
-          <h2 {...getLayoutProps({ type: 'title' })}>List title</h2>
+      <Column>
+        <h2 {...getLayoutProps({ type: 'title' })}>List title</h2>
 
-          <span {...getLayoutProps({ type: 'label' })}>Label</span>
-        </Column>
-      </>
+        <span {...getLayoutProps({ type: 'label' })}>Label</span>
+      </Column>
     )}
   </ListItemModule>
 );

--- a/src/components/UNSTABLE__LayoutModules/ListItemModule/ListItemModule.stories.js
+++ b/src/components/UNSTABLE__LayoutModules/ListItemModule/ListItemModule.stories.js
@@ -3,7 +3,12 @@
  * @copyright IBM Security 2021
  */
 
-import { Bee16, Locked16, UserAvatar20 } from '@carbon/icons-react';
+import {
+  Bee16,
+  InProgress16,
+  Locked16,
+  UserAvatar20,
+} from '@carbon/icons-react';
 import React from 'react';
 
 import { getDocsParameters } from '../../../../.storybook';
@@ -39,7 +44,7 @@ export const Default = () => (
   </ListItemModule>
 );
 
-export const Static = () => (
+export const NonInteractive = () => (
   <ListItemModule>
     {({ Column, getLayoutProps }) => (
       <>
@@ -93,7 +98,7 @@ export const Detailed = () => (
           <UserAvatar20 {...getLayoutProps({ type: 'avatar' })} />
         </Column>
 
-        <Column {...getLayoutProps({ type: 'right-column' })}>
+        <Column {...getLayoutProps({ type: 'farside-column' })}>
           <Locked16 />
         </Column>
       </>
@@ -135,11 +140,11 @@ export const WithTag = () => (
   <ListItemModule href="#">
     {({ Column, getLayoutProps }) => (
       <>
-        <Column {...getLayoutProps({ type: 'centered-column' })}>
+        <Column {...getLayoutProps()}>
           <h2 {...getLayoutProps({ type: 'title' })}>Bill Callahan</h2>
         </Column>
 
-        <Column {...getLayoutProps({ type: 'right-column' })}>
+        <Column {...getLayoutProps({ type: 'farside-column' })}>
           <Tag>16</Tag>
         </Column>
       </>
@@ -162,21 +167,6 @@ export const WithComponent = () => (
 
           <section {...getLayoutProps({ type: 'component' })}>
             <ICA label="Label" value={100} />
-            {/* <Button
-              iconDescription="Button icon"
-              kind="ghost"
-              largeText={null}
-              onClick={function noRefCheck(){}}
-              onFocus={function noRefCheck(){}}
-              renderIcon={Add16}
-              size="field"
-              tabIndex={0}
-              tooltipAlignment="center"
-              tooltipPosition="top"
-              type="button"
-            >
-              Add to canvas
-            </Button> */}
           </section>
         </Column>
       </>
@@ -196,7 +186,7 @@ export const WithStatusIcon = () => (
           <span {...getLayoutProps({ type: 'label' })}>Threat activity</span>
         </Column>
 
-        <Column {...getLayoutProps({ type: 'right-column' })}>
+        <Column {...getLayoutProps({ type: 'farside-column' })}>
           <StatusIcon iconDescription="Status Icon" size="lg" status="info" />
         </Column>
       </>
@@ -204,12 +194,12 @@ export const WithStatusIcon = () => (
   </ListItemModule>
 );
 
-export const WithInProgressStatus = () => (
+export const WithInProgressIcon = () => (
   <ListItemModule href="#">
     {({ Column, getLayoutProps }) => (
       <>
         <Column>
-          <Bee16 {...getLayoutProps({ type: 'icon' })} />
+          <InProgress16 {...getLayoutProps({ type: 'icon' })} />
         </Column>
 
         <Column>
@@ -224,7 +214,7 @@ export const WithInProgressStatus = () => (
   </ListItemModule>
 );
 
-export const Columns = () => (
+export const WithDistributedColumns = () => (
   <ListItemModule href="#">
     {({ Column, getLayoutProps }) => (
       <>
@@ -232,15 +222,15 @@ export const Columns = () => (
           <Bee16 {...getLayoutProps({ type: 'icon' })} />
         </Column>
 
-        <Column {...getLayoutProps({ type: 'narrow-column' })}>
+        <Column {...getLayoutProps({ type: 'distributed-column' })}>
           <h2 {...getLayoutProps({ type: 'title' })}>Asset_name</h2>
         </Column>
 
-        <Column {...getLayoutProps({ type: 'narrow-column' })}>
+        <Column {...getLayoutProps({ type: 'distributed-column' })}>
           <h2 {...getLayoutProps({ type: 'title' })}>Data set</h2>
         </Column>
 
-        <Column {...getLayoutProps({ type: 'narrow-column' })}>
+        <Column {...getLayoutProps({ type: 'distributed-column' })}>
           <h2 {...getLayoutProps({ type: 'title' })}>3:47 pm</h2>
         </Column>
       </>

--- a/src/components/UNSTABLE__LayoutModules/ListItemModule/_index.scss
+++ b/src/components/UNSTABLE__LayoutModules/ListItemModule/_index.scss
@@ -33,7 +33,6 @@
   &--button {
     @include transition($transition-property: background-color);
 
-    // display: block;
     color: inherit;
     text-decoration: none;
     cursor: pointer;
@@ -41,27 +40,25 @@
 
   &--button {
     text-align: left;
-    // TODO: width: 33vw; ?
   }
 
+  &--a:focus,
+  &--a:hover,
   &--button:focus,
   &--button:hover {
     background-color: $hover-ui;
   }
 
+  &--a:focus,
   &--button:focus {
     @include focus-outline($type: outline);
   }
 
-  &__centered-column {
-    align-self: center;
-  }
-
-  &__right-column {
+  &__farside-column {
     margin-left: auto;
   }
 
-  &__narrow-column {
+  &__distributed-column {
     margin-right: auto;
   }
 
@@ -75,7 +72,6 @@
   }
 
   &__top-icon {
-    // margin-left: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-05;
   }
 
@@ -117,26 +113,15 @@
     }
   }
 
+  .bx--tag {
+    margin-top: -$carbon--spacing-02;
+    margin-bottom: -$carbon--spacing-02;
+  }
+
   // TODO: class naming (right-to-left readers, etc)
-  // TODO: wide screens, Button does not cover entire bottom
 
   &__component {
     margin-top: $carbon--spacing-05;
     margin-bottom: 0;
-
-    /****
-    * For ghost button as last component
-    *
-    &:last-child {
-      min-width: 100%;
-      margin-right: -$carbon--spacing-05;
-      margin-bottom: -$carbon--spacing-05;
-      margin-left: -$carbon--spacing-05;
-
-      button:last-child {
-        min-width: 100%;
-        justify-content: flex-start;
-      }
-    }****/
   }
 }

--- a/src/components/UNSTABLE__LayoutModules/ListItemModule/_index.scss
+++ b/src/components/UNSTABLE__LayoutModules/ListItemModule/_index.scss
@@ -42,6 +42,7 @@
 
   &--button {
     text-align: left;
+    width: inherit;
   }
 
   &--a:focus,

--- a/src/components/UNSTABLE__LayoutModules/ListItemModule/_index.scss
+++ b/src/components/UNSTABLE__LayoutModules/ListItemModule/_index.scss
@@ -10,6 +10,8 @@
 
 @import '../../../globals/border/index';
 
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+
 @import '../../Component/mixins';
 @import '../variables';
 

--- a/src/components/UNSTABLE__LayoutModules/ListItemModule/index.js
+++ b/src/components/UNSTABLE__LayoutModules/ListItemModule/index.js
@@ -12,7 +12,7 @@ import LayoutModule, { layoutModuleNamespace } from '../LayoutModule';
 const namespace = 'list-item';
 
 /**
- * TODO: Description.
+ * The ListItem is a module designed for flexibility. It consists of optional pieces that can be used to design & build variants with universal consistency.
  */
 const ListItemModule = ({ children, as, href, onClick, ...other }) => {
   const content = children({
@@ -30,15 +30,13 @@ const ListItemModule = ({ children, as, href, onClick, ...other }) => {
 
   let component = 'div';
 
-  if (as) {
+  if (as !== 'div') {
     component = as;
   } else if (href) {
     component = 'a';
   } else if (onClick) {
     component = 'button';
   }
-
-  // div under button which is a flexbox with text-align: left
 
   return (
     <LayoutModule
@@ -52,18 +50,6 @@ const ListItemModule = ({ children, as, href, onClick, ...other }) => {
     </LayoutModule>
   );
 };
-
-/*    <>
-      {hover ? (
-        <LayoutModule namespace={`${namespace} ${layoutModuleNamespace}--${namespace}--hover`} as={'a'} href="#" {...other}>
-          {content}
-        </LayoutModule>
-      ) : (
-        <LayoutModule namespace={namespace} {...other}>
-          {content}
-        </LayoutModule>
-      )}
-    </> */
 
 ListItemModule.propTypes = {
   /** Provide the content for the `ListItemModule` */

--- a/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI.spec.js.snap
@@ -5466,9 +5466,23 @@ Map {
     },
   },
   "ListItemModule" => Object {
+    "defaultProps": Object {
+      "as": "div",
+      "href": null,
+      "onClick": null,
+    },
     "propTypes": Object {
+      "as": Object {
+        "type": "elementType",
+      },
       "children": Object {
         "isRequired": true,
+        "type": "func",
+      },
+      "href": Object {
+        "type": "string",
+      },
+      "onClick": Object {
         "type": "func",
       },
     },


### PR DESCRIPTION
## Pull request 
Adding new stories for ListItem Module:
- Default
- Non Interactive
- As Button
- Detailed
- With Profile Image
- With Tag
- With Component
- With Status Icon
- With In Progress Icon
- With Distributed Columns

### Affected issues

- For [listItem module #243](https://github.ibm.com/security/design-core-experience/issues/243)

### Proposed changes

- 10 stories for ListItem module in Storybook

### Testing instructions

- Go to the UNSTABLE Layout Modules -> ListItemModule in storybook
- Browse through the 10 stories
- Consider functionality such as hover, links, nested components, column layouts, etc.