### PR TITLE
fix(PanelV2): change footer position from fixed to absolute

### DIFF
--- a/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
+++ b/src/__tests__/scss/__snapshots__/SCSS.spec.js.snap
@@ -5928,7 +5928,7 @@ a.bx--overflow-menu-options__btn::before {
 
 .security--panel--v2__footer {
   display: flex;
-  position: fixed;
+  position: absolute;
   bottom: 0;
   width: 20rem;
 }

--- a/src/components/PanelV2/_mixins.scss
+++ b/src/components/PanelV2/_mixins.scss
@@ -151,7 +151,7 @@
 
   &__footer {
     display: flex;
-    position: fixed;
+    position: absolute;
     bottom: 0;
     width: $panel__sizing__width;
 


### PR DESCRIPTION
## Pull request - change footer position to absolute

### Proposed changes
Current panelV2 footer position is set to `fixed`. This would create another stacking context within footer.
This might cause footer overflow menu has lower `z-index` than other element in panel context.

See below screenshot :
<img width="1433" alt="Screen Shot 2021-04-16 at 12 22 59" src="https://user-images.githubusercontent.com/5744158/114971279-95397180-9eae-11eb-96c2-b07e17374bcb.png">




