### PR TITLE
fix: change require to import syntax for `carbon-components` to allow treeshaking again

### DIFF
--- a/src/components/TruncatedList/TruncatedList.js
+++ b/src/components/TruncatedList/TruncatedList.js
@@ -6,11 +6,10 @@
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
 
 import Button from '../Button';
 import ScrollGradient from '../ScrollGradient';
-import { getComponentNamespace } from '../../globals/namespace';
+import { carbonPrefix, getComponentNamespace } from '../../globals/namespace';
 import theme from '../../globals/theme';
 
 const namespace = getComponentNamespace('truncated-list');
@@ -108,7 +107,7 @@ const TruncatedList = ({
         <Button
           className={classnames(
             expandButtonClassName,
-            `${settings.prefix}--link`,
+            `${carbonPrefix}--link`,
             `${namespace}__expand-button`
           )}
           iconDescription=""

--- a/src/globals/namespace/index.js
+++ b/src/globals/namespace/index.js
@@ -3,9 +3,9 @@
  * @copyright IBM Security 2018 - 2021
  */
 
-const {
-  settings: { prefix: carbonPrefix },
-} = require('carbon-components');
+import { settings } from 'carbon-components';
+
+const carbonPrefix = settings.prefix;
 
 const namespace = 'security--';
 


### PR DESCRIPTION
## Pull request - <!-- Short description -->

### Affected issues

- `carbon-components` JavaScript ends up entirely in the application bundle

### Proposed changes

- change require to import syntax for `carbon-components` to allow treeshaking again

### Testing instructions

- check the snapshot tests to make sure the same prefix is still applied
