### PR TITLE
docs(README): fix copy, update npm guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install Carbon for IBM Security in your project, you'll need to run one of th
 
 ```bash
 # npm - https://www.npmjs.com
-npm i -S @carbon/ibm-security
+npm i @carbon/ibm-security
 
 # Yarn - https://yarnpkg.com
 yarn add @carbon/ibm-security
@@ -44,7 +44,7 @@ yarn add @carbon/ibm-security
 
 ### Distribution tags
 
-Please use [distribution tags](https://docs.npmjs.com/cli/dist-tag) to install the most relevant version of this framework. e.g. `npm i -S @carbon/ibm-security@latest`:
+Please use [distribution tags](https://docs.npmjs.com/cli/dist-tag) to install the most relevant version of this library. e.g. `npm i @carbon/ibm-security@latest`:
 
 - `@latest` - Stable
 - `@canary` - Unstable prerelease


### PR DESCRIPTION
## Pull request - docs(README): fix copy, update npm guidance

### Proposed change

Fix README copy and update npm guidance - [`-S` is no longer needed by npm](https://docs.npmjs.com/cli/v7/commands/npm-install)