### PR TITLE
build: automate and schedule Carbon dependencies upgrades

### DIFF
--- a/.github/workflows/carbon.yml
+++ b/.github/workflows/carbon.yml
@@ -29,9 +29,9 @@ jobs:
       #   run: yarn test -u
 
       - name: Create pull request
-        id: cpr
         uses: peter-evans/create-pull-request@v3 # https://github.com/marketplace/actions/create-pull-request
         with:
           title: 'feat: upgrade Carbon dependencies'
           body: https://github.com/carbon-design-system/carbon/releases
-          branch: ${{ steps.cpr.outputs.pull-request-number }}/upgrade-carbon
+          branch: upgrade-carbon
+          branch-suffix: short-commit-hash

--- a/.github/workflows/carbon.yml
+++ b/.github/workflows/carbon.yml
@@ -1,8 +1,10 @@
 name: Upgrade Carbon
 
 on:
-  schedule:
-    - cron: '0 3 * * WED'
+  push:
+    branches: [create-carbon-pr]
+  # schedule:
+  #   - cron: '0 3 * * WED'
 
 jobs:
   Upgrade:
@@ -27,9 +29,10 @@ jobs:
         run: yarn test -u
 
       - name: Create pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v3 # https://github.com/marketplace/actions/create-pull-request
         with:
           commit-message: &commit-message 'feat: upgrade Carbon dependencies'
           title: *commit-message
-          body: *commit-message
-          branch: upgrade-carbon
+          body: https://github.com/carbon-design-system/carbon/releases
+          branch: ${{ steps.cpr.outputs.pull-request-number }}/upgrade-carbon

--- a/.github/workflows/carbon.yml
+++ b/.github/workflows/carbon.yml
@@ -32,7 +32,6 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3 # https://github.com/marketplace/actions/create-pull-request
         with:
-          commit-message: &commit-message 'feat: upgrade Carbon dependencies'
-          title: *commit-message
+          title: 'feat: upgrade Carbon dependencies'
           body: https://github.com/carbon-design-system/carbon/releases
           branch: ${{ steps.cpr.outputs.pull-request-number }}/upgrade-carbon

--- a/.github/workflows/carbon.yml
+++ b/.github/workflows/carbon.yml
@@ -1,0 +1,35 @@
+name: Upgrade Carbon
+
+on:
+  schedule:
+    - cron: '0 3 * * WED'
+
+jobs:
+  Upgrade:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2 # https://github.com/actions/checkout
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2 # https://github.com/actions/setup-node
+        with:
+          node-version: 12
+
+      - name: Install
+        run: yarn --offline
+
+      - name: Upgrade Carbon dependencies
+        run: yarn upgrade -L --caret --pattern 'carbon'
+
+      - name: Update snapshot artifacts
+        run: yarn test -u
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3 # https://github.com/marketplace/actions/create-pull-request
+        with:
+          commit-message: &commit-message 'feat: upgrade Carbon dependencies'
+          title: *commit-message
+          body: *commit-message
+          branch: upgrade-carbon

--- a/.github/workflows/carbon.yml
+++ b/.github/workflows/carbon.yml
@@ -2,9 +2,8 @@ name: Upgrade Carbon
 
 on:
   push:
-    branches: [create-carbon-pr]
-  # schedule:
-  #   - cron: '0 3 * * WED'
+    schedule:
+      - cron: '0 3 * * WED'
 
 jobs:
   Upgrade:
@@ -23,10 +22,7 @@ jobs:
         run: yarn --offline
 
       - name: Upgrade Carbon dependencies
-        run: yarn upgrade -L --caret --pattern 'carbon'
-
-      # - name: Update snapshot artifacts
-      #   run: yarn test -u
+        run: yarn upgrade -L --caret --pattern 'carbon' # https://classic.yarnpkg.com/en/docs/cli/upgrade/#toc-yarn-upgrade-package-package-tag-package-version-scope-ignore-engines-pattern
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v3 # https://github.com/marketplace/actions/create-pull-request

--- a/.github/workflows/carbon.yml
+++ b/.github/workflows/carbon.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Upgrade Carbon dependencies
         run: yarn upgrade -L --caret --pattern 'carbon'
 
-      - name: Update snapshot artifacts
-        run: yarn test -u
+      # - name: Update snapshot artifacts
+      #   run: yarn test -u
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
## Pull request - build: automate and schedule Carbon dependencies upgrades

### Affected issue

Contributes to #976

### Proposed change

Add GitHub Action to automate and schedule PRs for Carbon dependencies upgrades

### Testing instruction

Review https://github.com/carbon-design-system/ibm-security/pull/996