### PR TITLE
feat(tearsheet-small): undeprecate `children` prop

### DIFF
--- a/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.js
+++ b/src/components/Tearsheet/TearsheetSmall/TearsheetSmall.js
@@ -5,7 +5,6 @@
 
 import { Close20 } from '@carbon/icons-react';
 
-import deprecate from 'carbon-components-react/es/prop-types/deprecate';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
@@ -210,11 +209,8 @@ TearsheetSmall.propTypes = {
     PropTypes.element,
   ]),
 
-  /** @deprecated Deprecated. Please use `body` prop. */
-  children: deprecate(
-    PropTypes.element,
-    `\nThe prop \`children\` for TearsheetSmall has been deprecated in favor of \`body\`.`
-  ),
+  /** Provide the content for the `TearsheetSmall` */
+  children: PropTypes.element,
 
   /** @type {object<object>} An object list of primary button props. */
   primaryButton: buttonType.isRequired,

--- a/src/components/__tests__/__snapshots__/publicAPI-test.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI-test.js.snap
@@ -11764,7 +11764,9 @@ Map {
         ],
         "type": "oneOfType",
       },
-      "children": [Function],
+      "children": Object {
+        "type": "element",
+      },
       "className": Object {
         "type": "string",
       },


### PR DESCRIPTION
## Pull request - feat(tearsheet-small): undeprecate `children` prop

### Affected issue

Contributes to #973 

### Proposed change

To prepare for Cloud & Cognitive compatibility, undeprecate `children` prop to suppress the warning in the test output without having to rewrite the test suite.