### PR TITLE
test(styles): fix file reference

### DIFF
--- a/src/__tests__/scss/styles-test.js
+++ b/src/__tests__/scss/styles-test.js
@@ -12,7 +12,7 @@ describe('Styles', () => {
   test('Bundle', () => {
     expect(
       renderSync({
-        file: resolve(root, 'src/index.scss'),
+        file: resolve(__dirname, '../../index.scss'),
         includePaths: [resolve(root, 'node_modules')],
         outputStyle: 'expanded',
       }).css.toString()


### PR DESCRIPTION
## Pull request - test(styles): fix file reference

### Affected issue

- Contributes to #973 
- Resolves https://github.com/carbon-design-system/ibm-cloud-cognitive/pull/918/checks#step:7:1114

### Proposed change

Make styles test entry point relative to the current directory as the `root` variable will vary between repos. In `ibm-security` it's `__dirname`, but in `ibm-cloud-cognitive`, as it's a monorepo, it's `${__dirname}/../..`