### PR TITLE
chore(globals): fix jsdoc params in deprecate util

### DIFF
--- a/src/globals/deprecate/index.js
+++ b/src/globals/deprecate/index.js
@@ -10,7 +10,7 @@ import isDevelopment from '../env';
  * @param {string} description The description to use when logging.
  * @param {string} type The property type to log.
  * @param {Array.<string>} componentKeys The component keys to filter.
- * @param {Function} condition The condition to filter the component keys.
+ * @param {Function} filterCondition The condition to filter the component keys.
  * @returns {string} The description and appropriate properties.
  */
 const logDeviations = (description, type, componentKeys, filterCondition) =>


### PR DESCRIPTION
## Pull request - <!-- Short description -->

### Affected issues

- Resolves eslint finding

### Proposed changes

- Align function and jsdoc param name

### Testing instructions

- <!-- List of instructions for reviewer to test that proposed changes in this PR work properly -->
