### PR TITLE
fix(nav-item): remove unused prop `onKeyPress`

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -123,8 +123,14 @@ export default class Nav extends Component {
   }
 
   render() {
-    const { activeHref, className, children, heading, label, ...other } =
-      this.props;
+    const {
+      activeHref: _, // throw away
+      className,
+      children,
+      heading,
+      label,
+      ...other
+    } = this.props;
 
     return (
       <nav

--- a/src/components/Nav/NavItem/NavItem.js
+++ b/src/components/Nav/NavItem/NavItem.js
@@ -59,9 +59,6 @@ export default class NavItem extends Component {
     /** @type {Function} Click handler of an item. */
     onClick: func,
 
-    /** @type {Function} Handler for keypresses on an item. */
-    onKeyPress: func,
-
     /** @type {number} `tabindex` of an item. */
     tabIndex: number,
   };
@@ -79,7 +76,6 @@ export default class NavItem extends Component {
     label: '',
     link: true,
     onClick: () => {},
-    onKeyPress: () => {},
     tabIndex: 0,
   };
 
@@ -102,10 +98,9 @@ export default class NavItem extends Component {
       disabled,
       label,
       onClick,
-      onKeyPress,
       href,
       activeHref,
-      current,
+      current: _, // throw away
       handleItemSelect,
       link,
       id,

--- a/src/components/Nav/NavItem/__tests__/NavItem-test.js
+++ b/src/components/Nav/NavItem/__tests__/NavItem-test.js
@@ -15,15 +15,10 @@ const { fn } = jest;
 describe('NavItem', () => {
   let navigationItem;
   const onClick = fn();
-  const onKeyPress = fn();
 
   beforeEach(() => {
     navigationItem = shallow(
-      <NavItem
-        className={className}
-        href={href()}
-        onClick={onClick}
-        onKeyPress={onKeyPress}>
+      <NavItem className={className} href={href()} onClick={onClick}>
         {label}
       </NavItem>
     );

--- a/src/components/Nav/NavList/__tests__/__snapshots__/NavList-test.js.snap
+++ b/src/components/Nav/NavList/__tests__/__snapshots__/NavList-test.js.snap
@@ -110,7 +110,6 @@ exports[`Nav Rendering renders correctly 1`] = `
         label=""
         link={true}
         onClick={[Function]}
-        onKeyPress={[Function]}
         tabIndex={0}
       >
         <li

--- a/src/components/Nav/__tests__/__snapshots__/Nav-test.js.snap
+++ b/src/components/Nav/__tests__/__snapshots__/Nav-test.js.snap
@@ -129,7 +129,6 @@ exports[`Nav Rendering renders correctly 1`] = `
               label=""
               link={true}
               onClick={[Function]}
-              onKeyPress={[Function]}
               tabIndex={-1}
             >
               <li
@@ -270,7 +269,6 @@ exports[`Nav Rendering renders correctly 1`] = `
               label=""
               link={true}
               onClick={[Function]}
-              onKeyPress={[Function]}
               tabIndex={-1}
             >
               <li
@@ -314,7 +312,6 @@ exports[`Nav Rendering renders correctly 1`] = `
         label=""
         link={true}
         onClick={[Function]}
-        onKeyPress={[Function]}
         tabIndex={0}
       >
         <li

--- a/src/components/__tests__/__snapshots__/publicAPI-test.js.snap
+++ b/src/components/__tests__/__snapshots__/publicAPI-test.js.snap
@@ -6740,7 +6740,6 @@ Map {
       "label": "",
       "link": true,
       "onClick": [Function],
-      "onKeyPress": [Function],
       "tabIndex": 0,
     },
     "propTypes": Object {
@@ -6778,9 +6777,6 @@ Map {
         "type": "bool",
       },
       "onClick": Object {
-        "type": "func",
-      },
-      "onKeyPress": Object {
         "type": "func",
       },
       "tabIndex": Object {


### PR DESCRIPTION
## Pull request - <!-- Short description -->

### Affected issues

- Contributes to #973 

### Proposed changes

- Nav: mark `activeHref` as throw away
- NavItem:
  - remove unused `onKeyPress`
  - mark `current` as throw away

### Testing instructions

- <!-- List of instructions for reviewer to test that proposed changes in this PR work properly -->
