### PR TITLE
fix(header): set aria-expanded and aria-haspopup on the appropriate element

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -427,40 +427,33 @@ export default class Header extends Component {
     return isUserActive ? (
       <Fragment>
         {this.props.showNotifications && (
-          <HeaderListItem
-            className={headerListItemClass}
-            hasPopup={isUserActive}
-            isExpanded={isActive.notifications}>
-            <Fragment>
-              <IconButton
-                aria-label={labels.notifications.button}
-                className={notificationsButtonClasses}
-                onClick={() => this.toggle('notifications')}
-                renderIcon={Notification20}
-                state={notifications}
-                tooltip={false}>
-                <Icon name="notification" />
-              </IconButton>
-              {this.renderNotifications()}
-            </Fragment>
+          <HeaderListItem className={headerListItemClass}>
+            <IconButton
+              aria-expanded={isActive.notifications}
+              aria-haspopup={isUserActive}
+              aria-label={labels.notifications.button}
+              className={notificationsButtonClasses}
+              onClick={() => this.toggle('notifications')}
+              renderIcon={Notification20}
+              state={notifications}
+              tooltip={false}>
+              <Icon name="notification" />
+            </IconButton>
+            {this.renderNotifications()}
           </HeaderListItem>
         )}
 
-        <HeaderListItem
-          className={headerListItemClass}
-          hasPopup={isUserActive}
-          isExpanded={isActive.profile}>
-          <Fragment>
-            <button
-              aria-label={labels.profile.button}
-              className={profileButtonClasses}
-              onClick={() => this.toggle('profile')}
-              type="button">
-              <ProfileImage profile={profile} />
-            </button>
-
-            {this.renderProfile()}
-          </Fragment>
+        <HeaderListItem className={headerListItemClass}>
+          <button
+            aria-expanded={isActive.profile}
+            aria-haspopup={isUserActive}
+            aria-label={labels.profile.button}
+            className={profileButtonClasses}
+            onClick={() => this.toggle('profile')}
+            type="button">
+            <ProfileImage profile={profile} />
+          </button>
+          {this.renderProfile()}
         </HeaderListItem>
       </Fragment>
     ) : (

--- a/src/components/Header/HeaderListItem/HeaderListItem.js
+++ b/src/components/Header/HeaderListItem/HeaderListItem.js
@@ -13,13 +13,8 @@ import { defaultProps, namespace, propTypes } from './constants';
  * @param {object.<string, *>} props Header list item props.
  * @returns {HeaderListItem} Header list item instance.
  */
-const HeaderListItem = ({ children, className, hasPopup, isExpanded }) => (
-  <li
-    className={classnames(namespace, className)}
-    aria-expanded={isExpanded}
-    aria-haspopup={hasPopup}>
-    {children}
-  </li>
+const HeaderListItem = ({ children, className }) => (
+  <li className={classnames(namespace, className)}>{children}</li>
 );
 
 HeaderListItem.propTypes = propTypes;

--- a/src/components/Header/HeaderListItem/__tests__/HeaderListItem-test.js
+++ b/src/components/Header/HeaderListItem/__tests__/HeaderListItem-test.js
@@ -31,17 +31,5 @@ describe('HeaderListItem', () => {
     it('renders extra classes', () => {
       expect(headerListItem.hasClass(className)).toEqual(true);
     });
-
-    it('renders the `aria-expanded` attribute', () => {
-      expect(headerListItem.prop('aria-expanded')).toEqual(isExpanded);
-      headerListItem.setProps({ isExpanded: !isExpanded });
-      expect(headerListItem.prop('aria-expanded')).toEqual(!isExpanded);
-    });
-
-    it('renders the `aria-haspopup` attribute', () => {
-      expect(headerListItem.prop('aria-haspopup')).toEqual(hasPopup);
-      headerListItem.setProps({ hasPopup: !hasPopup });
-      expect(headerListItem.prop('aria-haspopup')).toEqual(!hasPopup);
-    });
   });
 });

--- a/src/components/Header/HeaderListItem/constants.js
+++ b/src/components/Header/HeaderListItem/constants.js
@@ -10,24 +10,16 @@ import { namespace as headerNamespace } from '../constants';
 
 const defaultProps = {
   className: '',
-  hasPopup: false,
-  isExpanded: false,
 };
 
 const namespace = appendComponentNamespace(headerNamespace, 'list__item');
 
 const propTypes = {
-  /** @type {boolean|HTMLElement} List item children. */
-  children: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]).isRequired,
+  /** @type {node} List item children. */
+  children: PropTypes.node.isRequired,
 
   /** @type {string} Extra classes. */
   className: PropTypes.string,
-
-  /** @type {boolean} Whether it has a popover or not. */
-  hasPopup: PropTypes.bool,
-
-  /** @type {boolean} Whether it is expanded or not. */
-  isExpanded: PropTypes.bool,
 };
 
 export { defaultProps, namespace, propTypes };

--- a/src/components/Header/__tests__/__snapshots__/Header-test.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header-test.js.snap
@@ -204,12 +204,8 @@ exports[`Header Rendering renders correctly 1`] = `
       >
         <HeaderListItem
           className=""
-          hasPopup={false}
-          isExpanded={false}
         >
           <li
-            aria-expanded={false}
-            aria-haspopup={false}
             className="security--header__list__item"
           >
             <Button
@@ -257,12 +253,8 @@ exports[`Header Rendering renders correctly 1`] = `
         </HeaderListItem>
         <HeaderListItem
           className=""
-          hasPopup={false}
-          isExpanded={false}
         >
           <li
-            aria-expanded={false}
-            aria-haspopup={false}
             className="security--header__list__item"
           >
             <Button


### PR DESCRIPTION
## Pull request - <!-- Short description -->

### Affected issues

- Contributes to #973 
- `aria-expanded` and `aria-haspopup` are not valid on `li` (role `listitem`)

### Proposed changes

- Move the two attributes to the buttons that have this characteristic.
- Clean up the `children` prop.

### Testing instructions

- <!-- List of instructions for reviewer to test that proposed changes in this PR work properly -->
