### PR TITLE
test(testing-library): align `datatest-id` format with Cloud & Cognitive

### DIFF
--- a/config/jest/index.js
+++ b/config/jest/index.js
@@ -4,15 +4,16 @@
  */
 
 import '@testing-library/jest-dom';
-import Enzyme from 'enzyme';
+import { configure } from '@testing-library/dom';
+
+import { configure as enzyme } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import toBeAccessible from './matchers/toBeAccessible';
 import toHaveNoAxeViolations from './matchers/toHaveNoAxeViolations';
 
-const { fn } = jest;
-
-Enzyme.configure({ adapter: new Adapter() });
+configure({ testIdAttribute: 'data-test-id' });
+enzyme({ adapter: new Adapter() });
 
 // We can extend `expect` using custom matchers as defined by:
 // https://jest-bot.github.io/jest/docs/expect.html#expectextendmatchers
@@ -26,6 +27,8 @@ Enzyme.configure({ adapter: new Adapter() });
 // For more information, check out the docs here:
 // https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array
 expect.extend({ toBeAccessible, toHaveNoAxeViolations });
+
+const { fn } = jest;
 
 // https://github.com/nickcolley/jest-axe/issues/147
 const { getComputedStyle } = window;

--- a/src/components/Button/__tests__/Button-test.js
+++ b/src/components/Button/__tests__/Button-test.js
@@ -80,7 +80,7 @@ describe('Button', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <Button data-testid="test-id">test button</Button>
+      <Button data-test-id="test-id">test button</Button>
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/ComboButton/__tests__/ComboButton-test.js
+++ b/src/components/ComboButton/__tests__/ComboButton-test.js
@@ -39,7 +39,7 @@ const renderComboButton = (overflowMenuItemCount = 0) => {
   const items = [primaryItem, ...overflowMenuItems];
 
   return render(
-    <div data-testid={COMBO_BUTTON_TESTID}>
+    <div data-test-id={COMBO_BUTTON_TESTID}>
       <ComboButton>{items}</ComboButton>
     </div>
   );

--- a/src/components/ComboButton/__tests__/__snapshots__/ComboButton-test.js.snap
+++ b/src/components/ComboButton/__tests__/__snapshots__/ComboButton-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ComboButton renders a combo button with children and an overflow menu 1`] = `
 <div
-  data-testid="combo-button"
+  data-test-id="combo-button"
 >
   <div
     class="security--combo-button"
@@ -70,7 +70,7 @@ exports[`ComboButton renders a combo button with children and an overflow menu 1
 
 exports[`ComboButton renders a combo button without an overflow menu 1`] = `
 <div
-  data-testid="combo-button"
+  data-test-id="combo-button"
 >
   <div
     class="security--combo-button"

--- a/src/components/DataDecorator/Decorator/__tests__/Decorator-test.js
+++ b/src/components/DataDecorator/Decorator/__tests__/Decorator-test.js
@@ -184,7 +184,7 @@ Object.keys(icons).forEach((icon) => {
     test('should pass through extra props via spread attribute', () => {
       const { queryByTestId } = render(
         <Component
-          data-testid="test-id"
+          data-test-id="test-id"
           description={`${formattedName} severity`}
         />
       );

--- a/src/components/ErrorPage/__tests__/ErrorPage-test.js
+++ b/src/components/ErrorPage/__tests__/ErrorPage-test.js
@@ -86,7 +86,7 @@ describe('ErrorPage', () => {
   });
 
   test('should accept extra props via spread attribute', () => {
-    const { queryByTestId } = render(<ErrorPage data-testid="test-id" />);
+    const { queryByTestId } = render(<ErrorPage data-test-id="test-id" />);
     expect(queryByTestId('test-id')).toBeVisible();
   });
 });

--- a/src/components/ExternalLink/__tests__/ExternalLink-test.js
+++ b/src/components/ExternalLink/__tests__/ExternalLink-test.js
@@ -48,7 +48,7 @@ describe('ExternalLink', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <ExternalLink href="https://www.ibm.com/security" data-testid="test-id">
+      <ExternalLink href="https://www.ibm.com/security" data-test-id="test-id">
         test link
       </ExternalLink>
     );

--- a/src/components/FilterPanel/FilterPanelAccordion/__tests__/FilterPanelAccordion-test.js
+++ b/src/components/FilterPanel/FilterPanelAccordion/__tests__/FilterPanelAccordion-test.js
@@ -27,7 +27,7 @@ describe('FilterPanelAccordion', () => {
 
   test('renders with a heading node', () => {
     const { getByTestId } = render(
-      <FilterPanelAccordion heading={<span data-testid="node-title" />} />
+      <FilterPanelAccordion heading={<span data-test-id="node-title" />} />
     );
     expect(getByTestId('node-title')).toBeVisible();
   });
@@ -35,7 +35,7 @@ describe('FilterPanelAccordion', () => {
   test('renders with content', () => {
     const { getByTestId } = render(
       <FilterPanelAccordion>
-        <div data-testid="content" />
+        <div data-test-id="content" />
       </FilterPanelAccordion>
     );
     expect(getByTestId('content')).toBeVisible();

--- a/src/components/FilterPanel/FilterPanelAccordionItem/__tests__/FilterPanelAccordionItem-test.js
+++ b/src/components/FilterPanel/FilterPanelAccordionItem/__tests__/FilterPanelAccordionItem-test.js
@@ -16,7 +16,7 @@ import FilterPanelAccordionItem from '../FilterPanelAccordiontItem';
 const createChildChildren = (length) =>
   new Array(length).fill(null).map((value, index) => (
     // eslint-disable-next-line react/no-array-index-key
-    <div key={index} data-testid={`child-${index + 1}`}>
+    <div key={index} data-test-id={`child-${index + 1}`}>
       child {index + 1}
     </div>
   ));
@@ -50,7 +50,7 @@ describe('FilterPanelAccordionItem', () => {
 
   test('renders with a heading node', () => {
     const { getByTestId } = render(
-      <FilterPanelAccordionItem heading={<span data-testid="node-title" />} />
+      <FilterPanelAccordionItem heading={<span data-test-id="node-title" />} />
     );
     expect(getByTestId('node-title')).toBeVisible();
   });
@@ -58,7 +58,7 @@ describe('FilterPanelAccordionItem', () => {
   test('renders with content', () => {
     const { getByTestId } = render(
       <FilterPanelAccordionItem>
-        <div data-testid="content" />
+        <div data-test-id="content" />
       </FilterPanelAccordionItem>
     );
     expect(getByTestId('content')).toBeVisible();

--- a/src/components/FilterPanel/FilterPanelGroup/__tests__/FilterPanelGroup-test.js
+++ b/src/components/FilterPanel/FilterPanelGroup/__tests__/FilterPanelGroup-test.js
@@ -30,7 +30,7 @@ describe('FilterPanelGroup', () => {
 
   test('renders with a heading node', () => {
     const { getByTestId } = render(
-      <FilterPanelGroup heading={<span data-testid="node-title" />} />
+      <FilterPanelGroup heading={<span data-test-id="node-title" />} />
     );
     expect(getByTestId('node-title')).toBeVisible();
   });
@@ -38,7 +38,7 @@ describe('FilterPanelGroup', () => {
   test('renders with content', () => {
     const { getByTestId } = render(
       <FilterPanelGroup>
-        <div data-testid="content" />
+        <div data-test-id="content" />
       </FilterPanelGroup>
     );
     expect(getByTestId('content')).toBeVisible();

--- a/src/components/FilterPanel/FilterPanelLabel/__tests__/FilterPanelLabel-test.js
+++ b/src/components/FilterPanel/FilterPanelLabel/__tests__/FilterPanelLabel-test.js
@@ -28,7 +28,7 @@ describe('FilterPanelLabel', () => {
   test('renders with a heading node', () => {
     const { getByTestId } = render(
       <FilterPanelLabel>
-        <span data-testid="node-label" />
+        <span data-test-id="node-label" />
       </FilterPanelLabel>
     );
     expect(getByTestId('node-label')).toBeVisible();

--- a/src/components/FilterPanel/FilterPanelSearch/__tests__/FilterSearch-test.js
+++ b/src/components/FilterPanel/FilterPanelSearch/__tests__/FilterSearch-test.js
@@ -33,7 +33,7 @@ describe(name, () => {
       <FilterPanelSearch
         labelText="search label"
         placeholder="search placeholder">
-        <div data-testid="result-content" />
+        <div data-test-id="result-content" />
       </FilterPanelSearch>
     );
 
@@ -46,7 +46,7 @@ describe(name, () => {
       <FilterPanelSearch
         labelText="search label"
         placeholder="search placeholder">
-        <div data-testid="result-content" />
+        <div data-test-id="result-content" />
       </FilterPanelSearch>
     );
 
@@ -65,7 +65,7 @@ describe(name, () => {
       <FilterPanelSearch
         labelText="search label"
         placeholder="search placeholder">
-        <div data-testid="result-content">
+        <div data-test-id="result-content">
           <Checkbox labelText="checkbox" id="checkbox" />
         </div>
       </FilterPanelSearch>
@@ -87,7 +87,7 @@ describe(name, () => {
 
     expect(
       render(
-        <FilterPanelSearch data-testid={dataTestId} labelText={name} />
+        <FilterPanelSearch data-test-id={dataTestId} labelText={name} />
       ).getByTestId(dataTestId)
     ).toBeInTheDocument();
   });

--- a/src/components/FilterPanel/LEGACY_FilterPanel/FilterPanel.js
+++ b/src/components/FilterPanel/LEGACY_FilterPanel/FilterPanel.js
@@ -1,10 +1,11 @@
 /**
- * @file Filter Panel.
+ * @file Filter panel.
  * @copyright IBM Security 2019, 2021
  */
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import FilterSearch from './FilterSearch';
 import FilterCategory from './FilterCategory';
 import {
@@ -12,6 +13,7 @@ import {
   filterDataDefaultProps,
   getFilterCategoriesArray,
 } from './FilterPanelUtilities';
+
 import { getComponentNamespace } from '../../../globals/namespace';
 import * as defaultLabels from '../../../globals/nls';
 
@@ -40,7 +42,7 @@ const FilterPanel = (props) => {
   };
 
   return (
-    <aside className={namespace} data-testid="legacy-filter-panel">
+    <aside className={namespace} data-test-id="legacy-filter-panel">
       {title && <h1 className={`${namespace}__title`}>{title}</h1>}
       <div className={`${namespace}__search`}>
         <FilterSearch

--- a/src/components/FilterPanel/LEGACY_FilterPanel/__tests__/__snapshots__/FilterPanel-test.js.snap
+++ b/src/components/FilterPanel/LEGACY_FilterPanel/__tests__/__snapshots__/FilterPanel-test.js.snap
@@ -3,7 +3,7 @@
 exports[`FilterPanel renders with no title 1`] = `
 <aside
   className="security--filter-panel"
-  data-testid="legacy-filter-panel"
+  data-test-id="legacy-filter-panel"
 >
   <div
     className="security--filter-panel__search"
@@ -1803,7 +1803,7 @@ exports[`FilterPanel renders with no title 1`] = `
 exports[`FilterPanel renders with title 1`] = `
 <aside
   className="security--filter-panel"
-  data-testid="legacy-filter-panel"
+  data-test-id="legacy-filter-panel"
 >
   <h1
     className="security--filter-panel__title"
@@ -3608,7 +3608,7 @@ exports[`FilterPanel renders with title 1`] = `
 exports[`FilterPanel should overwrite \`labels\` when unique props defined 1`] = `
 <aside
   className="security--filter-panel"
-  data-testid="legacy-filter-panel"
+  data-test-id="legacy-filter-panel"
 >
   <div
     className="security--filter-panel__search"

--- a/src/components/FilterPanel/__tests__/FilterPanel-test.js
+++ b/src/components/FilterPanel/__tests__/FilterPanel-test.js
@@ -29,7 +29,7 @@ describe('FilterPanel', () => {
 
   test('renders with a title node', () => {
     const { getByTestId } = render(
-      <FilterPanel title={<span data-testid="node-title" />} />
+      <FilterPanel title={<span data-test-id="node-title" />} />
     );
     expect(getByTestId('node-title')).toBeVisible();
   });
@@ -37,7 +37,7 @@ describe('FilterPanel', () => {
   test('renders with content', () => {
     const { getByTestId } = render(
       <FilterPanel>
-        <div data-testid="content" />
+        <div data-test-id="content" />
       </FilterPanel>
     );
     expect(getByTestId('content')).toBeVisible();

--- a/src/components/InteractiveTag/__tests__/InteractiveTag-test.js
+++ b/src/components/InteractiveTag/__tests__/InteractiveTag-test.js
@@ -38,7 +38,7 @@ describe('InteractiveTag', () => {
 
   test('should add a custom class', () => {
     const { queryByTestId } = render(
-      <InteractiveTag className="custom-class" data-testid={dataTestId}>
+      <InteractiveTag className="custom-class" data-test-id={dataTestId}>
         test tag
       </InteractiveTag>
     );
@@ -48,7 +48,7 @@ describe('InteractiveTag', () => {
 
   test('should add selected class when `isSelected` is `true`', () => {
     const { queryByTestId } = render(
-      <InteractiveTag data-testid={dataTestId} isSelected>
+      <InteractiveTag data-test-id={dataTestId} isSelected>
         test tag
       </InteractiveTag>
     );
@@ -58,7 +58,7 @@ describe('InteractiveTag', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <InteractiveTag data-testid={dataTestId}>test tag</InteractiveTag>
+      <InteractiveTag data-test-id={dataTestId}>test tag</InteractiveTag>
     );
 
     expect(queryByTestId(dataTestId)).toBeInTheDocument();

--- a/src/components/LayoutModules/ButtonClusterModule/__tests__/ButtonClusterModule-test.js
+++ b/src/components/LayoutModules/ButtonClusterModule/__tests__/ButtonClusterModule-test.js
@@ -31,7 +31,7 @@ describe(name, () => {
 
     expect(
       render(
-        <ButtonClusterModule data-testid={dataTestId}>
+        <ButtonClusterModule data-test-id={dataTestId}>
           {name}
         </ButtonClusterModule>
       ).getByTestId(dataTestId)

--- a/src/components/LayoutModules/DescriptionListModule/__tests__/DescriptionListModule-test.js
+++ b/src/components/LayoutModules/DescriptionListModule/__tests__/DescriptionListModule-test.js
@@ -33,7 +33,7 @@ describe(name, () => {
 
     expect(
       render(
-        <DescriptionListModule data-testid={dataTestId}>
+        <DescriptionListModule data-test-id={dataTestId}>
           {name}
         </DescriptionListModule>
       ).getByTestId(dataTestId)

--- a/src/components/NonEntitledSection/__tests__/NonEntitledSection-test.js
+++ b/src/components/NonEntitledSection/__tests__/NonEntitledSection-test.js
@@ -108,7 +108,7 @@ describe('NonEntitledSection', () => {
       <NonEntitledSection
         title="test title"
         subTitle="test subtitle"
-        data-testid="test-id"
+        data-test-id="test-id"
       />
     );
     expect(queryByTestId('test-id')).toBeVisible();

--- a/src/components/Portal/__tests__/Portal-test.js
+++ b/src/components/Portal/__tests__/Portal-test.js
@@ -68,7 +68,10 @@ describe(name, () => {
       <div onCopy={copyHandler}>
         <Portal>
           <section>
-            <button data-testid="in-portal" onCopy={inPortalCopy} type="button">
+            <button
+              data-test-id="in-portal"
+              onCopy={inPortalCopy}
+              type="button">
               I should call copyHandler
             </button>
           </section>
@@ -89,7 +92,7 @@ describe(name, () => {
       /* eslint-disable jsx-a11y/mouse-events-have-key-events */
       <div onMouseOver={mouseOverHandler}>
         <button
-          data-testid="out-portal"
+          data-test-id="out-portal"
           onMouseOver={outPortalMouseOver}
           type="button">
           I should call mouseOverHandler
@@ -97,7 +100,7 @@ describe(name, () => {
         <Portal stopPropagation>
           <section>
             <button
-              data-testid="in-portal"
+              data-test-id="in-portal"
               onMouseOver={inPortalMouseOver}
               type="button">
               I should NOT call mouseOverHandler
@@ -129,7 +132,7 @@ describe(name, () => {
         <Portal stopPropagationEvents={['onMouseUp']}>
           <section>
             <button
-              data-testid="in-portal"
+              data-test-id="in-portal"
               onMouseDown={onMouseDownMock}
               onMouseUp={onMouseUpMock}
               type="button">

--- a/src/components/ProfileImage/__tests__/ProfileImage-test.js
+++ b/src/components/ProfileImage/__tests__/ProfileImage-test.js
@@ -111,7 +111,7 @@ describe('ProfileImage', () => {
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
       <ProfileImage
-        data-testid="test-id"
+        data-test-id="test-id"
         profile={{
           image_url: null,
           name: {

--- a/src/components/StackedNotification/__tests__/StackedNotification-test.js
+++ b/src/components/StackedNotification/__tests__/StackedNotification-test.js
@@ -60,7 +60,7 @@ describe('StackedNotification', () => {
         subtitle="test subtitle"
         iconDescription="test close button icon"
         statusIconDescription="test status icon"
-        data-testid="test-id"
+        data-test-id="test-id"
       />
     );
     expect(queryByTestId('test-id')).toBeVisible();

--- a/src/components/StepIndicator/__tests__/StepIndicator-test.js
+++ b/src/components/StepIndicator/__tests__/StepIndicator-test.js
@@ -29,7 +29,7 @@ describe('StepIndicator', () => {
   });
 
   test('should pass through extra prop to parent component via spread attriute', () => {
-    const { queryByTestId } = render(<StepIndicator data-testid="test-id" />);
+    const { queryByTestId } = render(<StepIndicator data-test-id="test-id" />);
     expect(queryByTestId('test-id')).toBeVisible();
   });
 

--- a/src/components/SummaryCard/SummaryCardAction/__tests__/SummaryCardAction-test.js
+++ b/src/components/SummaryCard/SummaryCardAction/__tests__/SummaryCardAction-test.js
@@ -48,7 +48,7 @@ describe('SummaryCardAction', () => {
       <SummaryCardAction
         closeButtonIconDescription="test close button"
         expandedContent="test expanded action content"
-        data-testid="test-button-id">
+        data-test-id="test-button-id">
         test button
       </SummaryCardAction>
     );
@@ -108,7 +108,7 @@ describe('SummaryCardAction', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <SummaryCardAction data-testid="test-id" />
+      <SummaryCardAction data-test-id="test-id" />
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/SummaryCard/SummaryCardBatchActions/__tests__/SummaryCardBatchActions-test.js
+++ b/src/components/SummaryCard/SummaryCardBatchActions/__tests__/SummaryCardBatchActions-test.js
@@ -1,6 +1,6 @@
 /**
  * @file Summary card batch actions tests.
- * @copyright IBM Security 2020
+ * @copyright IBM Security 2020 - 2021
  */
 
 import { render } from '@testing-library/react';
@@ -12,7 +12,7 @@ describe('SummaryCardBatchActions', () => {
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
       <SummaryCardBatchActions
-        data-testid="test-id"
+        data-test-id="test-id"
         onCancel={() => {}}
         totalSelected={0}
       />

--- a/src/components/SummaryCard/SummaryCardBody/__tests__/SummaryCardBody-test.js
+++ b/src/components/SummaryCard/SummaryCardBody/__tests__/SummaryCardBody-test.js
@@ -1,6 +1,6 @@
 /**
  * @file Summary card body tests.
- * @copyright IBM Security 2020
+ * @copyright IBM Security 2020 - 2021
  */
 
 import { render } from '@testing-library/react';
@@ -25,7 +25,7 @@ describe('SummaryCardBody', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <SummaryCardBody data-testid="test-id">test content</SummaryCardBody>
+      <SummaryCardBody data-test-id="test-id">test content</SummaryCardBody>
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/SummaryCard/SummaryCardFooter/__tests__/SummaryCardFooter-test.js
+++ b/src/components/SummaryCard/SummaryCardFooter/__tests__/SummaryCardFooter-test.js
@@ -1,6 +1,6 @@
 /**
  * @file Summary card footer tests.
- * @copyright IBM Security 2020
+ * @copyright IBM Security 2020 - 2021
  */
 
 import { render } from '@testing-library/react';
@@ -27,7 +27,7 @@ describe('SummaryCardFooter', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <SummaryCardFooter data-testid="test-id">test content</SummaryCardFooter>
+      <SummaryCardFooter data-test-id="test-id">test content</SummaryCardFooter>
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/SummaryCard/SummaryCardHeader/__tests__/SummaryCardHeader-test.js
+++ b/src/components/SummaryCard/SummaryCardHeader/__tests__/SummaryCardHeader-test.js
@@ -1,6 +1,6 @@
 /**
  * @file Summary card header tests.
- * @copyright IBM Security 2020
+ * @copyright IBM Security 2020 - 2021
  */
 
 import { render } from '@testing-library/react';
@@ -37,7 +37,7 @@ describe('SummaryCardHeader', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <SummaryCardHeader data-testid="test-id" title="test title" />
+      <SummaryCardHeader data-test-id="test-id" title="test title" />
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/SummaryCard/SummaryCardSelect/__tests__/SummaryCardSelect-test.js
+++ b/src/components/SummaryCard/SummaryCardSelect/__tests__/SummaryCardSelect-test.js
@@ -1,6 +1,6 @@
 /**
  * @file Summary card select tests.
- * @copyright IBM Security 2019
+ * @copyright IBM Security 2019 - 2021
  */
 
 import { render } from '@testing-library/react';
@@ -25,7 +25,7 @@ describe('SummaryCardSelect', () => {
       <SummaryCardSelect
         id="test-summary-select"
         labelText="test select"
-        data-testid="test-id"
+        data-test-id="test-id"
       />
     );
     expect(queryByTestId('test-id')).toBeVisible();

--- a/src/components/SummaryCard/SummaryCardSkeleton/__tests__/SummaryCardSkeleton-test.js
+++ b/src/components/SummaryCard/SummaryCardSkeleton/__tests__/SummaryCardSkeleton-test.js
@@ -30,7 +30,7 @@ describe('SummaryCardSkeleton', () => {
     const dataTestId = 'dataTestId';
 
     expect(
-      render(<SummaryCardSkeleton data-testid={dataTestId} />).getByTestId(
+      render(<SummaryCardSkeleton data-test-id={dataTestId} />).getByTestId(
         dataTestId
       )
     ).toBeInTheDocument();

--- a/src/components/SummaryCard/__tests__/SummaryCard-test.js
+++ b/src/components/SummaryCard/__tests__/SummaryCard-test.js
@@ -165,7 +165,7 @@ describe('SummaryCard', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <SummaryCard data-testid="test-id">test content</SummaryCard>
+      <SummaryCard data-test-id="test-id">test content</SummaryCard>
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/TimeIndicator/__tests__/TimeIndicator-test.js
+++ b/src/components/TimeIndicator/__tests__/TimeIndicator-test.js
@@ -25,7 +25,7 @@ describe('TimeIndicator', () => {
 
   test('should pass extra props through spread attribute', () => {
     const { queryByTestId } = render(
-      <TimeIndicator data-testid="test-id">test content</TimeIndicator>
+      <TimeIndicator data-test-id="test-id">test content</TimeIndicator>
     );
     expect(queryByTestId('test-id')).toBeInTheDocument();
   });

--- a/src/components/TrendingCard/__tests__/TrendingCard-test.js
+++ b/src/components/TrendingCard/__tests__/TrendingCard-test.js
@@ -57,7 +57,7 @@ describe('TrendingCard', () => {
 
   test('should add extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <TrendingCard title="test title" data-testid="test-id" />
+      <TrendingCard title="test title" data-test-id="test-id" />
     );
     expect(queryByTestId('test-id')).toBeVisible();
   });

--- a/src/components/TruncatedList/__tests__/TruncatedList-test.js
+++ b/src/components/TruncatedList/__tests__/TruncatedList-test.js
@@ -42,7 +42,7 @@ describe(TruncatedList.name, () => {
   });
 
   test('passes additional props down to the list', () => {
-    const { getByTestId } = render(<TruncatedList data-testid="test-list" />);
+    const { getByTestId } = render(<TruncatedList data-test-id="test-list" />);
     expect(getByTestId('test-list')).toBeInTheDocument();
   });
 

--- a/src/components/TruncatedList/_mocks_/index.js
+++ b/src/components/TruncatedList/_mocks_/index.js
@@ -1,6 +1,6 @@
 /**
  * @file Truncated list mock data utilities used in tests and Storybook stories.
- * @copyright IBM Security 2020
+ * @copyright IBM Security 2020 - 2021
  */
 
 import React from 'react';
@@ -14,7 +14,7 @@ import ListItem from '../../ListItem';
 export const createChildrenArray = (length) =>
   new Array(length).fill(null).map((value, index) => (
     // eslint-disable-next-line react/no-array-index-key
-    <ListItem key={index} data-testid={`child-${index + 1}`}>
+    <ListItem key={index} data-test-id={`child-${index + 1}`}>
       child {index + 1}
     </ListItem>
   ));

--- a/src/components/TypeLayout/__tests__/TypeLayout-test.js
+++ b/src/components/TypeLayout/__tests__/TypeLayout-test.js
@@ -64,10 +64,10 @@ describe('TypeLayout', () => {
 
   test('should pass through extra props via spread attribute', () => {
     const { queryByTestId } = render(
-      <TypeLayout data-testid="layout-test-id">
-        <TypeLayoutBody data-testid="body-test-id">
-          <TypeLayoutRow data-testid="row-test-id">
-            <TypeLayoutCell data-testid="cell-test-id">
+      <TypeLayout data-test-id="layout-test-id">
+        <TypeLayoutBody data-test-id="body-test-id">
+          <TypeLayoutRow data-test-id="row-test-id">
+            <TypeLayoutCell data-test-id="cell-test-id">
               test cell
             </TypeLayoutCell>
           </TypeLayoutRow>
@@ -82,10 +82,10 @@ describe('TypeLayout', () => {
 
   test('should apply `children` for each component', () => {
     const { queryByTestId } = render(
-      <TypeLayout data-testid="layout-test-id">
-        <TypeLayoutBody data-testid="body-test-id">
-          <TypeLayoutRow data-testid="row-test-id">
-            <TypeLayoutCell data-testid="cell-test-id">
+      <TypeLayout data-test-id="layout-test-id">
+        <TypeLayoutBody data-test-id="body-test-id">
+          <TypeLayoutRow data-test-id="row-test-id">
+            <TypeLayoutCell data-test-id="cell-test-id">
               test cell
             </TypeLayoutCell>
           </TypeLayoutRow>
@@ -99,7 +99,7 @@ describe('TypeLayout', () => {
   });
 
   test('should apply correct class when `border` is `true`', () => {
-    const { container } = render(<TypeLayout data-testid="test-id" border />);
+    const { container } = render(<TypeLayout data-test-id="test-id" border />);
     expect(container.firstElementChild).toHaveClass(`${namespace}--bordered`);
   });
 


### PR DESCRIPTION
## Pull request - test(testing-library): align `datatest-id` format with Cloud & Cognitive

### Affected issue

Contributes to #973

### Proposed change

Align `datatest-id` format with [Cloud & Cognitive](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js#L25)
