### PR TITLE
fix(decorator): fix icon `fill` styles

### DIFF
--- a/src/__tests__/scss/__snapshots__/styles-test.js.snap
+++ b/src/__tests__/scss/__snapshots__/styles-test.js.snap
@@ -8818,22 +8818,27 @@ a.bx--overflow-menu-options__btn::before {
   padding-left: 0.25rem;
 }
 
+.security--decorator__icon--critical,
 .security--decorator--critical .security--decorator__icon {
   fill: var(--cds-support-01, #fa4d56);
 }
 
+.security--decorator__icon--high,
 .security--decorator--high .security--decorator__icon {
   fill: var(--cds-support-01, #fa4d56);
 }
 
+.security--decorator__icon--low,
 .security--decorator--low .security--decorator__icon {
   fill: var(--cds-support-03, #f1c21b);
 }
 
+.security--decorator__icon--medium,
 .security--decorator--medium .security--decorator__icon {
   fill: #ff832b;
 }
 
+.security--decorator__icon--unknown,
 .security--decorator--unknown .security--decorator__icon {
   fill: var(--cds-icon-02, #c6c6c6);
 }

--- a/src/components/DataDecorator/_mixins.scss
+++ b/src/components/DataDecorator/_mixins.scss
@@ -134,6 +134,7 @@
         unknown: $icon-02
       )
   {
+    &__icon--#{$modifier},
     &--#{$modifier} #{$root}__icon {
       fill: $fill;
     }


### PR DESCRIPTION
## Pull request - fix(decorator): fix icon `fill` styles

Resolves https://ibm-casdesign.slack.com/archives/C02AMK63SUD/p1631526628000400

### Proposed change

Include `Decorator` icon styles removed as part of refactor
