### PR TITLE
fix(storybook): Update addon-storysource for renamed Layout Modules

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,7 +16,14 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-postcss',
     '@storybook/addon-viewport',
-    '@storybook/addon-storysource',
+    {
+      name: '@storybook/addon-storysource',
+      options: {
+        rule: {
+          test: [/(-story)|(\.stories)\.jsx?$/],
+        },
+      },
+    },
     '@storybook/addon-knobs',
     '@storybook/addon-controls',
     '@storybook/addon-actions',


### PR DESCRIPTION
## Pull request - Since this PR (https://github.com/carbon-design-system/ibm-security/pull/1013), code samples for Layout Modules have not been working. I added a configuration to addon-storysource to account for the renamed files.

### Testing instructions

- In Storybook, check that you can see source code under the Story tab in the Canvas for all components, including Layout Module components such as ListItemModule.
- Also for Layout Modules, check the Docs tab to see the "Hide Code" buttons after stories and their corresponding source code.