### PR TITLE
docs: align 'Layouts' naming with Cloud & Cognitive

### DIFF
--- a/.storybook/index.js
+++ b/.storybook/index.js
@@ -10,7 +10,7 @@ const CATEGORIES = {
   COMPONENTS: 'Components',
   DEPRECATED: 'Deprecated',
   LAYOUT_MODULES: 'Layout modules',
-  PAGE_LAYOUTS: 'Page layouts',
+  PAGE_LAYOUTS: 'Layouts',
   PATTERNS: 'Patterns',
 };
 

--- a/.storybook/index.js
+++ b/.storybook/index.js
@@ -10,7 +10,7 @@ const CATEGORIES = {
   COMPONENTS: 'Components',
   DEPRECATED: 'Deprecated',
   LAYOUT_MODULES: 'Layout modules',
-  PAGE_LAYOUTS: 'Page layouts (Canary)',
+  PAGE_LAYOUTS: 'Page layouts',
   PATTERNS: 'Patterns',
 };
 

--- a/src/components/LayoutModules/docs/examples/Detail/index.mdx
+++ b/src/components/LayoutModules/docs/examples/Detail/index.mdx
@@ -4,7 +4,7 @@ import detail from './images/detail.png';
 <Column lg={8}>
   <LinkTo
     className="storybook__link--image"
-    kind={getDocsId('page-layouts-detail')}>
+    kind={getDocsId('layouts-detail')}>
     <img alt="Detail page layout example" src={detail} />
   </LinkTo>
 </Column>

--- a/src/components/LayoutModules/docs/examples/Detail/index.mdx
+++ b/src/components/LayoutModules/docs/examples/Detail/index.mdx
@@ -4,7 +4,7 @@ import detail from './images/detail.png';
 <Column lg={8}>
   <LinkTo
     className="storybook__link--image"
-    kind={getDocsId('page-layouts-canary-detail')}>
+    kind={getDocsId('page-layouts-detail')}>
     <img alt="Detail page layout example" src={detail} />
   </LinkTo>
 </Column>

--- a/src/components/LayoutModules/docs/examples/Overview/index.mdx
+++ b/src/components/LayoutModules/docs/examples/Overview/index.mdx
@@ -4,7 +4,7 @@ import overview from './images/overview.png';
 <Column lg={8}>
   <LinkTo
     className="storybook__link--image"
-    kind={getDocsId('page-layouts-canary-overview')}>
+    kind={getDocsId('page-layouts-overview')}>
     <img alt="Overview page layout example" src={overview} />
   </LinkTo>
 </Column>

--- a/src/components/LayoutModules/docs/examples/Overview/index.mdx
+++ b/src/components/LayoutModules/docs/examples/Overview/index.mdx
@@ -4,7 +4,7 @@ import overview from './images/overview.png';
 <Column lg={8}>
   <LinkTo
     className="storybook__link--image"
-    kind={getDocsId('page-layouts-overview')}>
+    kind={getDocsId('layouts-overview')}>
     <img alt="Overview page layout example" src={overview} />
   </LinkTo>
 </Column>


### PR DESCRIPTION
#### Affected issue

Contributes to #973 

#### Proposed change

Align 'Layouts' category naming with Cloud & Cognitive per https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/packages/core/story-structure.js#L149